### PR TITLE
fix(draw3d): bound geometry scale to bbox

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/geometry/fit.ts
@@ -27,7 +27,9 @@ export function fitPositionsToBBox(
   const bcx = (bbox.minX + bbox.maxX) / 2
   const bcy = (bbox.minY + bbox.maxY) / 2
 
-  const s = Math.max(bw, bh) / (Math.max(w, h) || 1)
+  const sw = bw / (w || 1)
+  const sh = bh / (h || 1)
+  const s = Math.min(sw, sh)
 
   const out = new Float32Array(positions.length)
   for (let i = 0; i < positions.length; i += 3) {


### PR DESCRIPTION
## Summary
- ensure geometry fit uses minimum per-axis scale to stay within target bbox

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf3d6d9ae48328867a2e8f35f19330