### PR TITLE
draw3d(ml): filter tfjs conv2d_1 warning, keep lazy load

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ml/doodlenet.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ml/doodlenet.ts
@@ -35,8 +35,13 @@ export async function loadDoodleNet(): Promise<DoodleClassifier> {
     doodlePromise = loadMl5().then((ml5) => {
       const originalWarn = console.warn
       console.warn = (msg?: any, ...rest: any[]) => {
-        const s = String(msg ?? '')
-        if (s.includes('The shape of the input tensor') && s.includes('conv2d_1')) return
+        if (
+          typeof msg === 'string' &&
+          msg.includes('The shape of the input tensor') &&
+          msg.includes('conv2d_1')
+        ) {
+          return
+        }
         originalWarn(msg, ...rest)
       }
       return ml5.imageClassifier('DoodleNet').finally(() => {


### PR DESCRIPTION
## Summary
- avoid noisy conv2d_1 input tensor warning when loading DoodleNet, without muting other warnings

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c03a193d788328adfbe3fa8f0727ef