### PR TITLE
feat(draw3d): route scaffolding + HUD

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Draw3DPage() {
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setReady(true), 500)
+    return () => clearTimeout(t)
+  }, [])
+  return (
+    <main className="relative flex h-full w-full flex-col md:flex-row">
+      <div className="flex flex-1 items-center justify-center bg-black text-white">
+        <span>Canvas Placeholder</span>
+      </div>
+      <div className="flex flex-1 items-center justify-center bg-gray-900 text-white">
+        <span>3D View Placeholder</span>
+      </div>
+      <div className="absolute left-2 top-2 rounded bg-black/60 px-2 py-1 text-xs text-white">
+        {ready ? 'Ready' : 'Loading...'}
+      </div>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add /draw3d route scaffolding with responsive canvas/3D panes
- include simple status HUD with loading/ready placeholder

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings: any, missing deps)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: unable to fetch Google Fonts)*
- `pnpm run smoke`
- `curl http://localhost:3000/draw3d` (via dev server)

------
https://chatgpt.com/codex/tasks/task_e_68bc7b45e5e88328824f3826725f9b6f