### PR TITLE
fix(preprocess): alpha-aware bbox; preserve center-crop→28×28 grayscale with solid alpha

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/preprocess.ts
@@ -24,7 +24,7 @@ export function make28x28Canvas(src: HTMLCanvasElement): HTMLCanvasElement {
   const ctx = off.getContext('2d')
   if (!ctx) return off
 
-  // Compute tight bounding box of non-white pixels, with padding
+  // Compute tight bounding box of opaque, non-white pixels with padding
   const sctx = src.getContext('2d')!
   const sData = sctx.getImageData(0, 0, src.width, src.height)
   let minX = src.width,
@@ -37,8 +37,9 @@ export function make28x28Canvas(src: HTMLCanvasElement): HTMLCanvasElement {
       const r = sData.data[i]
       const g = sData.data[i + 1]
       const b = sData.data[i + 2]
+      const a = sData.data[i + 3]
       const v = r | g | b
-      if (v !== 255) {
+      if (a >= 250 && v !== 255) {
         if (x < minX) minX = x
         if (y < minY) minY = y
         if (x > maxX) maxX = x


### PR DESCRIPTION
## Summary
- treat pixels with low alpha or white channels as background during Draw3D preprocessing
- continue center-crop with padding, draw to offscreen 28×28 and force grayscale/solid alpha

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bedff7c70c832885e50add20407b92