### PR TITLE
Update existing CI-safe smoke (no inference)

### DIFF
--- a/apps/cryptiq-mindmap-demo/tests/draw3d.smoke.spec.ts
+++ b/apps/cryptiq-mindmap-demo/tests/draw3d.smoke.spec.ts
@@ -1,15 +1,23 @@
 import { test, expect } from '@playwright/test'
 
-// Light smoke: ensure the /draw3d route boots and HUD reports ready
+// Light smoke: ensure the /draw3d route boots and HUD/canvases mount
 // Skip when Playwright browsers are unavailable in CI
-const browserUnavailable =
-  !!process.env.CI && !process.env.PLAYWRIGHT_BROWSERS_PATH
+const browserUnavailable = !!process.env.CI && !process.env.PLAYWRIGHT_BROWSERS_PATH
 
 test.describe('draw3d smoke', () => {
   test.skip(browserUnavailable, 'Playwright browsers not installed in CI')
 
-  test('HUD shows ready label', async ({ page }) => {
-    await page.goto('/draw3d')
+  test('HUD and canvases mount', async ({ page }) => {
+    await page.goto('/draw3d', { waitUntil: 'domcontentloaded' })
+
     await expect(page.getByText('ready:')).toBeVisible()
+    await expect(page.getByText('load:')).toBeVisible()
+    await expect(page.getByText('infer:')).toBeVisible()
+    await expect(page.getByText('fps:')).toBeVisible()
+    await expect(page.getByText('instances:')).toBeVisible()
+
+    const canvases = page.locator('canvas')
+    await expect(canvases).toHaveCount(1)
+    await expect(canvases.first()).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- tighten draw3d smoke test to assert HUD metrics and canvas mount while retaining CI skip guard.

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warns)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: unable to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c19699bb388328a0fea0dee4543c37