### PR TITLE
fix(draw3d): detect white pixels correctly in rasterToCloud

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
@@ -40,6 +40,12 @@ describe('rasterToCloud', () => {
     const pts2 = rasterToCloud(c, { max })
     expect(Array.from(pts)).toEqual(Array.from(pts2))
   })
+
+  it('keeps fully saturated colored strokes', () => {
+    const c = makeCanvas(16, 16, [255, 0, 0, 255])
+    const pts = rasterToCloud(c)
+    expect(pts.length).toBeGreaterThan(0)
+  })
 })
 
 describe('resampleCloud', () => {

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
@@ -21,8 +21,9 @@ export function rasterToCloud(
       const xi = Math.floor(x)
       const idx = (yi * w + xi) * 4
       const a = data[idx + 3]
-      const v = data[idx] | data[idx + 1] | data[idx + 2]
-      if (a >= threshold && v !== 255) {
+      const isWhite =
+        data[idx] === 255 && data[idx + 1] === 255 && data[idx + 2] === 255
+      if (a >= threshold && !isWhite) {
         const nx = (x / w) * 2 - 1
         const ny = (y / h) * 2 - 1
         const jx = (rnd() - 0.5) * jitter


### PR DESCRIPTION
## Summary
- avoid dropping saturated colored strokes in `rasterToCloud`
- cover colored stroke sampling in tests

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` and `IBM Plex Mono` fonts)*
- `pnpm run smoke`
- `pnpm --filter cryptiq-mindmap-demo test -- app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68c0410baa588328b7a91b94973c6e6c