### PR TITLE
PR-6 — Renderer context-loss hardening (FormationView only)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/FormationView.tsx
@@ -19,7 +19,9 @@ function InstancedFormation({ positions }: FormationViewProps) {
   }, [gl])
 
   // respect device/env caps on instance count and keep mesh mounted
-  const maxInstances = useRef(capInstances(positions.length / 3))
+  const maxInstances = useRef(0)
+  const capped = capInstances(positions.length / 3)
+  if (capped > maxInstances.current) maxInstances.current = capped
   const visibleCount = useFormationTransition(mesh, positions, maxInstances.current)
 
   // expose visible count instead of remounting


### PR DESCRIPTION
## Summary
- keep instanced mesh mounted and update its visible count instead of remounting on clear
- guard canvas against WebGL context loss and request high-performance power
- update instanced capacity when positions grow

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from https://fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0b9b3776c8328a26b72846fa31cf5