### PR TITLE
draw3d(canvas): add rasterToCloud() + resampleCloud()

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
@@ -40,6 +40,12 @@ describe('rasterToCloud', () => {
     const pts2 = rasterToCloud(c, { max })
     expect(Array.from(pts)).toEqual(Array.from(pts2))
   })
+
+  it('keeps fully saturated colored strokes', () => {
+    const c = makeCanvas(16, 16, [255, 0, 0, 255])
+    const pts = rasterToCloud(c)
+    expect(pts.length).toBeGreaterThan(0)
+  })
 })
 
 describe('resampleCloud', () => {

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { rasterToCloud, resampleCloud } from '../rasterToCloud'
+
+function makeCanvas(w: number, h: number, rgba: [number, number, number, number]) {
+  const data = new Uint8ClampedArray(w * h * 4)
+  for (let i = 0; i < w * h; i++) {
+    const idx = i * 4
+    data[idx] = rgba[0]
+    data[idx + 1] = rgba[1]
+    data[idx + 2] = rgba[2]
+    data[idx + 3] = rgba[3]
+  }
+  return {
+    width: w,
+    height: h,
+    getContext: () => ({ getImageData: () => ({ data }) })
+  } as unknown as HTMLCanvasElement
+}
+
+describe('rasterToCloud', () => {
+  it('returns no points for empty canvas', () => {
+    const c = makeCanvas(16, 16, [0, 0, 0, 0])
+    const pts = rasterToCloud(c)
+    expect(pts.length).toBe(0)
+  })
+
+  it('samples dense stroke up to max points', () => {
+    const max = 256
+    const c = makeCanvas(32, 32, [0, 0, 0, 255])
+    const pts = rasterToCloud(c, { max })
+    expect(pts.length % 3).toBe(0)
+    const count = pts.length / 3
+    expect(count).toBeGreaterThan(max * 0.9)
+    expect(count).toBeLessThanOrEqual(max)
+    for (const v of pts) {
+      expect(v).toBeGreaterThanOrEqual(-1)
+      expect(v).toBeLessThanOrEqual(1)
+    }
+    // determinism
+    const pts2 = rasterToCloud(c, { max })
+    expect(Array.from(pts)).toEqual(Array.from(pts2))
+  })
+})
+
+describe('resampleCloud', () => {
+  it('reduces point count deterministically', () => {
+    const src = Float32Array.from({ length: 30 }, (_, i) => (i % 3) - 1)
+    const out = resampleCloud(src, 5)
+    expect(out.length).toBe(15)
+  })
+})
+

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
@@ -21,8 +21,9 @@ export function rasterToCloud(
       const xi = Math.floor(x)
       const idx = (yi * w + xi) * 4
       const a = data[idx + 3]
-      const v = data[idx] | data[idx + 1] | data[idx + 2]
-      if (a >= threshold && v !== 255) {
+      const isWhite =
+        data[idx] === 255 && data[idx + 1] === 255 && data[idx + 2] === 255
+      if (a >= threshold && !isWhite) {
         const nx = (x / w) * 2 - 1
         const ny = (y / h) * 2 - 1
         const jx = (rnd() - 0.5) * jitter

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
@@ -1,0 +1,76 @@
+export function rasterToCloud(
+  src: HTMLCanvasElement,
+  opts?: { max?: number; threshold?: number; jitter?: number }
+): Float32Array {
+  const max = opts?.max ?? 256
+  const threshold = opts?.threshold ?? 250
+  const jitter = opts?.jitter ?? 1 / 256
+  const w = src.width
+  const h = src.height
+  if (!w || !h) return new Float32Array(0)
+  const ctx = src.getContext('2d')
+  if (!ctx) return new Float32Array(0)
+  const { data } = ctx.getImageData(0, 0, w, h)
+  const step = Math.max(1, Math.sqrt((w * h) / max))
+  const half = step / 2
+  const rnd = mulberry32(1)
+  const out: number[] = []
+  for (let y = half; y < h; y += step) {
+    const yi = Math.floor(y)
+    for (let x = half; x < w; x += step) {
+      const xi = Math.floor(x)
+      const idx = (yi * w + xi) * 4
+      const a = data[idx + 3]
+      const v = data[idx] | data[idx + 1] | data[idx + 2]
+      if (a >= threshold && v !== 255) {
+        const nx = (x / w) * 2 - 1
+        const ny = (y / h) * 2 - 1
+        const jx = (rnd() - 0.5) * jitter
+        const jy = (rnd() - 0.5) * jitter
+        const jz = (rnd() - 0.5) * jitter
+        out.push(
+          clamp(nx + jx),
+          clamp(ny + jy),
+          clamp(jz)
+        )
+        if (out.length / 3 >= max) return new Float32Array(out)
+      }
+    }
+  }
+  return new Float32Array(out)
+}
+
+export function resampleCloud(pts: Float32Array, count: number): Float32Array {
+  const n = pts.length / 3
+  if (n <= count) return pts.slice()
+  const rnd = mulberry32(2)
+  const idx = Array.from({ length: n }, (_, i) => i)
+  for (let i = idx.length - 1; i > 0; i--) {
+    const j = Math.floor(rnd() * (i + 1))
+    const t = idx[i]
+    idx[i] = idx[j]
+    idx[j] = t
+  }
+  const out = new Float32Array(count * 3)
+  for (let i = 0; i < count; i++) {
+    const k = idx[i] * 3
+    out[i * 3] = pts[k]
+    out[i * 3 + 1] = pts[k + 1]
+    out[i * 3 + 2] = pts[k + 2]
+  }
+  return out
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5)
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function clamp(v: number) {
+  return v < -1 ? -1 : v > 1 ? 1 : v
+}
+


### PR DESCRIPTION
## Summary
- convert canvas rasters to normalized point clouds with `rasterToCloud`
- add `resampleCloud` helper for deterministic point shuffling and capping
- test empty and dense canvas cases

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` and `IBM Plex Mono` fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c03a6f010c83289c97ba0449484195