### PR TITLE
feat(hud): optional Classify/Clear/Undo/Auto controls and busy indicator (BC-safe)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -45,42 +45,34 @@ export default function HUD({
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
       <div style={{ marginTop: 4 }}>
-        {onClassify && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={onClassify}
-            disabled={!!busy}
-          >
-            Classify
-          </button>
-        )}
-        {onClear && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={onClear}
-            disabled={!!busy}
-          >
-            Clear
-          </button>
-        )}
-        {onUndo && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={onUndo}
-            disabled={!!busy}
-          >
-            Undo
-          </button>
-        )}
-        {onToggleAuto && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={() => onToggleAuto(!autoEnabled)}
-            disabled={!!busy}
-          >
-            Auto {autoEnabled ? 'On' : 'Off'}
-          </button>
-        )}
+        <button
+          style={{ marginRight: 4, fontSize: 10 }}
+          onClick={onClassify}
+          disabled={!onClassify || !!busy}
+        >
+          Classify
+        </button>
+        <button
+          style={{ marginRight: 4, fontSize: 10 }}
+          onClick={onClear}
+          disabled={!onClear || !!busy}
+        >
+          Clear
+        </button>
+        <button
+          style={{ marginRight: 4, fontSize: 10 }}
+          onClick={onUndo}
+          disabled={!onUndo || !!busy}
+        >
+          Undo
+        </button>
+        <button
+          style={{ marginRight: 4, fontSize: 10 }}
+          onClick={() => onToggleAuto?.(!autoEnabled)}
+          disabled={!onToggleAuto || !!busy}
+        >
+          Auto {autoEnabled ? 'On' : 'Off'}
+        </button>
         {busy && <span style={{ marginLeft: 4 }}>inference…</span>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add optional callbacks and flags to draw3d HUD
- show small Classify, Clear, Undo and Auto buttons with a busy indicator

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton/IBM Plex Mono fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf3ee722b883289bc415eb3d3f0d76