### PR TITLE
PR-10 — Playwright smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "smoke-check": "node scripts/watch-smoke.cjs --once",
     "smoke": "node -e \"console.log('smoke ok')\"",
     "smoke:brain": "playwright test tests/brain.smoke.spec.ts --reporter=line",
+    "test:smoke:draw3d": "playwright test tests/draw3d.smoke.spec.ts --reporter=line",
     "vggt:readme": "node -e \"require('fs').createReadStream('tools/vggt-cli/README.md').pipe(process.stdout)\""
   },
   "devDependencies": {

--- a/tests/draw3d.smoke.spec.ts
+++ b/tests/draw3d.smoke.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+
+test('draw3d smoke', async ({ page }) => {
+  const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+  const url = `${baseUrl}/draw3d`
+
+  await page.goto(url, { waitUntil: 'domcontentloaded' })
+
+  await expect(page.getByText('ready:')).toBeVisible()
+  await expect(page.getByText('load:')).toBeVisible()
+  await expect(page.getByText('infer:')).toBeVisible()
+  await expect(page.getByText('fps:')).toBeVisible()
+  await expect(page.getByText('instances:')).toBeVisible()
+
+  const canvases = page.locator('canvas')
+  await expect(canvases).toHaveCount(1)
+  await expect(canvases.first()).toBeVisible()
+
+  await expect(page.getByRole('button', { name: 'Classify' })).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary
- add Playwright smoke test for /draw3d covering HUD labels, canvas, and hidden Classify control
- expose test:smoke:draw3d script

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton from Google Fonts)*
- `pnpm run smoke`
- `pnpm test:smoke:draw3d`


------
https://chatgpt.com/codex/tasks/task_e_68c04c5253b883289aa568dd957ec1d5