### PR TITLE
Consolidated trace doc

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-consolidated-info.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-consolidated-info.md
@@ -112,6 +112,30 @@ type Draw3DResult = {
 
 - **Emit when:** after successful classify+formation selection or fallback synthesis.
 
+### Trace template
+
+Matches fields emitted by AppHost trace.
+
+```json
+{
+  "timestamps": {},
+  "inkMetrics": {},
+  "rasterConfig": {},
+  "topK": [],
+  "normalized": "",
+  "counts": {},
+  "caps": {},
+  "fetch": {},
+  "env": {},
+  "fps": 0
+}
+```
+
+### How to collect
+
+- **DevTools:** copy from `[trace]` or `window.__draw3dTraces`
+- **CLI:** `pnpm run dev:trace`
+
 ---
 
 ## 6) Risks and Mitigations


### PR DESCRIPTION
## Summary
- add trace template listing AppHost trace fields and collection instructions

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c196c06b0c8328864902ba248b61d6