### PR TITLE
Perf guards hardening

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -18,6 +18,7 @@ function InstancedFormation({ positions }: FormationViewProps) {
     clampDpr(gl)
   }, [gl])
 
+  // respect device/env caps on instance count
   const maxInstances = capInstances(positions.length / 3)
   const count = useFormationTransition(mesh, positions, maxInstances)
 

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -42,7 +42,7 @@ function InstancedMorph({
 
   const data = useMemo(() => {
     const maxCount = Math.max(source ? source.length : 0, target.length) / 3
-    const count = capInstances(maxCount)
+    const count = capInstances(maxCount) // respect device/env caps
     const tgt = resampleCloud(target, count)
     const src = source ? resampleCloud(source, count) : undefined
     const map = src ? computeMorphMap(src, tgt) : undefined

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
@@ -8,10 +8,12 @@ export function clampDpr(gl: WebGLRenderer, max = 2): void {
 }
 
 // Read instance caps from env (falls back to sensible defaults)
-const MOBILE_CAP =
-  parseInt(process.env.NEXT_PUBLIC_DRAW3D_MOBILE_CAP ?? '', 10) || 200
-const DESKTOP_CAP =
-  parseInt(process.env.NEXT_PUBLIC_DRAW3D_DESKTOP_CAP ?? '', 10) || 20000
+function readCap(env: string | undefined, fallback: number): number {
+  const cap = parseInt(env ?? '', 10)
+  return Number.isNaN(cap) ? fallback : cap
+}
+const MOBILE_CAP = readCap(process.env.NEXT_PUBLIC_DRAW3D_MOBILE_CAP, 200)
+const DESKTOP_CAP = readCap(process.env.NEXT_PUBLIC_DRAW3D_DESKTOP_CAP, 20000)
 
 // Limit instanced rendering counts based on device class.
 export function capInstances(

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
@@ -1,18 +1,27 @@
-import type { WebGLRenderer } from 'three';
+import type { WebGLRenderer } from 'three'
 
 // Clamp device pixel ratio to reduce GPU load (default max 2)
 export function clampDpr(gl: WebGLRenderer, max = 2): void {
   if (typeof window !== 'undefined') {
-    gl.setPixelRatio(Math.min(window.devicePixelRatio, max));
+    gl.setPixelRatio(Math.min(window.devicePixelRatio, max))
   }
 }
 
+// Read instance caps from env (falls back to sensible defaults)
+const MOBILE_CAP =
+  parseInt(process.env.NEXT_PUBLIC_DRAW3D_MOBILE_CAP ?? '', 10) || 200
+const DESKTOP_CAP =
+  parseInt(process.env.NEXT_PUBLIC_DRAW3D_DESKTOP_CAP ?? '', 10) || 20000
+
 // Limit instanced rendering counts based on device class.
-// Mobile devices are capped at 200 instances to maintain ~30fps.
-export function capInstances(count: number, mobileCap = 200, desktopCap = 20000): number {
+export function capInstances(
+  count: number,
+  mobileCap = MOBILE_CAP,
+  desktopCap = DESKTOP_CAP
+): number {
   const isMobile =
-    typeof navigator !== 'undefined' && /Mobi|Android/i.test(navigator.userAgent);
-  const cap = isMobile ? mobileCap : desktopCap;
-  return Math.min(count, cap);
+    typeof navigator !== 'undefined' && /Mobi|Android/i.test(navigator.userAgent)
+  const cap = isMobile ? mobileCap : desktopCap
+  return Math.min(count, cap)
 }
 


### PR DESCRIPTION
## Summary
- clamp WebGL DPR to max 2
- cap instanced counts via env thresholds in FormationView and MorphFormationView

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` (warnings only)
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: unable to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c04c5efe788328823fdcab05065cf7