### PR TITLE
Robust raster cloud (stroke sampling)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -8,7 +8,7 @@ import type { DoodleCanvasHandle } from './types'
 import MorphFormationView from './renderer/MorphFormationView'
 import HUD from './ui/HUD'
 import { normalizeLabel } from './data/labelMap'
-import { rasterToCloud } from './canvas/rasterToCloud'
+import { rasterToCloud, resampleCloud } from './canvas/rasterToCloud'
 import '../styles/draw3d.css'
 
 const formationCache = new Map<string, Promise<Float32Array>>()
@@ -112,7 +112,13 @@ export default function AppHost() {
       console.log('[commitFired]')
       const preStart = performance.now()
       const off = make28x28Canvas(canvas)
-      const strokeCloud = rasterToCloud(canvas, { max: 256, threshold: 200 })
+      let strokeCloud = rasterToCloud(canvas, {
+        threshold: 200,
+        gridStride: 4
+      })
+      if (strokeCloud.length / 3 > 256) {
+        strokeCloud = resampleCloud(strokeCloud, 256)
+      }
       const preMs = performance.now() - preStart
 
       let lMs = loadMs

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
@@ -24,20 +24,18 @@ describe('rasterToCloud', () => {
     expect(pts.length).toBe(0)
   })
 
-  it('samples dense stroke up to max points', () => {
-    const max = 256
+  it('samples dense stroke with grid stride deterministically', () => {
     const c = makeCanvas(32, 32, [0, 0, 0, 255])
-    const pts = rasterToCloud(c, { max })
+    const pts = rasterToCloud(c, { gridStride: 8, minCount: 0 })
     expect(pts.length % 3).toBe(0)
     const count = pts.length / 3
-    expect(count).toBeGreaterThan(max * 0.9)
-    expect(count).toBeLessThanOrEqual(max)
+    expect(count).toBe(16)
     for (const v of pts) {
       expect(v).toBeGreaterThanOrEqual(-1)
       expect(v).toBeLessThanOrEqual(1)
     }
     // determinism
-    const pts2 = rasterToCloud(c, { max })
+    const pts2 = rasterToCloud(c, { gridStride: 8, minCount: 0 })
     expect(Array.from(pts)).toEqual(Array.from(pts2))
   })
 


### PR DESCRIPTION
## Summary
- resample stroke clouds and set grid stride after raster options change
- update rasterToCloud tests for new options

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed: Failed to fetch font file)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0b949a8bc832880c6ddf7fb3d13cf