### PR TITLE
feat(draw3d): add MorphFormationView with center-out emission + bounce

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -23,7 +23,7 @@ function InstancedMorph({
   source,
   target,
   durationMs = 500,
-  bounce = true,
+  bounce = false,
   fitScale = 1,
 }: MorphFormationViewProps) {
   const { gl } = useThree()

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/morph.ts
@@ -71,7 +71,7 @@ export function computeMorphMap(
   src: Float32Array,
   dst: Float32Array
 ): Uint32Array {
-  const count = Math.max(src.length, dst.length) / 3
+  const count = Math.floor(Math.max(src.length, dst.length) / 3)
   const resSrc = resampleCloud(src, count)
   const resDst = resampleCloud(dst, count)
   const srcOrder = orderRadial(resSrc)


### PR DESCRIPTION
## Summary
- add morph utilities with radial pairing and easing helpers
- introduce MorphFormationView for center-out point reveals with optional bounce

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0ae06a6908328abb9fd78d4dec0fc