### PR TITLE
chore(draw3d): add renderer style tokens (radius, jitter, ramp, morph duration)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/style.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/style.ts
@@ -1,0 +1,4 @@
+export const SPHERE_RADIUS = 0.035;
+export const SIZE_JITTER = 0.08;
+export const COLOR_RAMP = [0x6ec6ff, 0x42a5f5, 0x1e88e5]; // placeholder
+export const MORPH_MS = 400;


### PR DESCRIPTION
## Summary
- add renderer style tokens for draw3d (radius, jitter, color ramp, morph duration)

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: TS errors)*
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: font fetch errors)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf3638714083288735b277ec703195