### PR TITLE
feat(draw3d): auto-commit idle timer with busy/ink guards; HUD wiring

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -65,8 +65,10 @@ export default function AppHost() {
   const [inferMs, setInferMs] = useState(0)
   const [fps, setFps] = useState(0)
   const [busy, setBusy] = useState(false)
+  const [autoEnabled, setAutoEnabled] = useState(false)
   const canvasRef = useRef<DoodleCanvasHandle>(null)
   const inferRef = useRef(false)
+  const timerRef = useRef<number | null>(null)
 
   const meetsInk = () => {
     const { area, length } = canvasRef.current?.getInkMetrics() ?? { area: 0, length: 0 }
@@ -75,6 +77,10 @@ export default function AppHost() {
 
   const classifyNow = async () => {
     if (inferRef.current || !meetsInk()) return
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
     const canvas = canvasRef.current?.toCanvas()
     if (!canvas) return
     inferRef.current = true
@@ -116,6 +122,22 @@ export default function AppHost() {
     }
   }
 
+  const resetTimer = () => {
+    if (!autoEnabled || inferRef.current || !meetsInk()) return
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null
+      if (!inferRef.current && meetsInk()) classifyNow()
+    }, 800)
+  }
+
+  useEffect(() => {
+    if (!autoEnabled && timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [autoEnabled])
+
   // simple fps tracker
   useEffect(() => {
     let frame = 0
@@ -154,13 +176,23 @@ export default function AppHost() {
         onClear={() => {
           canvasRef.current?.clear()
           setPositions(null)
+          if (timerRef.current) {
+            clearTimeout(timerRef.current)
+            timerRef.current = null
+          }
         }}
         onUndo={() => {
           canvasRef.current?.undo()
+          if (timerRef.current) {
+            clearTimeout(timerRef.current)
+            timerRef.current = null
+          }
         }}
+        autoEnabled={autoEnabled}
+        onToggleAuto={setAutoEnabled}
         busy={busy}
       />
-      <DoodleCanvas ref={canvasRef} />
+      <DoodleCanvas ref={canvasRef} onStrokeEnd={resetTimer} />
       {positions && <FormationView positions={positions} />}
     </div>
   )

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/DoodleCanvas.tsx
@@ -1,6 +1,10 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import type { DoodleCanvasHandle } from '../types'
 
+interface DoodleCanvasProps {
+  onStrokeEnd?(): void
+}
+
 type Point = { x: number; y: number }
 type BBox = { minX: number; minY: number; maxX: number; maxY: number }
 
@@ -13,110 +17,117 @@ function union(b: BBox | null, x: number, y: number): BBox {
   return b
 }
 
-const DoodleCanvas = forwardRef<DoodleCanvasHandle>((_, ref) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const dpr = useRef(1)
-  const isDrawing = useRef(false)
-  const last = useRef<Point | null>(null)
-  const strokes = useRef<Point[][]>([])
-  const bbox = useRef<BBox | null>(null)
-  const length = useRef(0)
+const DoodleCanvas = forwardRef<DoodleCanvasHandle, DoodleCanvasProps>(
+  ({ onStrokeEnd }, ref) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const dpr = useRef(1)
+    const isDrawing = useRef(false)
+    const last = useRef<Point | null>(null)
+    const strokes = useRef<Point[][]>([])
+    const bbox = useRef<BBox | null>(null)
+    const length = useRef(0)
+    const strokeEndRef = useRef<(() => void) | null>(null)
 
-  const start = (x: number, y: number) => {
-    isDrawing.current = true
-    last.current = { x, y }
-    strokes.current.push([{ x, y }])
-    bbox.current = union(bbox.current, x, y)
-  }
+    useEffect(() => {
+      strokeEndRef.current = onStrokeEnd ?? null
+    }, [onStrokeEnd])
 
-  const move = (x: number, y: number) => {
-    const canvas = canvasRef.current
-    const ctx = canvas?.getContext('2d')
-    const stroke = strokes.current[strokes.current.length - 1]
-    if (!isDrawing.current || !ctx || !last.current || !stroke) return
-    stroke.push({ x, y })
-    ctx.lineCap = 'round'
-    ctx.lineJoin = 'round'
-    ctx.lineWidth = 16 * dpr.current
-    ctx.strokeStyle = 'rgba(255,255,255,0.8)'
-    const { x: lx, y: ly } = last.current
-    ctx.beginPath()
-    ctx.moveTo(lx, ly)
-    const mx = (lx + x) / 2
-    const my = (ly + y) / 2
-    ctx.quadraticCurveTo(lx, ly, mx, my)
-    ctx.stroke()
-    last.current = { x, y }
-    bbox.current = union(bbox.current, x, y)
-    const dx = x - lx
-    const dy = y - ly
-    length.current += Math.hypot(dx, dy)
-  }
+    const start = (x: number, y: number) => {
+      isDrawing.current = true
+      last.current = { x, y }
+      strokes.current.push([{ x, y }])
+      bbox.current = union(bbox.current, x, y)
+    }
 
-  const end = () => {
-    isDrawing.current = false
-    last.current = null
-  }
-
-  const redraw = () => {
-    const canvas = canvasRef.current
-    const ctx = canvas?.getContext('2d')
-    if (!canvas || !ctx) return
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-    for (const stroke of strokes.current) {
-      if (!stroke.length) continue
+    const move = (x: number, y: number) => {
+      const canvas = canvasRef.current
+      const ctx = canvas?.getContext('2d')
+      const stroke = strokes.current[strokes.current.length - 1]
+      if (!isDrawing.current || !ctx || !last.current || !stroke) return
+      stroke.push({ x, y })
       ctx.lineCap = 'round'
       ctx.lineJoin = 'round'
       ctx.lineWidth = 16 * dpr.current
       ctx.strokeStyle = 'rgba(255,255,255,0.8)'
+      const { x: lx, y: ly } = last.current
       ctx.beginPath()
-      const [p0, ...rest] = stroke
-      ctx.moveTo(p0.x, p0.y)
-      let prev = p0
-      for (const p of rest) {
-        const mx = (prev.x + p.x) / 2
-        const my = (prev.y + p.y) / 2
-        ctx.quadraticCurveTo(prev.x, prev.y, mx, my)
-        prev = p
-      }
+      ctx.moveTo(lx, ly)
+      const mx = (lx + x) / 2
+      const my = (ly + y) / 2
+      ctx.quadraticCurveTo(lx, ly, mx, my)
       ctx.stroke()
+      last.current = { x, y }
+      bbox.current = union(bbox.current, x, y)
+      const dx = x - lx
+      const dy = y - ly
+      length.current += Math.hypot(dx, dy)
     }
-  }
 
-  const clear = () => {
-    strokes.current = []
-    bbox.current = null
-    length.current = 0
-    redraw()
-  }
+    const end = () => {
+      isDrawing.current = false
+      last.current = null
+      strokeEndRef.current?.()
+    }
 
-  const undo = () => {
-    strokes.current.pop()
-    bbox.current = null
-    length.current = 0
-    for (const stroke of strokes.current) {
-      let prev: Point | null = null
-      for (const p of stroke) {
-        bbox.current = union(bbox.current, p.x, p.y)
-        if (prev) {
-          length.current += Math.hypot(p.x - prev.x, p.y - prev.y)
+    const redraw = () => {
+      const canvas = canvasRef.current
+      const ctx = canvas?.getContext('2d')
+      if (!canvas || !ctx) return
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      for (const stroke of strokes.current) {
+        if (!stroke.length) continue
+        ctx.lineCap = 'round'
+        ctx.lineJoin = 'round'
+        ctx.lineWidth = 16 * dpr.current
+        ctx.strokeStyle = 'rgba(255,255,255,0.8)'
+        ctx.beginPath()
+        const [p0, ...rest] = stroke
+        ctx.moveTo(p0.x, p0.y)
+        let prev = p0
+        for (const p of rest) {
+          const mx = (prev.x + p.x) / 2
+          const my = (prev.y + p.y) / 2
+          ctx.quadraticCurveTo(prev.x, prev.y, mx, my)
+          prev = p
         }
-        prev = p
+        ctx.stroke()
       }
     }
-    redraw()
-  }
 
-  useImperativeHandle(ref, () => ({
-    clear,
-    undo,
-    toCanvas: () => canvasRef.current,
-    getInkMetrics: () => {
-      const b = bbox.current
-      const area = b ? (b.maxX - b.minX) * (b.maxY - b.minY) : 0
-      return { area, length: length.current }
-    },
-  }))
+    const clear = () => {
+      strokes.current = []
+      bbox.current = null
+      length.current = 0
+      redraw()
+    }
+
+    const undo = () => {
+      strokes.current.pop()
+      bbox.current = null
+      length.current = 0
+      for (const stroke of strokes.current) {
+        let prev: Point | null = null
+        for (const p of stroke) {
+          bbox.current = union(bbox.current, p.x, p.y)
+          if (prev) {
+            length.current += Math.hypot(p.x - prev.x, p.y - prev.y)
+          }
+          prev = p
+        }
+      }
+      redraw()
+    }
+
+    useImperativeHandle(ref, () => ({
+      clear,
+      undo,
+      toCanvas: () => canvasRef.current,
+      getInkMetrics: () => {
+        const b = bbox.current
+        const area = b ? (b.maxX - b.minX) * (b.maxY - b.minY) : 0
+        return { area, length: length.current }
+      },
+    }))
 
   useEffect(() => {
     const canvas = canvasRef.current


### PR DESCRIPTION
## Summary
- add optional auto-classify idle timer gated by ink area and busy state, with HUD toggle
- expose `onStrokeEnd` callback from doodle canvas so host can reset idle timer

## Testing
- `corepack enable` *(command not found)*
- `pnpm install --frozen-lockfile`
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit` *(tsconfig.path missing)*
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed to fetch fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf44d994508328955bf0e35bf138fc