### PR TITLE
HUD “Copy trace” (devControls only)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -27,6 +27,12 @@ export default function HUD({
   busy,
   devControls,
 }: HUDProps) {
+  const onCopyTrace = () => {
+    const traces = (window as any).__draw3dTraces
+    const trace = traces?.at?.(-1) ?? traces
+    const text = JSON.stringify(trace ?? [])
+    navigator.clipboard.writeText(text).catch(() => {})
+  }
   return (
     <div
       style={{
@@ -69,13 +75,21 @@ export default function HUD({
           Undo
         </button>
         {devControls && (
-          <button
-            style={{ marginRight: 4, fontSize: 10 }}
-            onClick={onClassify}
-            disabled={!onClassify || !!busy}
-          >
-            Classify
-          </button>
+          <>
+            <button
+              style={{ marginRight: 4, fontSize: 10 }}
+              onClick={onClassify}
+              disabled={!onClassify || !!busy}
+            >
+              Classify
+            </button>
+            <button
+              style={{ marginRight: 4, fontSize: 10 }}
+              onClick={onCopyTrace}
+            >
+              Copy trace
+            </button>
+          </>
         )}
         {busy && <span style={{ marginLeft: 4 }}>inference…</span>}
       </div>


### PR DESCRIPTION
## Summary
- add a dev-only HUD action that copies the latest draw3d trace to the clipboard

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1965360d8832899855fa4d9d37d96