### PR TITLE
feat(draw3d): HUD module

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -1,0 +1,19 @@
+export interface HUDProps {
+  ready: boolean;
+  loadMs: number;
+  inferMs: number;
+  fps: number;
+  instances: number;
+}
+
+export default function HUD({ ready, loadMs, inferMs, fps, instances }: HUDProps) {
+  return (
+    <div>
+      <div>ready: {String(ready)}</div>
+      <div>load: {loadMs}ms</div>
+      <div>infer: {inferMs}ms</div>
+      <div>fps: {fps}</div>
+      <div>instances: {instances}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add HUD module displaying draw3d metrics

## Testing
- `pnpm --filter cryptiq-mindmap-demo exec tsx -e "import React from 'react'; globalThis.React = React; import { renderToString } from 'react-dom/server'; import HUD from './app/draw3d/modules/ui/HUD.tsx'; console.log(renderToString(React.createElement(HUD, {ready:true, loadMs:123, inferMs:456, fps:60, instances:7})));"`
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit && echo "schema ok"`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: fetch font file 403)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc990cf8788328a7620d5c768ebb6d