### PR TITLE
feat(input-hub): implement emitIntent stub with minimal test (task 6)

### DIFF
--- a/.taskmaster/scratchpads/2025-07-04.md
+++ b/.taskmaster/scratchpads/2025-07-04.md
@@ -159,3 +159,24 @@ Refactor the monorepo to use TypeScript project references correctly, enabling a
 - ✅ TypeScript project references working correctly
 - ✅ All packages built in dependency order (schema first)
 - ✅ Single `tsc -b tsconfig.build.json` command builds everything
+
+---
+
+## Task 6: Implement Input Hub for Multimodal Control
+
+### Context
+- Task requires creating unified gesture and voice intent bus
+- Should map gestures and voice commands to intent enum
+- Must translate multimodal inputs to graph operations
+- Package already exists at packages/input-hub
+
+### Plan
+1. Create intent enum for graph manipulation commands
+2. Implement emitIntent stub function
+3. Define types for gesture and voice inputs
+4. Create minimal test for emitIntent
+
+### Implementation Notes
+- Using RendererCommand types from store for output
+- Intent types should map to common graph operations
+- Focus on stub implementation with proper typing

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -64,7 +64,7 @@
         "testStrategy": "Test gesture recognition accuracy with various hand positions. Verify voice command processing and intent mapping. Test multimodal input coordination and conflict resolution.",
         "priority": "medium",
         "dependencies": [],
-        "status": "pending",
+        "status": "in-progress",
         "subtasks": []
       },
       {
@@ -156,7 +156,7 @@
     ],
     "metadata": {
       "created": "2025-07-02T21:33:31.640Z",
-      "updated": "2025-07-04T15:17:44.506Z",
+      "updated": "2025-07-05T00:00:49.667Z",
       "description": "Tasks for master context"
     }
   },

--- a/packages/input-hub/src/index.test.ts
+++ b/packages/input-hub/src/index.test.ts
@@ -1,8 +1,137 @@
 import { describe, it, expect } from 'vitest'
