### PR TITLE
feat(draw3d): curated label map (≈30)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/labelMap.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/labelMap.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getFormationId } from './labelMap'
+
+describe('labelMap', () => {
+  it('maps known label to formation id', () => {
+    expect(getFormationId('frontal lobe')).toBeGreaterThan(0)
+  })
+
+  it('falls back for unknown labels', () => {
+    expect(getFormationId('not-a-label')).toBe(0)
+  })
+})

--- a/apps/cryptiq-mindmap-demo/app/draw3d/labelMap.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/labelMap.ts
@@ -1,0 +1,46 @@
+export const labels = [
+  'frontal lobe',
+  'parietal lobe',
+  'temporal lobe',
+  'occipital lobe',
+  'cerebellum',
+  'brainstem',
+  'hypothalamus',
+  'thalamus',
+  'hippocampus',
+  'amygdala',
+  'corpus callosum',
+  'pituitary gland',
+  'pineal gland',
+  'midbrain',
+  'pons',
+  'medulla oblongata',
+  'basal ganglia',
+  'broca area',
+  'wernicke area',
+  'somatosensory cortex',
+  'motor cortex',
+  'visual cortex',
+  'auditory cortex',
+  'olfactory bulb',
+  'cingulate gyrus',
+  'insula',
+  'nucleus accumbens',
+  'substantia nigra',
+  'cerebral cortex',
+  'unknown',
+] as const;
+
+export type Label = (typeof labels)[number];
+
+export const labelToFormationId: Record<Label, number> = labels.reduce(
+  (acc, label, index) => {
+    acc[label] = label === 'unknown' ? 0 : index + 1;
+    return acc;
+  },
+  {} as Record<Label, number>
+);
+
+export function getFormationId(label: string): number {
+  return labelToFormationId[label as Label] ?? labelToFormationId['unknown'];
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+import { getFormationId, labels } from './labelMap'
+
+export default function Draw3DPage() {
+  useEffect(() => {
+    console.log('sample labels', labels.slice(0, 3))
+    console.log('frontal lobe ->', getFormationId('frontal lobe'))
+    console.log('unknown ->', getFormationId('not-a-real-label'))
+  }, [])
+
+  return <main />
+}


### PR DESCRIPTION
## Summary
- add curated draw3d label map and mapping helper
- wire label map into placeholder draw3d page
- cover label mapping with a basic unit test

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit` *(fails: 360 errors)*
- `pnpm --filter cryptiq-mindmap-demo run lint` *(fails: same 360 type errors)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: font fetch errors)*
- `pnpm run smoke`
- `pnpm --filter cryptiq-mindmap-demo exec vitest run app/draw3d/labelMap.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b87a3f483289049e0d2095fd0a2