### PR TITLE
feat(draw3d-overlay): full-viewport DoodleCanvas, transparent overlay, shared handle type

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
@@ -4,6 +4,7 @@ export default function DoodleCanvas({ onEnd }: { onEnd?(canvas: HTMLCanvasEleme
   const ref = useRef<HTMLCanvasElement>(null)
   const drawing = useRef(false)
   const last = useRef<{ x: number; y: number } | null>(null)
+  const dpr = useRef(1)
 
   const start = (x: number, y: number) => {
     drawing.current = true
@@ -16,7 +17,8 @@ export default function DoodleCanvas({ onEnd }: { onEnd?(canvas: HTMLCanvasEleme
     if (!drawing.current || !ctx || !last.current) return
     ctx.lineCap = 'round'
     ctx.lineJoin = 'round'
-    ctx.lineWidth = 16
+    ctx.lineWidth = 16 * dpr.current
+    ctx.strokeStyle = 'rgba(255,255,255,0.8)'
     const { x: lx, y: ly } = last.current
     ctx.beginPath()
     ctx.moveTo(lx, ly)
@@ -36,13 +38,15 @@ export default function DoodleCanvas({ onEnd }: { onEnd?(canvas: HTMLCanvasEleme
     const canvas = ref.current
     if (!canvas) return
 
-    // Initialize white background and black stroke for deterministic input
     const ctx = canvas.getContext('2d')
-    if (ctx) {
-      ctx.fillStyle = '#fff'
-      ctx.fillRect(0, 0, canvas.width, canvas.height)
-      ctx.strokeStyle = '#000'
-    }
+    if (!ctx) return
+
+    dpr.current = Math.min(window.devicePixelRatio || 1, 1.5)
+    canvas.width = window.innerWidth * dpr.current
+    canvas.height = window.innerHeight * dpr.current
+    canvas.style.width = '100%'
+    canvas.style.height = '100%'
+    ctx.setTransform(dpr.current, 0, 0, dpr.current, 0, 0)
 
     const rect = () => canvas.getBoundingClientRect()
 
@@ -78,9 +82,7 @@ export default function DoodleCanvas({ onEnd }: { onEnd?(canvas: HTMLCanvasEleme
   return (
     <canvas
       ref={ref}
-      width={280}
-      height={280}
-      style={{ touchAction: 'none', position: 'relative', zIndex: 1 }}
+      style={{ position: 'absolute', inset: 0, zIndex: 1, touchAction: 'none' }}
     />
   )
 }

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
@@ -1,0 +1,5 @@
+export type DoodleCanvasHandle = {
+  clear(): void
+  undo(): void
+  toCanvas(): HTMLCanvasElement | null
+}


### PR DESCRIPTION
## Summary
- Expand doodle canvas to cover the viewport with DPR scaling and semi-opaque stroke.
- Add shared `DoodleCanvasHandle` type for future controls.

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` (warnings)
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bedfea62e883288c0189f13ee9a3db