-import { version } from './index'
+import { version, emitIntent, Intent, type IntentContext, type GestureInput, type VoiceInput } from './index'
 
 describe('input-hub Package', () => {
   it('should export version', () => {
     expect(version).toBe('0.0.0')
+  })
+})
+
+describe('emitIntent', () => {
+  it('should emit ADD_NODE command for CREATE_NODE intent', () => {
+    const context: IntentContext = {
+      intent: Intent.CREATE_NODE,
+      input: {
+        type: 'gesture',
+        gesture: 'pinch',
+        confidence: 0.9
+      },
+      parameters: {
+        label: 'Test Node',
+        position: { x: 100, y: 200, z: 0 }
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toMatchObject({
+      type: 'ADD_NODE',
+      payload: {
+        node: {
+          id: expect.any(String),
+          label: 'Test Node',
+          position: { x: 100, y: 200, z: 0 }
+        }
+      }
+    })
+  })
+  
+  it('should emit SELECT_NODES command for SELECT_NODE intent', () => {
+    const context: IntentContext = {
+      intent: Intent.SELECT_NODE,
+      input: {
+        type: 'voice',
+        command: 'select node',
+        confidence: 0.95
+      },
+      parameters: {
+        nodeIds: ['node-1', 'node-2']
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toEqual({
+      type: 'SELECT_NODES',
+      payload: {
+        nodeIds: ['node-1', 'node-2'],
+        mode: 'replace'
+      }
+    })
+  })
+  
+  it('should emit CLEAR_SELECTION command', () => {
+    const context: IntentContext = {
+      intent: Intent.CLEAR_SELECTION,
+      input: {
+        type: 'gesture',
+        gesture: 'wave',
+        confidence: 0.8
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toEqual({ type: 'CLEAR_SELECTION' })
+  })
+  
+  it('should emit SET_ZOOM command for ZOOM_IN intent', () => {
+    const context: IntentContext = {
+      intent: Intent.ZOOM_IN,
+      input: {
+        type: 'gesture',
+        gesture: 'spread',
+        confidence: 0.85
+      },
+      parameters: {
+        zoom: 1.5
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toEqual({
+      type: 'SET_ZOOM',
+      payload: { zoom: 1.5 }
+    })
+  })
+  
+  it('should return null for unimplemented intents', () => {
+    const context: IntentContext = {
+      intent: Intent.DELETE_NODE,
+      input: {
+        type: 'voice',
+        command: 'delete node',
+        confidence: 0.9
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toBeNull()
+  })
+  
+  it('should handle missing parameters with defaults', () => {
+    const context: IntentContext = {
+      intent: Intent.CREATE_NODE,
+      input: {
+        type: 'gesture',
+        gesture: 'tap',
+        confidence: 0.7
+      }
+    }
+    
+    const command = emitIntent(context)
+    
+    expect(command).toMatchObject({
+      type: 'ADD_NODE',
+      payload: {
+        node: {
+          id: expect.stringMatching(/^node-\d+$/),
+          label: 'New Node',
+          position: { x: 0, y: 0, z: 0 }
+        }
+      }
+    })
   })
 })

--- a/packages/input-hub/src/index.ts
+++ b/packages/input-hub/src/index.ts
@@ -1,2 +1,129 @@
 // @refinery/input-hub - Entry point
 export const version = '0.0.0'
+
+import type { RendererCommand } from '@refinery/store'
+
+/**
+ * Supported intent types for graph manipulation
+ */
+export enum Intent {
+  // Node operations
+  CREATE_NODE = 'CREATE_NODE',
+  DELETE_NODE = 'DELETE_NODE',
+  SELECT_NODE = 'SELECT_NODE',
+  MOVE_NODE = 'MOVE_NODE',
+  
+  // Edge operations
+  CREATE_EDGE = 'CREATE_EDGE',
+  DELETE_EDGE = 'DELETE_EDGE',
+  
+  // Navigation
+  PAN_CAMERA = 'PAN_CAMERA',
+  ZOOM_IN = 'ZOOM_IN',
+  ZOOM_OUT = 'ZOOM_OUT',
+  FIT_VIEW = 'FIT_VIEW',
+  
+  // Selection
+  SELECT_ALL = 'SELECT_ALL',
+  CLEAR_SELECTION = 'CLEAR_SELECTION',
+  
+  // Layout
+  TOGGLE_LAYOUT = 'TOGGLE_LAYOUT',
+  RESET_LAYOUT = 'RESET_LAYOUT'
+}
+
+/**
+ * Gesture input data from Mediapipe
+ */
+export interface GestureInput {
+  type: 'gesture'
+  gesture: string
+  confidence: number
+  landmarks?: Array<{ x: number; y: number; z: number }>
+}
+
+/**
+ * Voice command input from Eleven Labs
+ */
+export interface VoiceInput {
+  type: 'voice'
+  command: string
+  confidence: number
+  transcript?: string
+}
+
+/**
+ * Union type for all input modalities
+ */
+export type MultimodalInput = GestureInput | VoiceInput
+
+/**
+ * Intent context with additional parameters
+ */
+export interface IntentContext {
+  intent: Intent
+  input: MultimodalInput
+  parameters?: Record<string, unknown>
+}
+
+/**
+ * Emits an intent as a RendererCommand for the store to process
+ * 
+ * @param context - The intent context with input data
+ * @returns RendererCommand or null if intent cannot be processed
+ */
+export function emitIntent(context: IntentContext): RendererCommand | null {
+  const { intent, parameters = {} } = context
+  
+  switch (intent) {
+    case Intent.CREATE_NODE:
+      // TODO: Generate proper node ID and position
+      return {
+        type: 'ADD_NODE',
+        payload: {
+          node: {
+            id: parameters.id as string || `node-${Date.now()}`,
+            label: parameters.label as string || 'New Node',
+            position: parameters.position as { x: number; y: number; z: number } || { x: 0, y: 0, z: 0 }
+          }
+        }
+      }
+      
+    case Intent.SELECT_NODE:
+      return {
+        type: 'SELECT_NODES',
+        payload: {
+          nodeIds: parameters.nodeIds as string[] || [],
+          mode: 'replace'
+        }
+      }
+      
+    case Intent.CLEAR_SELECTION:
+      return { type: 'CLEAR_SELECTION' }
+      
+    case Intent.ZOOM_IN:
+      return {
+        type: 'SET_ZOOM',
+        payload: { zoom: parameters.zoom as number || 1.2 }
+      }
+      
+    case Intent.ZOOM_OUT:
+      return {
+        type: 'SET_ZOOM',
+        payload: { zoom: parameters.zoom as number || 0.8 }
+      }
+      
+    case Intent.FIT_VIEW:
+      return {
+        type: 'FIT_TO_NODES',
+        payload: { nodeIds: parameters.nodeIds as string[] }
+      }
+      
+    case Intent.RESET_LAYOUT:
+      return { type: 'RESET_LAYOUT' }
+      
+    default:
+      // TODO: Implement remaining intents
+      return null
+  }
+}


### PR DESCRIPTION
- Add Intent enum for graph manipulation commands
- Define GestureInput and VoiceInput types for multimodal inputs
- Implement emitIntent function to translate intents to RendererCommands
- Add minimal tests covering basic operations
- Foundation for unified gesture and voice intent bus

🤖 Generated with [Claude Code](https://claude.ai/code)