### PR TITLE
HUD auto-first surface (Classify hidden behind devControls)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -10,6 +10,7 @@ export interface HUDProps {
   autoEnabled?: boolean
   onToggleAuto?(next: boolean): void
   busy?: boolean
+  devControls?: boolean
 }
 
 export default function HUD({
@@ -24,6 +25,7 @@ export default function HUD({
   autoEnabled,
   onToggleAuto,
   busy,
+  devControls,
 }: HUDProps) {
   return (
     <div
@@ -45,13 +47,15 @@ export default function HUD({
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
       <div style={{ marginTop: 4 }}>
-        <button
-          style={{ marginRight: 4, fontSize: 10 }}
-          onClick={onClassify}
-          disabled={!onClassify || !!busy}
-        >
-          Classify
-        </button>
+        {devControls && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onClassify}
+            disabled={!onClassify || !!busy}
+          >
+            Classify
+          </button>
+        )}
         <button
           style={{ marginRight: 4, fontSize: 10 }}
           onClick={onClear}

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -47,7 +47,7 @@ export default function HUD({
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
       <div style={{ marginTop: 4 }}>
-        {devControls && (
+        {(devControls || autoEnabled === false) && (
           <button
             style={{ marginRight: 4, fontSize: 10 }}
             onClick={onClassify}


### PR DESCRIPTION
## Summary
- hide `Classify` HUD control by default, gated behind optional `devControls`

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/...`)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c03a62a9508328a8d4494d4e27d6c0