### PR TITLE
feat(draw3d): ml (DoodleNet) module (runtime script injection)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ml/doodlenet.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ml/doodlenet.ts
@@ -1,0 +1,43 @@
+export type DoodlePrediction = {
+  label: string;
+  confidence: number;
+};
+
+export type DoodleClassifier = {
+  classify(input: HTMLCanvasElement, k?: number): Promise<DoodlePrediction[]>;
+};
+
+let doodlePromise: Promise<DoodleClassifier> | null = null;
+let ml5Promise: Promise<any> | null = null;
+
+function loadMl5(): Promise<any> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('ml5 requires a browser environment'));
+  }
+  if (ml5Promise) return ml5Promise;
+  ml5Promise = new Promise((resolve, reject) => {
+    if ((window as any).ml5) {
+      resolve((window as any).ml5);
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/ml5@0.12.2/dist/ml5.min.js';
+    script.async = true;
+    script.onload = () => resolve((window as any).ml5);
+    script.onerror = () => reject(new Error('Failed to load ml5'));
+    document.head.appendChild(script);
+  });
+  return ml5Promise;
+}
+
+export async function loadDoodleNet(): Promise<DoodleClassifier> {
+  if (!doodlePromise) {
+    doodlePromise = loadMl5().then((ml5) => ml5.imageClassifier('DoodleNet'));
+  }
+  return doodlePromise;
+}
+
+export async function classify(canvas: HTMLCanvasElement, k = 5) {
+  const classifier = await loadDoodleNet();
+  return classifier.classify(canvas, k);
+}


### PR DESCRIPTION
## Summary
- add DoodleNet ML module for draw3d with runtime ml5 script injection and memoized model loading

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit` *(no output)*
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings only)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: could not fetch Google Fonts)*
- `pnpm run smoke`
- `node harness` *(fails: ml5 CDN blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98f01a4c8328b089ce9e5f28a1d9