### PR TITLE
PR-6 — Renderer context-loss hardening: handle instanced capacity growth

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -19,7 +19,11 @@ function InstancedFormation({ positions }: FormationViewProps) {
   }, [gl])
 
   // respect device/env caps on instance count and keep mesh mounted
-  const maxInstances = useRef(capInstances(positions.length / 3))
+  const maxInstances = useRef(0)
+  const capped = capInstances(positions.length / 3)
+  if (capped > maxInstances.current) {
+    maxInstances.current = capped
+  }
   const visibleCount = useFormationTransition(mesh, positions, maxInstances.current)
 
   // expose visible count instead of remounting
@@ -31,7 +35,11 @@ function InstancedFormation({ positions }: FormationViewProps) {
   return (
     <group scale={1.8}>
       {/* @ts-expect-error r3f intrinsic */}
-      <instancedMesh ref={mesh} args={[undefined, undefined, maxInstances.current]}>
+      <instancedMesh
+        key={maxInstances.current}
+        ref={mesh}
+        args={[undefined, undefined, maxInstances.current]}
+      >
         {/* @ts-expect-error r3f intrinsic */}
         <sphereGeometry args={[0.045, 6, 6]} />
         <meshBasicMaterial color={0xffffff} toneMapped={false} transparent opacity={1} />


### PR DESCRIPTION
## Summary
- recompute capped instance count when positions array grows
- remount instanced mesh via keyed ref to expand capacity

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from https://fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0b96a4fe083289ec70bbb9c6ed06e