### PR TITLE
HUD auto-first UI

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -47,15 +47,13 @@ export default function HUD({
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
       <div style={{ marginTop: 4 }}>
-        {(devControls || autoEnabled === false) && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={onClassify}
-            disabled={!onClassify || !!busy}
-          >
-            Classify
-          </button>
-        )}
+        <button
+          style={{ marginRight: 4, fontSize: 10 }}
+          onClick={() => onToggleAuto?.(!autoEnabled)}
+          disabled={!onToggleAuto || !!busy}
+        >
+          Auto {autoEnabled ? 'On' : 'Off'}
+        </button>
         <button
           style={{ marginRight: 4, fontSize: 10 }}
           onClick={onClear}
@@ -70,13 +68,15 @@ export default function HUD({
         >
           Undo
         </button>
-        <button
-          style={{ marginRight: 4, fontSize: 10 }}
-          onClick={() => onToggleAuto?.(!autoEnabled)}
-          disabled={!onToggleAuto || !!busy}
-        >
-          Auto {autoEnabled ? 'On' : 'Off'}
-        </button>
+        {devControls && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onClassify}
+            disabled={!onClassify || !!busy}
+          >
+            Classify
+          </button>
+        )}
         {busy && <span style={{ marginLeft: 4 }}>inference…</span>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reorder HUD controls to put Auto before Clear and Undo
- gate Classify button behind `devControls`

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` (fails: Failed to fetch Google Fonts)
- `pnpm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c0ae2c1d9c8328b49ea29cf862c18e