### PR TITLE
fix(draw3d): map eyeglasses to glasses

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
@@ -6,6 +6,7 @@ export const ALIASES: Record<string, string> = {
   mug: 'cup',
   leaf: 'flower',
   airplane: 'plane',
+  eyeglasses: 'glasses',
 };
 
 export const CURATED = new Set<string>([


### PR DESCRIPTION
## Summary
- map DoodleNet's eyeglasses label to glasses so new formation loads

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warns: Unexpected any)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c052685ee0832882907ce17c181986