### PR TITLE
HUD auto-first surface: expose Classify control when auto disabled

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -47,7 +47,7 @@ export default function HUD({
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
       <div style={{ marginTop: 4 }}>
-        {devControls && (
+        {(devControls || autoEnabled === false) && (
           <button
             style={{ marginRight: 4, fontSize: 10 }}
             onClick={onClassify}


### PR DESCRIPTION
## Summary
- show Classify button when auto classification is disabled without requiring devControls
- keep devControls for optional development controls

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton font from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c040d6a3648328b52381f23aef5e30