### PR TITLE
feat(draw3d): perf helpers

### DIFF
--- a/app/draw3d/modules/renderer/perf.ts
+++ b/app/draw3d/modules/renderer/perf.ts
@@ -1,0 +1,22 @@
+import type { WebGLRenderer } from 'three';
+
+/**
+ * Clamp the device pixel ratio to reduce GPU load.
+ * Defaults to a maximum DPR of 2.
+ */
+export function clampDpr(gl: WebGLRenderer, max = 2): void {
+  if (typeof window !== 'undefined') {
+    gl.setPixelRatio(Math.min(window.devicePixelRatio, max));
+  }
+}
+
+/**
+ * Limit instanced rendering counts based on device class.
+ * Mobile devices are capped at 200 instances to maintain ~30fps.
+ */
+export function capInstances(count: number, mobileCap = 200, desktopCap = 20000): number {
+  const isMobile =
+    typeof navigator !== 'undefined' && /Mobi|Android/i.test(navigator.userAgent);
+  const cap = isMobile ? mobileCap : desktopCap;
+  return Math.min(count, cap);
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -3,12 +3,11 @@
 import { Canvas, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
+import { clampDpr, capInstances } from '../../../../../../app/draw3d/modules/renderer/perf';
 
 export type FormationViewProps = {
   positions: Float32Array;
 };
-
-const MAX_INSTANCES = 20000;
 
 function InstancedFormation({ positions }: FormationViewProps) {
   const { gl } = useThree();
@@ -17,10 +16,10 @@ function InstancedFormation({ positions }: FormationViewProps) {
 
   // limit device pixel ratio to reduce GPU load
   useEffect(() => {
-    gl.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    clampDpr(gl);
   }, [gl]);
 
-  const count = Math.min(positions.length / 3, MAX_INSTANCES);
+  const count = capInstances(positions.length / 3);
 
   useEffect(() => {
     const m = mesh.current;


### PR DESCRIPTION
## Summary
- add Draw3D renderer perf helpers for DPR clamping and instance caps
- refactor FormationView to use perf helpers

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(fails: Warning: React Hook React.useEffect has a missing dependency... @typescript-eslint/no-explicit-any, etc.)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` from Google Fonts.)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bca33d13a88328b738d641d854283a