### PR TITLE
fix(draw3d): robust rasterToCloud with minCount + normalization + willReadFrequently

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -114,7 +114,7 @@ export default function AppHost() {
       const off = make28x28Canvas(canvas)
       let strokeCloud = rasterToCloud(canvas, {
         threshold: 200,
-        gridStride: 4
+        stride: 4
       })
       if (strokeCloud.length / 3 > 256) {
         strokeCloud = resampleCloud(strokeCloud, 256)

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/__tests__/rasterToCloud.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { rasterToCloud, resampleCloud } from '../rasterToCloud'
+import {
+  rasterToCloud,
+  resampleCloud,
+  getEffectiveRasterConfig
+} from '../rasterToCloud'
 
 function makeCanvas(w: number, h: number, rgba: [number, number, number, number]) {
   const data = new Uint8ClampedArray(w * h * 4)
@@ -24,25 +28,28 @@ describe('rasterToCloud', () => {
     expect(pts.length).toBe(0)
   })
 
-  it('samples dense stroke with grid stride deterministically', () => {
+  it('enforces minCount and remains deterministic', () => {
     const c = makeCanvas(32, 32, [0, 0, 0, 255])
-    const pts = rasterToCloud(c, { gridStride: 8, minCount: 0 })
+    const pts = rasterToCloud(c, { stride: 8, minCount: 0 })
     expect(pts.length % 3).toBe(0)
     const count = pts.length / 3
-    expect(count).toBe(16)
+    expect(count).toBeGreaterThanOrEqual(200)
     for (const v of pts) {
       expect(v).toBeGreaterThanOrEqual(-1)
       expect(v).toBeLessThanOrEqual(1)
     }
+    const cfg = getEffectiveRasterConfig()
+    expect(cfg.stride).toBe(8)
+    expect(cfg.minCount).toBeGreaterThanOrEqual(200)
     // determinism
-    const pts2 = rasterToCloud(c, { gridStride: 8, minCount: 0 })
+    const pts2 = rasterToCloud(c, { stride: 8, minCount: 0 })
     expect(Array.from(pts)).toEqual(Array.from(pts2))
   })
 
   it('keeps fully saturated colored strokes', () => {
     const c = makeCanvas(16, 16, [255, 0, 0, 255])
     const pts = rasterToCloud(c)
-    expect(pts.length).toBeGreaterThan(0)
+    expect(pts.length / 3).toBeGreaterThanOrEqual(200)
   })
 })
 

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/canvas/rasterToCloud.ts
@@ -1,11 +1,28 @@
+let effectiveConfig = {
+  threshold: 180,
+  stride: 2,
+  minCount: 200,
+  jitter: 1 / 256
+}
+
+export function getEffectiveRasterConfig() {
+  return effectiveConfig
+}
+
 export function rasterToCloud(
   src: HTMLCanvasElement,
-  opts?: { threshold?: number; gridStride?: number; minCount?: number }
+  opts?: {
+    threshold?: number
+    stride?: number
+    minCount?: number
+    jitter?: number
+  }
 ): Float32Array {
   const threshold = opts?.threshold ?? 180
-  const stride = opts?.gridStride ?? 2
-  const minCount = opts?.minCount ?? 200
-  const jitter = 1 / 256
+  const stride = opts?.stride ?? 2
+  const minCount = Math.max(opts?.minCount ?? 200, 200)
+  const jitter = opts?.jitter ?? 1 / 256
+  effectiveConfig = { threshold, stride, minCount, jitter }
   const w = src.width
   const h = src.height
   if (!w || !h) return new Float32Array(0)


### PR DESCRIPTION
## Summary
- add getEffectiveRasterConfig helper and expose stride/minCount/jitter options
- normalize raster samples and enforce a 200-point minimum
- use willReadFrequently 2d context and update callers/tests to new stride option

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warn: react-hooks/exhaustive-deps, no-explicit-any, prefer-const)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from Google Fonts)*
- `pnpm --filter cryptiq-mindmap-demo run test` *(fails: Playwright Test did not expect test.describe to be called here, missing Anton export, package entry failure)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c19602cf5c8328bf70736fdb6a6af4