### PR TITLE
sdk(draw3d): stub exports for later extraction

### DIFF
--- a/packages/canvas-r3f/draw3d/MorphFormationView.tsx
+++ b/packages/canvas-r3f/draw3d/MorphFormationView.tsx
@@ -1,0 +1,9 @@
+// Temporary type stub for MorphFormationView; implementation lives in app during incubation
+export interface MorphFormationViewProps {
+  source?: Float32Array
+  target: Float32Array
+  durationMs?: number
+  bounce?: boolean
+  fitScale?: number
+}
+

--- a/packages/ml-bridges/doodle/index.ts
+++ b/packages/ml-bridges/doodle/index.ts
@@ -1,0 +1,10 @@
+// Type definitions for DoodleNet classifier bridge
+export type DoodlePrediction = {
+  label: string
+  confidence: number
+}
+
+export interface DoodleClassifier {
+  classify(input: HTMLCanvasElement, k?: number): Promise<DoodlePrediction[]>
+}
+


### PR DESCRIPTION
## Summary
- stub MorphFormationView props in canvas-r3f for later extraction
- add DoodleNet bridge types for doodle classifier

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c068b63578832893c86f7a56037400