### PR TITLE
feat(draw3d): ml5 DoodleNet wrapper + timings

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/doodlenet.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/doodlenet.ts
@@ -1,0 +1,46 @@
+"use client";
+let classifierPromise: Promise<any> | null = null;
+let modelLoadMs = 0;
+
+async function ensureMl5(): Promise<any> {
+  if ((window as any).ml5) return (window as any).ml5;
+  return new Promise((resolve) => {
+    const check = () => {
+      if ((window as any).ml5) {
+        resolve((window as any).ml5);
+      } else {
+        setTimeout(check, 50);
+      }
+    };
+    check();
+  });
+}
+
+export async function loadDoodleNet() {
+  if (!classifierPromise) {
+    const ml5 = await ensureMl5();
+    const start = performance.now();
+    classifierPromise = new Promise((resolve, reject) => {
+      ml5.imageClassifier('DoodleNet', (err: any, classifier: any) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        modelLoadMs = performance.now() - start;
+        console.log(`DoodleNet loaded in ${modelLoadMs.toFixed(1)}ms`);
+        resolve(classifier);
+      });
+    });
+  }
+  const classifier = await classifierPromise;
+  return { classifier, loadMs: modelLoadMs };
+}
+
+export async function classify(canvas: HTMLCanvasElement, topK = 3) {
+  const { classifier } = await loadDoodleNet();
+  const start = performance.now();
+  const results = await classifier.classify(canvas, topK);
+  const inferenceMs = performance.now() - start;
+  console.log(`DoodleNet inference in ${inferenceMs.toFixed(1)}ms`, results);
+  return { results, inferenceMs, loadMs: modelLoadMs };
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/head.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/head.tsx
@@ -1,0 +1,9 @@
+import Script from "next/script";
+
+export default function Head() {
+  return (
+    <>
+      <Script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" strategy="beforeInteractive" />
+    </>
+  );
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { loadDoodleNet, classify } from "./doodlenet";
+
+export default function Draw3DPage() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [loadMs, setLoadMs] = useState<number | null>(null);
+  const [inferenceMs, setInferenceMs] = useState<number | null>(null);
+  const [results, setResults] = useState<any[]>([]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = "#000";
+      ctx.lineWidth = 10;
+      ctx.beginPath();
+      ctx.moveTo(20, 20);
+      ctx.lineTo(80, 80);
+      ctx.stroke();
+    }
+
+    loadDoodleNet().then(({ loadMs }) => {
+      setLoadMs(loadMs);
+      classify(canvas).then(({ results, inferenceMs }) => {
+        setInferenceMs(inferenceMs);
+        setResults(results);
+      });
+    });
+  }, []);
+
+  return (
+    <div>
+      <canvas
+        ref={canvasRef}
+        width={100}
+        height={100}
+        style={{ border: "1px solid #000" }}
+      />
+      <div id="hud">
+        <div id="load">model: {loadMs ? `${loadMs.toFixed(1)}ms` : "..."}</div>
+        <div id="infer">inference: {inferenceMs ? `${inferenceMs.toFixed(1)}ms` : "..."}</div>
+      </div>
+      <pre>{JSON.stringify(results, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- load ml5 DoodleNet via CDN for /draw3d
- wrap DoodleNet with memoized loader and classification timings
- show model load & inference ms on draw3d HUD

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: font downloads blocked)*
- `pnpm run smoke`
- classification attempt via Playwright *(blocked: 403 fetching ml5 CDN)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b7840d08328ac76491a5bcfc91d