### PR TITLE
feat(draw3d): robust draw-end, label mapping, and visibility tuning

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -1,15 +1,54 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import DoodleCanvas from './canvas/DoodleCanvas';
-import { get28x28Gray } from './canvas/preprocess';
+import { make28x28Canvas } from './canvas/preprocess';
 import { classify, loadDoodleNet } from './ml/doodlenet';
 import FormationView from './renderer/FormationView';
 import HUD from './ui/HUD';
-import { useFormation as fetchFormation } from './data/useFormation';
+
+const aliasMap: Record<string, string> = {
+  ship: 'boat',
+  cellphone: 'phone',
+  mobile: 'phone',
+  leaf: 'flower',
+};
+
+const seeded = new Set([
+  'balloon',
+  'bird',
+  'boat',
+  'car',
+  'cat',
+  'cup',
+  'fish',
+  'flower',
+  'house',
+  'phone',
+  'tree',
+]);
+
+async function fetchFormation(name: string): Promise<Float32Array> {
+  const url = `/formations/${name}.json`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  const data = Array.isArray(json) ? json : json.positions;
+  return new Float32Array(data);
+}
+
+function fallbackFormation(count = 8, scale = 1.8): Float32Array {
+  const arr = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2;
+    arr[i * 3] = Math.cos(angle) * scale;
+    arr[i * 3 + 1] = Math.sin(angle) * scale;
+    arr[i * 3 + 2] = 0;
+  }
+  return arr;
+}
 
 export default function AppHost() {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [positions, setPositions] = useState<Float32Array | null>(null);
   const [ready, setReady] = useState(false);
   const [loadMs, setLoadMs] = useState(0);
@@ -35,52 +74,40 @@ export default function AppHost() {
     return () => cancelAnimationFrame(raf);
   }, []);
 
