### PR TITLE
Label map curated-first verification logs

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
@@ -33,6 +33,10 @@ export const CURATED = new Set<string>([
   'umbrella',
 ]);
 
+const TRACE =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).has('trace');
+
 export function normalizeLabel(
   raw: string,
   topK: Array<{ label: string; confidence: number }> = [],
@@ -43,12 +47,20 @@ export function normalizeLabel(
   };
 
   const primary = normalize(raw);
-  if (CURATED.has(primary)) return primary;
+  let chosen = 'unknown';
 
-  for (const { label } of topK.slice(0, 5)) {
-    const mapped = normalize(label);
-    if (CURATED.has(mapped)) return mapped;
+  if (CURATED.has(primary)) {
+    chosen = primary;
+  } else {
+    for (const { label } of topK.slice(0, 5)) {
+      const mapped = normalize(label);
+      if (CURATED.has(mapped)) {
+        chosen = mapped;
+        break;
+      }
+    }
   }
 
-  return 'unknown';
+  if (TRACE) console.debug('[labelMap]', { topK, chosen });
+  return chosen;
 }


### PR DESCRIPTION
## Summary
- trace top-k predictions and selected label in `normalizeLabel`
- surface `[labelMap]` debug output when `?trace` is present

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c19660f9bc8328a45f8060996ecfd7