### PR TITLE
chore(draw3d): remove dev:trace script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "type-check": "tsc -b --clean tsconfig.build.json && tsc -b tsconfig.build.json",
     "clean": "turbo run clean",
     "dev": "turbo run dev",
-    "dev:trace": "node -e \"console.log(JSON.stringify(globalThis.__draw3dTraces||[],null,2))\"",
     "docs": "typedoc --plugin typedoc-plugin-markdown --entryPointStrategy Packages --entryPoints packages/* --skipErrorChecking --githubPages false --tsconfig tsconfig.build.json",
     "docs:watch": "typedoc --watch",
     "watch-smoke": "node scripts/watch-smoke.cjs",


### PR DESCRIPTION
## Summary
- remove `dev:trace` script that logged an undefined global

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1abcec4788328ab34ce75656c24d1