-  // wire draw end pipeline
-  useEffect(() => {
-    const canvas = document.querySelector('canvas');
-    if (!canvas) return;
-    canvasRef.current = canvas as HTMLCanvasElement;
+  const handleEnd = async (c: HTMLCanvasElement) => {
+    const preStart = performance.now();
+    const off = make28x28Canvas(c);
+    const preMs = performance.now() - preStart;
 
-    const handleEnd = async () => {
-      const c = canvasRef.current;
-      if (!c) return;
+    let lMs = loadMs;
+    if (!ready) {
+      const loadStart = performance.now();
+      await loadDoodleNet();
+      lMs = performance.now() - loadStart;
+      setLoadMs(lMs);
+      setReady(true);
+    }
 
-      const preStart = performance.now();
-      get28x28Gray(c);
-      const preMs = performance.now() - preStart;
+    const inferStart = performance.now();
+    const [pred] = await classify(off, 1);
+    const iMs = performance.now() - inferStart;
+    setInferMs(iMs);
 
-      let lMs = loadMs;
-      if (!ready) {
-        const loadStart = performance.now();
-        await loadDoodleNet();
-        lMs = performance.now() - loadStart;
-        setLoadMs(lMs);
-        setReady(true);
-      }
+    console.log(
+      `pre ${preMs.toFixed(1)}ms load ${lMs.toFixed(1)}ms infer ${iMs.toFixed(1)}ms`
+    );
 
-      const inferStart = performance.now();
-      const [pred] = await classify(c, 1);
-      const iMs = performance.now() - inferStart;
-      setInferMs(iMs);
-
-      console.log(
-        `pre ${preMs.toFixed(1)}ms load ${lMs.toFixed(1)}ms infer ${iMs.toFixed(1)}ms`
-      );
-
-      const label = pred?.label;
-      if (label) {
-        const form = await fetchFormation(label);
+    const label = pred?.label;
+    if (label) {
+      const normalized = aliasMap[label] ?? (seeded.has(label) ? label : 'cat');
+      try {
+        const form = await fetchFormation(normalized);
         setPositions(form);
+      } catch {
+        setPositions(fallbackFormation());
       }
-    };
-
-    canvas.addEventListener('mouseup', handleEnd);
-    canvas.addEventListener('touchend', handleEnd);
-    return () => {
-      canvas.removeEventListener('mouseup', handleEnd);
-      canvas.removeEventListener('touchend', handleEnd);
-    };
-  }, [ready, loadMs]);
+    }
+  };
 
   return (
     <div>
@@ -91,7 +118,7 @@ export default function AppHost() {
         fps={fps}
         instances={positions ? positions.length / 3 : 0}
       />
-      <DoodleCanvas />
+      <DoodleCanvas onEnd={handleEnd} />
       {positions && <FormationView positions={positions} />}
     </div>
   );

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 
-export default function DoodleCanvas() {
+export default function DoodleCanvas({
+  onEnd,
+}: {
+  onEnd?(canvas: HTMLCanvasElement): void;
+}) {
   const ref = useRef<HTMLCanvasElement>(null);
   const drawing = useRef(false);
   const last = useRef<{ x: number; y: number } | null>(null);
@@ -52,6 +56,7 @@ export default function DoodleCanvas() {
     const handleTouchEnd = (e: TouchEvent) => {
       e.preventDefault();
       end();
+      onEnd?.(canvas);
     };
 
     const handleMouseDown = (e: MouseEvent) => {
@@ -68,6 +73,7 @@ export default function DoodleCanvas() {
     const handleMouseUp = (e: MouseEvent) => {
       e.preventDefault();
       end();
+      onEnd?.(canvas);
     };
 
     canvas.addEventListener("touchstart", handleTouchStart, { passive: false });
@@ -88,5 +94,5 @@ export default function DoodleCanvas() {
     };
   }, []);
 
-  return <canvas ref={ref} width={280} height={280} />;
+  return <canvas ref={ref} width={280} height={280} style={{ touchAction: 'none' }} />;
 }

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
@@ -16,3 +16,23 @@ export function get28x28Gray(canvas: HTMLCanvasElement): Uint8ClampedArray {
   }
   return gray;
 }
+
+export function make28x28Canvas(src: HTMLCanvasElement): HTMLCanvasElement {
+  const size = 28;
+  const off =
+    src.ownerDocument?.createElement('canvas') ||
+    new (src.constructor as any)(size, size);
+  off.width = size;
+  off.height = size;
+  const ctx = off.getContext('2d');
+  if (!ctx) return off;
+  ctx.drawImage(src, 0, 0, size, size);
+  const img = ctx.getImageData(0, 0, size, size);
+  const data = img.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const avg = (data[i] + data[i + 1] + data[i + 2]) / 3;
+    data[i] = data[i + 1] = data[i + 2] = avg;
+  }
+  ctx.putImageData(img, 0, 0);
+  return off;
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -23,15 +23,17 @@ function InstancedFormation({ positions }: FormationViewProps) {
   const count = useFormationTransition(mesh, positions, maxInstances);
 
   return (
-    <instancedMesh ref={mesh} args={[undefined, undefined, count]}>
-      <sphereGeometry args={[0.01, 1, 1]} />
-      <meshBasicMaterial
-        color={0xffffff}
-        toneMapped={false}
-        transparent
-        opacity={1}
-      />
-    </instancedMesh>
+    <group scale={1.8}>
+      <instancedMesh ref={mesh} args={[undefined, undefined, count]}>
+        <sphereGeometry args={[0.03, 1, 1]} />
+        <meshBasicMaterial
+          color={0xffffff}
+          toneMapped={false}
+          transparent
+          opacity={1}
+        />
+      </instancedMesh>
+    </group>
   );
 }
 


### PR DESCRIPTION
## Summary
- wire doodle canvas end events to parent
- map classifier labels to known formations and fall back gracefully
- enlarge formation particles for better visibility

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from https://fonts.gstatic.com/s/...)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bd9d801d6c8328a5d659d94a39e0fa