### PR TITLE
draw3d(render): add MorphFormationView with source→target morph + center-out emit

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -72,10 +72,15 @@ function InstancedMorph({
   useEffect(() => {
     const m = mesh.current
     if (!m) return
-    const startPos = data.src ?? data.tgt
+    const { src, tgt, map } = data
     for (let i = 0; i < data.count; i++) {
       const i3 = i * 3
-      dummy.current.position.set(startPos[i3], startPos[i3 + 1], startPos[i3 + 2])
+      if (src && map) {
+        const sIdx = map[i] * 3
+        dummy.current.position.set(src[sIdx], src[sIdx + 1], src[sIdx + 2])
+      } else {
+        dummy.current.position.set(tgt[i3], tgt[i3 + 1], tgt[i3 + 2])
+      }
       dummy.current.scale.setScalar(0)
       dummy.current.updateMatrix()
       m.setMatrixAt(i, dummy.current.matrix)


### PR DESCRIPTION
## Summary
- seed morph transforms from mapped source indices to avoid popping

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton / IBM Plex Mono fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c04084772c8328b7a675d8428f98f7