### PR TITLE
feat(draw3d): host shell (page.tsx + AppHost)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -1,0 +1,8 @@
+export default function AppHost() {
+  return (
+    <div>
+      <div>HUD</div>
+      <div>TODO</div>
+    </div>
+  );
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/page.tsx
@@ -1,0 +1,5 @@
+import AppHost from "./modules/AppHost";
+
+export default function Page() {
+  return <AppHost />;
+}


### PR DESCRIPTION
## Summary
- add draw3d page to render new AppHost
- stub AppHost with placeholder HUD + TODO

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: failed to fetch Google Fonts)*
- `pnpm run smoke`
- `NEXT_DISABLE_NETFONTS=true pnpm --filter cryptiq-mindmap-demo run dev &` `curl -s http://localhost:3001/draw3d | grep -o -E "HUD|TODO"`


------
https://chatgpt.com/codex/tasks/task_e_68bc96f074ac83288fb7af479ac16ba5