### PR TITLE
Perf guards hardening: preserve zero instance caps

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/perf.ts
@@ -8,10 +8,12 @@ export function clampDpr(gl: WebGLRenderer, max = 2): void {
 }
 
 // Read instance caps from env (falls back to sensible defaults)
-const MOBILE_CAP =
-  parseInt(process.env.NEXT_PUBLIC_DRAW3D_MOBILE_CAP ?? '', 10) || 200
-const DESKTOP_CAP =
-  parseInt(process.env.NEXT_PUBLIC_DRAW3D_DESKTOP_CAP ?? '', 10) || 20000
+function readCap(env: string | undefined, fallback: number): number {
+  const cap = parseInt(env ?? '', 10)
+  return Number.isNaN(cap) ? fallback : cap
+}
+const MOBILE_CAP = readCap(process.env.NEXT_PUBLIC_DRAW3D_MOBILE_CAP, 200)
+const DESKTOP_CAP = readCap(process.env.NEXT_PUBLIC_DRAW3D_DESKTOP_CAP, 20000)
 
 // Limit instanced rendering counts based on device class.
 export function capInstances(


### PR DESCRIPTION
## Summary
- parse Draw3D instance caps with a helper that preserves zero env values

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` (warnings only)
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: unable to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0525831808328b717cbd022dbe3d5