### PR TITLE
draw3d(render): add MorphFormationView with source→target morph + center-out emit

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -72,10 +72,15 @@ function InstancedMorph({
   useEffect(() => {
     const m = mesh.current
     if (!m) return
-    const startPos = data.src ?? data.tgt
+    const { src, tgt, map } = data
     for (let i = 0; i < data.count; i++) {
       const i3 = i * 3
-      dummy.current.position.set(startPos[i3], startPos[i3 + 1], startPos[i3 + 2])
+      if (src && map) {
+        const sIdx = map[i] * 3
+        dummy.current.position.set(src[sIdx], src[sIdx + 1], src[sIdx + 2])
+      } else {
+        dummy.current.position.set(tgt[i3], tgt[i3 + 1], tgt[i3 + 2])
+      }
       dummy.current.scale.setScalar(0)
       dummy.current.updateMatrix()
       m.setMatrixAt(i, dummy.current.matrix)

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -4,53 +4,89 @@ import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { clampDpr, capInstances } from './perf'
-import { pairAndMorph } from './morph'
+import {
+  resampleCloud,
+  computeMorphMap,
+  easeOutBack,
+  easeOutQuad,
+} from './morph'
 
 export type MorphFormationViewProps = {
-  source: Float32Array
+  source?: Float32Array
   target: Float32Array
   durationMs?: number
+  bounce?: boolean
+  fitScale?: number
 }
 
-function InstancedMorph({ source, target, durationMs }: MorphFormationViewProps) {
+function InstancedMorph({
+  source,
+  target,
+  durationMs = 500,
+  bounce = true,
+  fitScale = 1,
+}: MorphFormationViewProps) {
   const { gl } = useThree()
   const mesh = useRef<any>(null)
   const dummy = useRef<any>(new THREE.Object3D())
   const anim = useRef<{ start: number; duration: number; active: boolean }>({
     start: 0,
-    duration: 300,
+    duration: durationMs,
     active: false,
   })
 
+  // limit device pixel ratio to reduce GPU load
   useEffect(() => {
     clampDpr(gl)
   }, [gl])
 
   const data = useMemo(() => {
-    const maxCount = Math.max(source.length, target.length) / 3
+    const maxCount = Math.max(source ? source.length : 0, target.length) / 3
     const count = capInstances(maxCount)
-    return pairAndMorph(source, target, count)
+    const tgt = resampleCloud(target, count)
+    const src = source ? resampleCloud(source, count) : undefined
+    const map = src ? computeMorphMap(src, tgt) : undefined
+    return { count, src, tgt, map }
   }, [source, target])
 
-  const count = data.source.length / 3
+  const radii = useMemo(() => {
+    const arr = new Float32Array(data.count)
+    let maxR = 0
+    const t = data.tgt
+    for (let i = 0; i < data.count; i++) {
+      const i3 = i * 3
+      const x = t[i3]
+      const y = t[i3 + 1]
+      const z = t[i3 + 2]
+      const r = Math.sqrt(x * x + y * y + z * z)
+      arr[i] = r
+      if (r > maxR) maxR = r
+    }
+    if (maxR > 0) {
+      for (let i = 0; i < data.count; i++) arr[i] /= maxR
+    }
+    return arr
+  }, [data])
 
+  // Initialize instance positions and scales
   useEffect(() => {
     const m = mesh.current
     if (!m) return
-    const src = data.source
-    for (let i = 0; i < count; i++) {
+    const startPos = data.src ?? data.tgt
+    for (let i = 0; i < data.count; i++) {
       const i3 = i * 3
-      dummy.current.position.set(src[i3], src[i3 + 1], src[i3 + 2])
+      dummy.current.position.set(startPos[i3], startPos[i3 + 1], startPos[i3 + 2])
+      dummy.current.scale.setScalar(0)
       dummy.current.updateMatrix()
       m.setMatrixAt(i, dummy.current.matrix)
     }
     m.instanceMatrix.needsUpdate = true
     anim.current = {
       start: performance.now(),
-      duration: durationMs ?? 300 + Math.random() * 200,
+      duration: durationMs,
       active: true,
     }
-  }, [data, durationMs, count])
+  }, [data, durationMs])
 
   useFrame(() => {
     const m = mesh.current
@@ -58,28 +94,40 @@ function InstancedMorph({ source, target, durationMs }: MorphFormationViewProps)
     const { start, duration, active } = anim.current
     if (!active) return
     const t = Math.min((performance.now() - start) / duration, 1)
-    const src = data.source
-    const tgt = data.target
-    for (let i = 0; i < count; i++) {
+    const eased = easeOutQuad(t)
+    const scaleVal = bounce ? easeOutBack(eased) : eased
+    const thresh = eased
+
+    const tgt = data.tgt
+    const src = data.src
+    const map = data.map
+
+    for (let i = 0; i < data.count; i++) {
       const i3 = i * 3
-      dummy.current.position.set(
-        src[i3] + (tgt[i3] - src[i3]) * t,
-        src[i3 + 1] + (tgt[i3 + 1] - src[i3 + 1]) * t,
-        src[i3 + 2] + (tgt[i3 + 2] - src[i3 + 2]) * t
-      )
+      if (src && map) {
+        const sIdx = map[i] * 3
+        dummy.current.position.set(
+          src[sIdx] + (tgt[i3] - src[sIdx]) * eased,
+          src[sIdx + 1] + (tgt[i3 + 1] - src[sIdx + 1]) * eased,
+          src[sIdx + 2] + (tgt[i3 + 2] - src[sIdx + 2]) * eased
+        )
+      } else {
+        dummy.current.position.set(tgt[i3], tgt[i3 + 1], tgt[i3 + 2])
+      }
+
+      const visible = radii[i] <= thresh
+      dummy.current.scale.setScalar(visible ? scaleVal : 0)
       dummy.current.updateMatrix()
       m.setMatrixAt(i, dummy.current.matrix)
     }
     m.instanceMatrix.needsUpdate = true
-    if (t >= 1) {
-      anim.current.active = false
-    }
+    if (t >= 1) anim.current.active = false
   })
 
   return (
-    <group scale={1.8}>
+    <group scale={1.8 * fitScale}>
       {/* @ts-expect-error r3f intrinsic */}
-      <instancedMesh ref={mesh} args={[undefined, undefined, count]}>
+      <instancedMesh ref={mesh} args={[undefined, undefined, data.count]}>
         {/* @ts-expect-error r3f intrinsic */}
         <sphereGeometry args={[0.045, 6, 6]} />
         <meshBasicMaterial color={0xffffff} toneMapped={false} transparent opacity={1} />
@@ -96,3 +144,4 @@ export default function MorphFormationView(props: MorphFormationViewProps) {
     </Canvas>
   )
 }
+

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
@@ -1,99 +1,99 @@
-export function pairAndMorph(
-  source: Float32Array,
-  target: Float32Array,
-  count: number
-): { source: Float32Array; target: Float32Array; indexMap: Uint32Array } {
-  const resample = (input: Float32Array, inCount: number, outCount: number, map?: Uint32Array) => {
-    const out = new Float32Array(outCount * 3)
-    if (inCount === outCount) {
-      out.set(input.subarray(0, outCount * 3))
-      if (map) {
-        for (let i = 0; i < outCount; i++) map[i] = i
-      }
-      return out
-    }
-    if (inCount < outCount) {
-      for (let i = 0; i < outCount; i++) {
-        const t = (i * (inCount - 1)) / (outCount - 1)
-        const i0 = Math.floor(t)
-        const i1 = Math.min(i0 + 1, inCount - 1)
-        const f = t - i0
-        const b0 = i0 * 3
-        const b1 = i1 * 3
-        out[i * 3] = input[b0] * (1 - f) + input[b1] * f
-        out[i * 3 + 1] = input[b0 + 1] * (1 - f) + input[b1 + 1] * f
-        out[i * 3 + 2] = input[b0 + 2] * (1 - f) + input[b1 + 2] * f
-        if (map) map[i] = i0
-      }
-      return out
-    }
-    const stride = inCount / outCount
+// Utility functions for point-cloud morphing and easing
+
+// Resample a point cloud to a specific number of points.
+// Points are interleaved as [x, y, z]. When upsampling, points are
+// linearly interpolated; when downsampling, points are evenly picked.
+export function resampleCloud(input: Float32Array, outCount: number): Float32Array {
+  const inCount = Math.floor(input.length / 3)
+  const out = new Float32Array(outCount * 3)
+
+  if (inCount === 0 || outCount === 0) return out
+
+  if (inCount === outCount) {
+    out.set(input.subarray(0, outCount * 3))
+    return out
+  }
+
+  if (inCount < outCount) {
     for (let i = 0; i < outCount; i++) {
-      const idx = Math.floor(i * stride)
-      const b = idx * 3
-      out[i * 3] = input[b]
-      out[i * 3 + 1] = input[b + 1]
-      out[i * 3 + 2] = input[b + 2]
-      if (map) map[i] = idx
+      const t = (i * (inCount - 1)) / (outCount - 1)
+      const i0 = Math.floor(t)
+      const i1 = Math.min(i0 + 1, inCount - 1)
+      const f = t - i0
+      const b0 = i0 * 3
+      const b1 = i1 * 3
+      out[i * 3] = input[b0] * (1 - f) + input[b1] * f
+      out[i * 3 + 1] = input[b0 + 1] * (1 - f) + input[b1 + 1] * f
+      out[i * 3 + 2] = input[b0 + 2] * (1 - f) + input[b1 + 2] * f
     }
     return out
   }
 
-  const srcCount = Math.floor(source.length / 3)
-  const tgtCount = Math.floor(target.length / 3)
-  const indexMap = new Uint32Array(count)
-  const src = resample(source, srcCount, count, indexMap)
-  const tgt = resample(target, tgtCount, count)
-
-  const sortAndNormalize = (arr: Float32Array, map?: Uint32Array) => {
-    const centroid = [0, 0, 0]
-    for (let i = 0; i < count; i++) {
-      centroid[0] += arr[i * 3]
-      centroid[1] += arr[i * 3 + 1]
-      centroid[2] += arr[i * 3 + 2]
-    }
-    centroid[0] /= count
-    centroid[1] /= count
-    centroid[2] /= count
-
-    const indices = Array.from({ length: count }, (_, i) => i)
-    indices.sort((a, b) => {
-      const ax = arr[a * 3] - centroid[0]
-      const ay = arr[a * 3 + 1] - centroid[1]
-      const bx = arr[b * 3] - centroid[0]
-      const by = arr[b * 3 + 1] - centroid[1]
-      return Math.atan2(ay, ax) - Math.atan2(by, bx)
-    })
-
-    const copy = arr.slice()
-    for (let i = 0; i < count; i++) {
-      const idx = indices[i]
-      arr[i * 3] = copy[idx * 3]
-      arr[i * 3 + 1] = copy[idx * 3 + 1]
-      arr[i * 3 + 2] = copy[idx * 3 + 2]
-      if (map) map[i] = map[idx]
-    }
-
-    let maxR = 0
-    for (let i = 0; i < count; i++) {
-      const x = arr[i * 3] - centroid[0]
-      const y = arr[i * 3 + 1] - centroid[1]
-      const z = arr[i * 3 + 2] - centroid[2]
-      const r = Math.sqrt(x * x + y * y + z * z)
-      if (r > maxR) maxR = r
-    }
-    const scale = maxR > 0 ? 1 / maxR : 1
-    for (let i = 0; i < count; i++) {
-      arr[i * 3] = (arr[i * 3] - centroid[0]) * scale
-      arr[i * 3 + 1] = (arr[i * 3 + 1] - centroid[1]) * scale
-      arr[i * 3 + 2] = (arr[i * 3 + 2] - centroid[2]) * scale
-    }
+  const stride = inCount / outCount
+  for (let i = 0; i < outCount; i++) {
+    const idx = Math.floor(i * stride)
+    const b = idx * 3
+    out[i * 3] = input[b]
+    out[i * 3 + 1] = input[b + 1]
+    out[i * 3 + 2] = input[b + 2]
   }
-
-  sortAndNormalize(src, indexMap)
-  sortAndNormalize(tgt)
-
-  return { source: src, target: tgt, indexMap }
+  return out
 }
 
-export default pairAndMorph
+// Sort point indices by increasing radius (distance from origin),
+// then by polar angle in the XY plane. Returns a mapping of sorted indices.
+export function orderRadial(points: Float32Array): Uint32Array {
+  const count = Math.floor(points.length / 3)
+  const indices = Array.from({ length: count }, (_, i) => i)
+  indices.sort((a, b) => {
+    const ax = points[a * 3]
+    const ay = points[a * 3 + 1]
+    const az = points[a * 3 + 2]
+    const bx = points[b * 3]
+    const by = points[b * 3 + 1]
+    const bz = points[b * 3 + 2]
+
+    const ra = ax * ax + ay * ay + az * az
+    const rb = bx * bx + by * by + bz * bz
+    if (ra !== rb) return ra - rb
+
+    const aa = Math.atan2(ay, ax)
+    const ab = Math.atan2(by, bx)
+    return aa - ab
+  })
+  return Uint32Array.from(indices)
+}
+
+// Compute a mapping from target indices to source indices. The source and
+// destination clouds are first resampled to the same size, then each is
+// sorted radially. Points with the same sort rank are paired together.
+export function computeMorphMap(
+  src: Float32Array,
+  dst: Float32Array
+): Uint32Array {
+  const count = Math.max(src.length, dst.length) / 3
+  const resSrc = resampleCloud(src, count)
+  const resDst = resampleCloud(dst, count)
+  const srcOrder = orderRadial(resSrc)
+  const dstOrder = orderRadial(resDst)
+  const map = new Uint32Array(count)
+  for (let i = 0; i < count; i++) {
+    map[dstOrder[i]] = srcOrder[i]
+  }
+  return map
+}
+
+// Easing functions used for animation timing
+export function easeOutQuad(t: number): number {
+  return 1 - (1 - t) * (1 - t)
+}
+
+export function easeOutBack(t: number): number {
+  const c1 = 1.70158
+  const c3 = c1 + 1
+  const p = t - 1
+  return 1 + c3 * p * p * p + c1 * p * p
+}
+
+export default computeMorphMap
+


### PR DESCRIPTION
## Summary
- add point-cloud morph utilities with radial ordering and easing helpers
- render MorphFormationView supporting source→target morph and center-out emission

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton / IBM Plex Mono fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c03dbb08608328a7b8efccf1c24e5d