### PR TITLE
feat(draw3d): auto-commit idle timer with busy/ink guards; HUD wiring

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -31,6 +31,9 @@ const seeded = new Set([
   'tree',
 ])
 
+const MIN_AREA = 32 * 32
+const MIN_LENGTH = 80
+
 async function fetchFormation(name: string): Promise<Float32Array> {
   const url = `/formations/${name}.json`
   const res = await fetch(url)
@@ -61,14 +64,27 @@ export default function AppHost() {
   const [loadMs, setLoadMs] = useState(0)
   const [inferMs, setInferMs] = useState(0)
   const [fps, setFps] = useState(0)
+  const [autoEnabled, setAutoEnabled] = useState(false)
+  const [busy, setBusy] = useState(false)
   const canvasRef = useRef<DoodleCanvasHandle>(null)
   const inferRef = useRef(false)
+  const idleRef = useRef<NodeJS.Timeout | null>(null)
+
+  const meetsInk = () => {
+    const { area, length } = canvasRef.current?.getInkMetrics() ?? { area: 0, length: 0 }
+    return area > MIN_AREA && length > MIN_LENGTH
+  }
 
   const classifyNow = async () => {
-    if (inferRef.current) return
+    if (inferRef.current || !meetsInk()) return
     const canvas = canvasRef.current?.toCanvas()
     if (!canvas) return
     inferRef.current = true
+    setBusy(true)
+    if (idleRef.current) {
+      clearTimeout(idleRef.current)
+      idleRef.current = null
+    }
     try {
       const preStart = performance.now()
       const off = make28x28Canvas(canvas)
@@ -102,7 +118,18 @@ export default function AppHost() {
       }
     } finally {
       inferRef.current = false
+      setBusy(false)
     }
+  }
+
+  const handleStrokeEnd = () => {
+    if (!autoEnabled || busy) return
+    if (idleRef.current) clearTimeout(idleRef.current)
+    idleRef.current = setTimeout(() => {
+      idleRef.current = null
+      if (busy) return
+      classifyNow()
+    }, 800)
   }
 
   // simple fps tracker
@@ -139,8 +166,33 @@ export default function AppHost() {
         inferMs={Math.round(inferMs)}
         fps={fps}
         instances={positions ? positions.length / 3 : 0}
+        onClassify={classifyNow}
+        onClear={() => {
+          if (idleRef.current) {
+            clearTimeout(idleRef.current)
+            idleRef.current = null
+          }
+          canvasRef.current?.clear()
+          setPositions(null)
+        }}
+        onUndo={() => {
+          if (idleRef.current) {
+            clearTimeout(idleRef.current)
+            idleRef.current = null
+          }
+          canvasRef.current?.undo()
+        }}
+        autoEnabled={autoEnabled}
+        onToggleAuto={(next) => {
+          setAutoEnabled(next)
+          if (!next && idleRef.current) {
+            clearTimeout(idleRef.current)
+            idleRef.current = null
+          }
+        }}
+        busy={busy}
       />
-      <DoodleCanvas ref={canvasRef} />
+      <DoodleCanvas ref={canvasRef} onStrokeEnd={handleStrokeEnd} />
       {positions && <FormationView positions={positions} />}
     </div>
   )

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import type { DoodleCanvasHandle } from '../types'
 
+type DoodleCanvasProps = { onStrokeEnd?: () => void }
+
 type Point = { x: number; y: number }
 type BBox = { minX: number; minY: number; maxX: number; maxY: number }
 
@@ -13,13 +15,14 @@ function union(b: BBox | null, x: number, y: number): BBox {
   return b
 }
 
-const DoodleCanvas = forwardRef<DoodleCanvasHandle>((_, ref) => {
+const DoodleCanvas = forwardRef<DoodleCanvasHandle, DoodleCanvasProps>(({ onStrokeEnd }, ref) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const dpr = useRef(1)
   const isDrawing = useRef(false)
   const last = useRef<Point | null>(null)
   const strokes = useRef<Point[][]>([])
   const bbox = useRef<BBox | null>(null)
+  const length = useRef(0)
 
   const start = (x: number, y: number) => {
     isDrawing.current = true
@@ -47,11 +50,15 @@ const DoodleCanvas = forwardRef<DoodleCanvasHandle>((_, ref) => {
     ctx.stroke()
     last.current = { x, y }
     bbox.current = union(bbox.current, x, y)
+    const dx = x - lx
+    const dy = y - ly
+    length.current += Math.hypot(dx, dy)
   }
 
   const end = () => {
     isDrawing.current = false
     last.current = null
+    onStrokeEnd?.()
   }
 
   const redraw = () => {
@@ -82,15 +89,22 @@ const DoodleCanvas = forwardRef<DoodleCanvasHandle>((_, ref) => {
   const clear = () => {
     strokes.current = []
     bbox.current = null
+    length.current = 0
     redraw()
   }
 
   const undo = () => {
     strokes.current.pop()
     bbox.current = null
+    length.current = 0
     for (const stroke of strokes.current) {
+      let prev: Point | null = null
       for (const p of stroke) {
         bbox.current = union(bbox.current, p.x, p.y)
+        if (prev) {
+          length.current += Math.hypot(p.x - prev.x, p.y - prev.y)
+        }
+        prev = p
       }
     }
     redraw()
@@ -100,6 +114,11 @@ const DoodleCanvas = forwardRef<DoodleCanvasHandle>((_, ref) => {
     clear,
     undo,
     toCanvas: () => canvasRef.current,
+    getInkMetrics: () => {
+      const b = bbox.current
+      const area = b ? (b.maxX - b.minX) * (b.maxY - b.minY) : 0
+      return { area, length: length.current }
+    },
   }))
 
   useEffect(() => {

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
@@ -2,4 +2,5 @@ export type DoodleCanvasHandle = {
   clear(): void
   undo(): void
   toCanvas(): HTMLCanvasElement | null
+  getInkMetrics(): { area: number; length: number }
 }


### PR DESCRIPTION
## Summary
- add auto-classify timer gated by busy state and minimum ink metrics
- expose stroke-end hook and ink stats from DoodleCanvas for idle detection
- wire HUD controls for auto mode, classify, clear, and undo

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton`/`IBM Plex Mono` fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf0287eb808328b9eb03cf4ab9605d