### PR TITLE
feat(draw3d): renderer (InstancedMesh) module

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Canvas, useThree } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+
+export type FormationViewProps = {
+  positions: Float32Array;
+};
+
+const MAX_INSTANCES = 20000;
+
+function InstancedFormation({ positions }: FormationViewProps) {
+  const { gl } = useThree();
+  const mesh = useRef<THREE.InstancedMesh>(null);
+  const dummy = useMemo(() => new THREE.Object3D(), []);
+
+  // limit device pixel ratio to reduce GPU load
+  useEffect(() => {
+    gl.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  }, [gl]);
+
+  const count = Math.min(positions.length / 3, MAX_INSTANCES);
+
+  useEffect(() => {
+    const m = mesh.current;
+    if (!m) return;
+    for (let i = 0; i < count; i++) {
+      dummy.position.set(
+        positions[i * 3],
+        positions[i * 3 + 1],
+        positions[i * 3 + 2]
+      );
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+    }
+    m.instanceMatrix.needsUpdate = true;
+  }, [positions, count, dummy]);
+
+  return (
+    <instancedMesh ref={mesh} args={[undefined, undefined, count]}>
+      <sphereGeometry args={[0.01, 1, 1]} />
+      <meshBasicMaterial color={0xffffff} toneMapped={false} />
+    </instancedMesh>
+  );
+}
+
+export default function FormationView({ positions }: FormationViewProps) {
+  return (
+    <Canvas dpr={[1, 2]}>
+      <InstancedFormation positions={positions} />
+    </Canvas>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add FormationView renderer with single InstancedMesh and capped instances
- clamp device pixel ratio and use lean material

## Testing
- `npx --yes tsx -e "import React from 'react'; import FormationView from './apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx'; const el = React.createElement(FormationView, { positions: new Float32Array([0,0,0]) }); console.log(typeof el);"`
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: failed to fetch Google fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc990605688328b9557fa1a3e31d88