### PR TITLE
PR-1 — Curated label map and normalization

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
@@ -1,0 +1,44 @@
+export const ALIASES: Record<string, string> = {
+  ship: 'boat',
+  cellphone: 'phone',
+  mobile: 'phone',
+  telephone: 'phone',
+  mug: 'cup',
+  leaf: 'flower',
+};
+
+export const CURATED = new Set<string>([
+  'balloon',
+  'bird',
+  'boat',
+  'car',
+  'cat',
+  'cup',
+  'fish',
+  'flower',
+  'house',
+  'phone',
+  'tree',
+  'star',
+  'sun',
+]);
+
+export function normalizeLabel(
+  raw: string,
+  topK: Array<{ label: string; confidence: number }> = [],
+): string {
+  const normalize = (label: string): string => {
+    const lc = label.toLowerCase();
+    return ALIASES[lc] ?? lc;
+  };
+
+  const primary = normalize(raw);
+  if (CURATED.has(primary)) return primary;
+
+  for (const { label } of topK) {
+    const mapped = normalize(label);
+    if (CURATED.has(mapped)) return mapped;
+  }
+
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary
- add alias mappings and curated label set for draw3d labels
- expose `normalizeLabel` helper to map raw or top-k predictions into curated labels

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`
- `pnpm tsx -e "import {normalizeLabel} from './apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap'; console.log(normalizeLabel('mug', []));"`


------
https://chatgpt.com/codex/tasks/task_e_68c039f62ed08328adc348845177d1ac