### PR TITLE
feat(draw3d): add fit-to-bbox geometry transforms (not wired)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
@@ -1,0 +1,39 @@
+export type BBox = { minX: number; minY: number; maxX: number; maxY: number }
+
+export function fitPositionsToBBox(
+  positions: Float32Array,
+  bbox: BBox,
+): Float32Array {
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i]
+    const y = positions[i + 1]
+    if (x < minX) minX = x
+    if (y < minY) minY = y
+    if (x > maxX) maxX = x
+    if (y > maxY) maxY = y
+  }
+
+  const w = maxX - minX
+  const h = maxY - minY
+  const cx = (minX + maxX) / 2
+  const cy = (minY + maxY) / 2
+
+  const bw = bbox.maxX - bbox.minX
+  const bh = bbox.maxY - bbox.minY
+  const bcx = (bbox.minX + bbox.maxX) / 2
+  const bcy = (bbox.minY + bbox.maxY) / 2
+
+  const s = Math.max(bw, bh) / (Math.max(w, h) || 1)
+
+  const out = new Float32Array(positions.length)
+  for (let i = 0; i < positions.length; i += 3) {
+    out[i] = (positions[i] - cx) * s + bcx
+    out[i + 1] = (positions[i + 1] - cy) * s + bcy
+    out[i + 2] = positions[i + 2] * s
+  }
+  return out
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
@@ -27,7 +27,9 @@ export function fitPositionsToBBox(
   const bcx = (bbox.minX + bbox.maxX) / 2
   const bcy = (bbox.minY + bbox.maxY) / 2
 
-  const s = Math.max(bw, bh) / (Math.max(w, h) || 1)
+  const sw = bw / (w || 1)
+  const sh = bh / (h || 1)
+  const s = Math.min(sw, sh)
 
   const out = new Float32Array(positions.length)
   for (let i = 0; i < positions.length; i += 3) {


### PR DESCRIPTION
## Summary
- add geometry helpers to scale and center formations into a target bbox

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf362a61988328861945a758670709