### PR TITLE
feat(draw3d): canvas + preprocess module

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+
+export default function DoodleCanvas() {
+  const ref = useRef<HTMLCanvasElement>(null);
+  const drawing = useRef(false);
+  const last = useRef<{ x: number; y: number } | null>(null);
+
+  const start = (x: number, y: number) => {
+    drawing.current = true;
+    last.current = { x, y };
+  };
+
+  const move = (x: number, y: number) => {
+    const canvas = ref.current;
+    const ctx = canvas?.getContext("2d");
+    if (!drawing.current || !ctx || !last.current) return;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.lineWidth = 16;
+    const { x: lx, y: ly } = last.current;
+    ctx.beginPath();
+    ctx.moveTo(lx, ly);
+    const mx = (lx + x) / 2;
+    const my = (ly + y) / 2;
+    ctx.quadraticCurveTo(lx, ly, mx, my);
+    ctx.stroke();
+    last.current = { x, y };
+  };
+
+  const end = () => {
+    drawing.current = false;
+    last.current = null;
+  };
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const rect = () => canvas.getBoundingClientRect();
+
+    const handleTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+      const r = rect();
+      const t = e.touches[0];
+      start(t.clientX - r.left, t.clientY - r.top);
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const r = rect();
+      const t = e.touches[0];
+      move(t.clientX - r.left, t.clientY - r.top);
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      e.preventDefault();
+      end();
+    };
+
+    const handleMouseDown = (e: MouseEvent) => {
+      e.preventDefault();
+      const r = rect();
+      start(e.clientX - r.left, e.clientY - r.top);
+    };
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!drawing.current) return;
+      e.preventDefault();
+      const r = rect();
+      move(e.clientX - r.left, e.clientY - r.top);
+    };
+    const handleMouseUp = (e: MouseEvent) => {
+      e.preventDefault();
+      end();
+    };
+
+    canvas.addEventListener("touchstart", handleTouchStart, { passive: false });
+    canvas.addEventListener("touchmove", handleTouchMove, { passive: false });
+    canvas.addEventListener("touchend", handleTouchEnd, { passive: false });
+
+    canvas.addEventListener("mousedown", handleMouseDown);
+    canvas.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      canvas.removeEventListener("touchstart", handleTouchStart);
+      canvas.removeEventListener("touchmove", handleTouchMove);
+      canvas.removeEventListener("touchend", handleTouchEnd);
+      canvas.removeEventListener("mousedown", handleMouseDown);
+      canvas.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  return <canvas ref={ref} width={280} height={280} />;
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
@@ -1,0 +1,18 @@
+export function get28x28Gray(canvas: HTMLCanvasElement): Uint8ClampedArray {
+  const size = 28;
+  const off =
+    canvas.ownerDocument?.createElement("canvas") ||
+    new (canvas.constructor as any)(size, size);
+  off.width = size;
+  off.height = size;
+  const ctx = off.getContext("2d");
+  if (!ctx) return new Uint8ClampedArray(size * size);
+  ctx.drawImage(canvas, 0, 0, size, size);
+  const { data } = ctx.getImageData(0, 0, size, size);
+  const gray = new Uint8ClampedArray(size * size);
+  for (let i = 0; i < size * size; i++) {
+    const idx = i * 4;
+    gray[i] = (data[idx] + data[idx + 1] + data[idx + 2]) / 3;
+  }
+  return gray;
+}


### PR DESCRIPTION
## Summary
- add DoodleCanvas component with mouse/touch drawing
- add preprocessing util to extract 28x28 grayscale pixels

## Testing
- `pnpm exec tsx -e "import { get28x28Gray } from './apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts'; class StubCanvas { width = 280; height = 280; getContext() { return { drawImage() {}, getImageData() { return { data: new Uint8ClampedArray(28*28*4) }; } }; } } const c = new StubCanvas(); const arr = get28x28Gray(c as any); console.log(arr.length); console.log(Array.from(arr.slice(0,10)));"`
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: Cannot use namespace 'EffectComposer' as a type ...)*
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc98e8557c83288a82b7399ea3a6c1