### PR TITLE
PR-13: Telemetry normalization

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.log.md
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.log.md
@@ -1,0 +1,28 @@
+# AppHost telemetry events
+
+Documented Draw3D AppHost console logs.
+
+## Event sequence
+
+- `[strokeEnd]` — pointer lifted; may trigger timer setup.
+- `[timerScheduled] <ms>ms` — idle timer scheduled for auto commit (e.g., `1500ms`).
+- `[timerFired]` — idle timer completed; classification begins if ink meets thresholds.
+- `[commitFired]` — classification started.
+- `pre <ms>ms load <ms>ms infer <ms>ms` — preprocessing, model load, and inference timings emitted after commit.
+- `[gateRejected]` `{ area, length, w, h, MIN_AREA, MIN_LENGTH }` — stroke rejected for insufficient ink.
+
+## Sample
+
+```text
+[strokeEnd]
+[timerScheduled] 1500ms
+[timerFired]
+[commitFired]
+pre 3.2ms load 120.5ms infer 40.1ms
+```
+
+When ink fails minimum requirements:
+
+```text
+[gateRejected] { area: 20, length: 60, w: 10, h: 10, MIN_AREA: 1024, MIN_LENGTH: 80 }
+```

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
@@ -1,6 +1,17 @@
+export interface InkBBox {
+  width: number
+  height: number
+}
+
+export interface InkMetrics {
+  area: number
+  length: number
+  bbox: InkBBox
+}
+
 export type DoodleCanvasHandle = {
   clear(): void
   undo(): void
   toCanvas(): HTMLCanvasElement | null
-  getInkMetrics(): { area: number; length: number; bbox: { width: number; height: number } }
+  getInkMetrics(): InkMetrics
 }


### PR DESCRIPTION
## Summary
- document Draw3D AppHost telemetry events
- add explicit InkMetrics typings

## Testing
- `corepack enable` *(fails: command not found)*
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit` *(warn: unsupported engine)*
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit` *(fails: TS5058 path not exist)*
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: failed to fetch fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c04c76e7e083289a81b141a86b5d33