### PR TITLE
fix(renderer): dispose resized instance buffers

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/renderer/MorphFormationView.tsx
@@ -79,12 +79,14 @@ function InstancedMorph({
     const m = mesh.current
     if (!m) return
     if (capacity.current < data.count) {
+      m.instanceMatrix?.dispose()
       capacity.current = data.count
       m.instanceMatrix = new THREE.InstancedBufferAttribute(
         new Float32Array(capacity.current * 16),
         16
       )
     }
+    m.instanceMatrix.setUsage(THREE.DynamicDrawUsage)
     m.count = data.count
     const { src, tgt, map } = data
     for (let i = 0; i < data.count; i++) {


### PR DESCRIPTION
## Summary
- dispose previous instance buffer attributes before resizing morph instances
- re-apply DynamicDrawUsage after buffer recreation

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit` *(no output)*
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(failed: TS errors)*
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings: no-explicit-any)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed: font fetch)*
- `pnpm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c1ab6072788328b4685b8ef143dffd