### PR TITLE
feat(draw3d): morph engine and MorphFormationView (not wired)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import * as THREE from 'three'
+import { clampDpr, capInstances } from './perf'
+import { pairAndMorph } from './morph'
+
+export type MorphFormationViewProps = {
+  source: Float32Array
+  target: Float32Array
+  durationMs?: number
+}
+
+function InstancedMorph({ source, target, durationMs }: MorphFormationViewProps) {
+  const { gl } = useThree()
+  const mesh = useRef<any>(null)
+  const dummy = useRef<any>(new THREE.Object3D())
+  const anim = useRef<{ start: number; duration: number; active: boolean }>({
+    start: 0,
+    duration: 300,
+    active: false,
+  })
+
+  useEffect(() => {
+    clampDpr(gl)
+  }, [gl])
+
+  const data = useMemo(() => {
+    const maxCount = Math.max(source.length, target.length) / 3
+    const count = capInstances(maxCount)
+    return pairAndMorph(source, target, count)
+  }, [source, target])
+
+  const count = data.source.length / 3
+
+  useEffect(() => {
+    const m = mesh.current
+    if (!m) return
+    const src = data.source
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3
+      dummy.current.position.set(src[i3], src[i3 + 1], src[i3 + 2])
+      dummy.current.updateMatrix()
+      m.setMatrixAt(i, dummy.current.matrix)
+    }
+    m.instanceMatrix.needsUpdate = true
+    anim.current = {
+      start: performance.now(),
+      duration: durationMs ?? 300 + Math.random() * 200,
+      active: true,
+    }
+  }, [data, durationMs, count])
+
+  useFrame(() => {
+    const m = mesh.current
+    if (!m) return
+    const { start, duration, active } = anim.current
+    if (!active) return
+    const t = Math.min((performance.now() - start) / duration, 1)
+    const src = data.source
+    const tgt = data.target
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3
+      dummy.current.position.set(
+        src[i3] + (tgt[i3] - src[i3]) * t,
+        src[i3 + 1] + (tgt[i3 + 1] - src[i3 + 1]) * t,
+        src[i3 + 2] + (tgt[i3 + 2] - src[i3 + 2]) * t
+      )
+      dummy.current.updateMatrix()
+      m.setMatrixAt(i, dummy.current.matrix)
+    }
+    m.instanceMatrix.needsUpdate = true
+    if (t >= 1) {
+      anim.current.active = false
+    }
+  })
+
+  return (
+    <group scale={1.8}>
+      {/* @ts-expect-error r3f intrinsic */}
+      <instancedMesh ref={mesh} args={[undefined, undefined, count]}>
+        {/* @ts-expect-error r3f intrinsic */}
+        <sphereGeometry args={[0.045, 6, 6]} />
+        <meshBasicMaterial color={0xffffff} toneMapped={false} transparent opacity={1} />
+        {/* @ts-expect-error r3f intrinsic */}
+      </instancedMesh>
+    </group>
+  )
+}
+
+export default function MorphFormationView(props: MorphFormationViewProps) {
+  return (
+    <Canvas dpr={[1, 2]} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+      <InstancedMorph {...props} />
+    </Canvas>
+  )
+}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
@@ -1,0 +1,99 @@
+export function pairAndMorph(
+  source: Float32Array,
+  target: Float32Array,
+  count: number
+): { source: Float32Array; target: Float32Array; indexMap: Uint32Array } {
+  const resample = (input: Float32Array, inCount: number, outCount: number, map?: Uint32Array) => {
+    const out = new Float32Array(outCount * 3)
+    if (inCount === outCount) {
+      out.set(input.subarray(0, outCount * 3))
+      if (map) {
+        for (let i = 0; i < outCount; i++) map[i] = i
+      }
+      return out
+    }
+    if (inCount < outCount) {
+      for (let i = 0; i < outCount; i++) {
+        const t = (i * (inCount - 1)) / (outCount - 1)
+        const i0 = Math.floor(t)
+        const i1 = Math.min(i0 + 1, inCount - 1)
+        const f = t - i0
+        const b0 = i0 * 3
+        const b1 = i1 * 3
+        out[i * 3] = input[b0] * (1 - f) + input[b1] * f
+        out[i * 3 + 1] = input[b0 + 1] * (1 - f) + input[b1 + 1] * f
+        out[i * 3 + 2] = input[b0 + 2] * (1 - f) + input[b1 + 2] * f
+        if (map) map[i] = i0
+      }
+      return out
+    }
+    const stride = inCount / outCount
+    for (let i = 0; i < outCount; i++) {
+      const idx = Math.floor(i * stride)
+      const b = idx * 3
+      out[i * 3] = input[b]
+      out[i * 3 + 1] = input[b + 1]
+      out[i * 3 + 2] = input[b + 2]
+      if (map) map[i] = idx
+    }
+    return out
+  }
+
+  const srcCount = Math.floor(source.length / 3)
+  const tgtCount = Math.floor(target.length / 3)
+  const indexMap = new Uint32Array(count)
+  const src = resample(source, srcCount, count, indexMap)
+  const tgt = resample(target, tgtCount, count)
+
+  const sortAndNormalize = (arr: Float32Array, map?: Uint32Array) => {
+    const centroid = [0, 0, 0]
+    for (let i = 0; i < count; i++) {
+      centroid[0] += arr[i * 3]
+      centroid[1] += arr[i * 3 + 1]
+      centroid[2] += arr[i * 3 + 2]
+    }
+    centroid[0] /= count
+    centroid[1] /= count
+    centroid[2] /= count
+
+    const indices = Array.from({ length: count }, (_, i) => i)
+    indices.sort((a, b) => {
+      const ax = arr[a * 3] - centroid[0]
+      const ay = arr[a * 3 + 1] - centroid[1]
+      const bx = arr[b * 3] - centroid[0]
+      const by = arr[b * 3 + 1] - centroid[1]
+      return Math.atan2(ay, ax) - Math.atan2(by, bx)
+    })
+
+    const copy = arr.slice()
+    for (let i = 0; i < count; i++) {
+      const idx = indices[i]
+      arr[i * 3] = copy[idx * 3]
+      arr[i * 3 + 1] = copy[idx * 3 + 1]
+      arr[i * 3 + 2] = copy[idx * 3 + 2]
+      if (map) map[i] = map[idx]
+    }
+
+    let maxR = 0
+    for (let i = 0; i < count; i++) {
+      const x = arr[i * 3] - centroid[0]
+      const y = arr[i * 3 + 1] - centroid[1]
+      const z = arr[i * 3 + 2] - centroid[2]
+      const r = Math.sqrt(x * x + y * y + z * z)
+      if (r > maxR) maxR = r
+    }
+    const scale = maxR > 0 ? 1 / maxR : 1
+    for (let i = 0; i < count; i++) {
+      arr[i * 3] = (arr[i * 3] - centroid[0]) * scale
+      arr[i * 3 + 1] = (arr[i * 3 + 1] - centroid[1]) * scale
+      arr[i * 3 + 2] = (arr[i * 3 + 2] - centroid[2]) * scale
+    }
+  }
+
+  sortAndNormalize(src, indexMap)
+  sortAndNormalize(tgt)
+
+  return { source: src, target: tgt, indexMap }
+}
+
+export default pairAndMorph


### PR DESCRIPTION
## Summary
- morph point sets with resampling, polar sort, normalization
- render MorphFormationView for morphing between formations

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton/IBM Plex Mono from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf36243f8c8328995fca364062e39d