### PR TITLE
feat(hud): optional Classify/Clear/Undo/Auto controls and busy indicator (BC-safe)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -4,9 +4,27 @@ export interface HUDProps {
   inferMs: number
   fps: number
   instances: number
+  onClassify?(): void
+  onClear?(): void
+  onUndo?(): void
+  autoEnabled?: boolean
+  onToggleAuto?(next: boolean): void
+  busy?: boolean
 }
 
-export default function HUD({ ready, loadMs, inferMs, fps, instances }: HUDProps) {
+export default function HUD({
+  ready,
+  loadMs,
+  inferMs,
+  fps,
+  instances,
+  onClassify,
+  onClear,
+  onUndo,
+  autoEnabled,
+  onToggleAuto,
+  busy,
+}: HUDProps) {
   return (
     <div
       style={{
@@ -26,6 +44,45 @@ export default function HUD({ ready, loadMs, inferMs, fps, instances }: HUDProps
       <div>infer: {inferMs}ms</div>
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
+      <div style={{ marginTop: 4 }}>
+        {onClassify && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onClassify}
+            disabled={!!busy}
+          >
+            Classify
+          </button>
+        )}
+        {onClear && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onClear}
+            disabled={!!busy}
+          >
+            Clear
+          </button>
+        )}
+        {onUndo && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onUndo}
+            disabled={!!busy}
+          >
+            Undo
+          </button>
+        )}
+        {onToggleAuto && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={() => onToggleAuto(!autoEnabled)}
+            disabled={!!busy}
+          >
+            Auto {autoEnabled ? 'On' : 'Off'}
+          </button>
+        )}
+        {busy && <span style={{ marginLeft: 4 }}>inference…</span>}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- extend Draw3D HUD with optional classify, clear, undo and auto toggle controls
- show busy inference indicator

Base branch: feat/cryptiq-mindmap-draw3d

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68befe0de87c83289fa7c3f4bd4157cb