### PR TITLE
feat(draw3d): add feature-flagged commit trace + visible-output fallback

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -9,33 +9,46 @@ import MorphFormationView from './renderer/MorphFormationView'
 import HUD from './ui/HUD'
 import { normalizeLabel } from './data/labelMap'
 import { rasterToCloud, resampleCloud } from './canvas/rasterToCloud'
+import { capInstances } from './renderer/perf'
 import '../styles/draw3d.css'
 
-const formationCache = new Map<string, Promise<Float32Array>>()
+const formationCache = new Map<
+  string,
+  { promise: Promise<Float32Array>; meta: { jsonLen: number; flatLen: number; mod3Ok: boolean } }
+>()
 
 const MIN_AREA = 32 * 32
 const MIN_LENGTH = 80
 const IDLE_MS = 3000
 
-async function fetchFormation(name: string): Promise<Float32Array> {
-  let promise = formationCache.get(name)
-  if (!promise) {
-    promise = (async () => {
-      const url = `/formations/${name}.json`
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const json = await res.json()
-      const raw = Array.isArray(json) ? json : json.positions
-      const flat: number[] = Array.isArray(raw?.[0])
-        ? (raw as number[][]).flat()
-        : ((raw as number[]) ?? [])
-      if (flat.length % 3 !== 0) throw new Error('invalid formation')
-      return new Float32Array(flat)
-    })()
-    formationCache.set(name, promise)
+async function fetchFormation(name: string, trace?: any): Promise<Float32Array> {
+  const url = `/formations/${name}.json`
+  const cached = formationCache.get(name)
+  const cacheHit = !!cached
+  if (cached) {
+    if (trace) trace.formation = { url, cacheHit, ...cached.meta }
+    return cached.promise
   }
+  const meta = { jsonLen: 0, flatLen: 0, mod3Ok: false }
+  const promise = (async () => {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const json = await res.json()
+    meta.jsonLen = JSON.stringify(json).length
+    const raw = Array.isArray(json) ? json : json.positions
+    const flat: number[] = Array.isArray(raw?.[0])
+      ? (raw as number[][]).flat()
+      : ((raw as number[]) ?? [])
+    meta.flatLen = flat.length
+    meta.mod3Ok = flat.length % 3 === 0
+    if (!meta.mod3Ok) throw new Error('invalid formation')
+    return new Float32Array(flat)
+  })()
+  formationCache.set(name, { promise, meta })
   try {
-    return await promise
+    const arr = await promise
+    if (trace) trace.formation = { url, cacheHit, ...meta }
+    return arr
   } catch (e) {
     formationCache.delete(name)
     throw e
@@ -53,13 +66,51 @@ function fallbackFormation(count = 256, scale = 1.8): Float32Array {
   return arr
 }
 
+function synthesizeCloud(count = 200): Float32Array {
+  const arr = new Float32Array(count * 3)
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2
+    const r = 1.2 + (Math.random() - 0.5) * 0.3
+    arr[i * 3] = Math.cos(angle) * r
+    arr[i * 3 + 1] = Math.sin(angle) * r
+    arr[i * 3 + 2] = (Math.random() - 0.5) * 0.3
+  }
+  return arr
+}
+
+function getEnv() {
+  if (typeof navigator === 'undefined') return {}
+  const ua = navigator.userAgent
+  let browser = 'unknown'
+  let os = 'unknown'
+  if (/Chrome\//.test(ua)) browser = 'Chrome'
+  else if (/Safari\//.test(ua)) browser = 'Safari'
+  else if (/Firefox\//.test(ua)) browser = 'Firefox'
+  else if (/Edge\//.test(ua)) browser = 'Edge'
+  if (/Windows/.test(ua)) os = 'Windows'
+  else if (/Mac OS X/.test(ua)) os = 'macOS'
+  else if (/Android/.test(ua)) os = 'Android'
+  else if (/iPhone|iPad|iPod/.test(ua)) os = 'iOS'
+  else if (/Linux/.test(ua)) os = 'Linux'
+  let gpu = ''
+  const canvas = document.createElement('canvas')
+  const gl = canvas.getContext('webgl')
+  if (gl) {
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    if (debugInfo) {
+      gpu = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+    }
+  }
+  return { browser, os, gpu, dpr: window.devicePixelRatio }
+}
+
 export default function AppHost() {
-  const [morph, setMorph] = useState<null | {
-    source: Float32Array
+  const [morph, setMorph] = useState<{
+    source?: Float32Array
     target: Float32Array
     fitScale?: number
     bounce?: boolean
-  }>(null)
+  }>({ target: new Float32Array() })
   const [ready, setReady] = useState(false)
   const [loadMs, setLoadMs] = useState(0)
   const [inferMs, setInferMs] = useState(0)
@@ -70,6 +121,14 @@ export default function AppHost() {
   const canvasWrapRef = useRef<HTMLDivElement>(null)
   const inferRef = useRef(false)
   const timerRef = useRef<number | null>(null)
+  const traceEnabled = useMemo(() => {
+    if (process.env.NEXT_PUBLIC_DRAW3D_TRACE === '1') return true
+    if (typeof window !== 'undefined') {
+      return new URLSearchParams(window.location.search).has('trace')
+    }
+    return false
+  }, [])
+  const traceRef = useRef<any | null>(null)
   const devControls = useMemo(() => {
     if (process.env.NEXT_PUBLIC_DRAW3D_DEBUG_UI === '1') return true
     if (typeof window !== 'undefined') {
@@ -101,7 +160,7 @@ export default function AppHost() {
       clearTimeout(timerRef.current)
       timerRef.current = null
     }
-    setMorph(null)
+    setMorph((m) => ({ ...m, source: undefined, target: new Float32Array(), fitScale: undefined }))
     const canvas = canvasRef.current?.toCanvas()
     if (!canvas) return
     inferRef.current = true
@@ -110,6 +169,10 @@ export default function AppHost() {
     canvasWrapRef.current?.classList.add('stroke-fade')
     try {
       console.log('[commitFired]')
+      if (traceEnabled) {
+        traceRef.current = traceRef.current || {}
+        traceRef.current.commitFired = performance.now()
+      }
       const preStart = performance.now()
       const off = make28x28Canvas(canvas)
       let strokeCloud = rasterToCloud(canvas, {
@@ -119,6 +182,14 @@ export default function AppHost() {
       if (strokeCloud.length / 3 > 256) {
         strokeCloud = resampleCloud(strokeCloud, 256)
       }
+      let cloudCount = strokeCloud.length / 3
+      if (cloudCount === 0) {
+        strokeCloud = synthesizeCloud()
+        cloudCount = strokeCloud.length / 3
+        if (traceEnabled && traceRef.current) traceRef.current.synthesized = true
+      }
+      if (traceEnabled && traceRef.current)
+        traceRef.current.raster = { count: cloudCount, threshold: 200, stride: 4 }
       const preMs = performance.now() - preStart
 
       let lMs = loadMs
@@ -138,6 +209,8 @@ export default function AppHost() {
       console.log(`pre ${preMs.toFixed(1)}ms load ${lMs.toFixed(1)}ms infer ${iMs.toFixed(1)}ms`)
 
       const normalized = normalizeLabel(preds[0]?.label ?? '', preds)
+      if (traceEnabled && traceRef.current)
+        traceRef.current.classify = { topK: preds, normalized }
       let target: Float32Array
       let fitScale: number | undefined
       let bounce = true
@@ -147,7 +220,7 @@ export default function AppHost() {
         bounce = false
       } else if (normalized) {
         try {
-          target = await fetchFormation(normalized)
+          target = await fetchFormation(normalized, traceRef.current)
         } catch {
           target = fallbackFormation()
         }
@@ -166,8 +239,28 @@ export default function AppHost() {
       const revealTime = fadeStart + 300 + 200
       const delay = revealTime - performance.now()
       if (delay > 0) await new Promise((r) => setTimeout(r, delay))
-
+      const maxCount = Math.max(strokeCloud.length, target.length) / 3
+      const visibleCount = capInstances(maxCount)
+      const capApplied = visibleCount < maxCount
+      if (traceEnabled && traceRef.current)
+        traceRef.current.morph = {
+          targetCount: target.length / 3,
+          capApplied,
+          visibleCount,
+          fitScale: fitScale ?? 1,
+          env: getEnv(),
+          fps,
+        }
       setMorph({ source: strokeCloud, target, fitScale, bounce })
+      if (traceEnabled && traceRef.current) {
+        const t = Object.freeze({ ...traceRef.current })
+        ;(window as any).__draw3dTraces = (
+          (window as any).__draw3dTraces || []
+        ) as any[]
+        ;(window as any).__draw3dTraces.push(t)
+        console.debug('[trace]', t)
+        traceRef.current = null
+      }
     } finally {
       inferRef.current = false
       setBusy(false)
@@ -176,6 +269,7 @@ export default function AppHost() {
 
   const resetTimer = () => {
     console.log('[strokeEnd]')
+    if (traceEnabled) traceRef.current = { strokeEnd: performance.now() }
     if (!autoEnabled) return
     if (inferRef.current) {
       console.log('[timerCancelled] inFlight')
@@ -186,9 +280,13 @@ export default function AppHost() {
     timerRef.current = window.setTimeout(() => {
       timerRef.current = null
       console.log('[timerFired]')
+      if (traceEnabled && traceRef.current)
+        traceRef.current.timerFired = performance.now()
       if (!inferRef.current && meetsInk()) classifyNow()
     }, IDLE_MS)
     console.log(`[timerScheduled] ${IDLE_MS}ms`)
+    if (traceEnabled && traceRef.current)
+      traceRef.current.timerScheduled = { idleMs: IDLE_MS, ts: performance.now() }
   }
 
   useEffect(() => {
@@ -232,11 +330,11 @@ export default function AppHost() {
         loadMs={Math.round(loadMs)}
         inferMs={Math.round(inferMs)}
         fps={fps}
-        instances={morph ? morph.target.length / 3 : 0}
+        instances={morph.target.length / 3}
         onClassify={devControls ? classifyNow : undefined}
         onClear={() => {
           canvasRef.current?.clear()
-          setMorph(null)
+          setMorph((m) => ({ ...m, source: undefined, target: new Float32Array(), fitScale: undefined }))
           canvasWrapRef.current?.classList.remove('stroke-fade')
           if (timerRef.current) {
             clearTimeout(timerRef.current)
@@ -245,6 +343,7 @@ export default function AppHost() {
         }}
         onUndo={() => {
           canvasRef.current?.undo()
+          canvasWrapRef.current?.classList.remove('stroke-fade')
           if (timerRef.current) {
             clearTimeout(timerRef.current)
             timerRef.current = null
@@ -258,15 +357,13 @@ export default function AppHost() {
       <div ref={canvasWrapRef} style={{ position: 'absolute', inset: 0 }}>
         <DoodleCanvas ref={canvasRef} onStrokeEnd={resetTimer} />
       </div>
-      {morph && (
-        <MorphFormationView
-          source={morph.source}
-          target={morph.target}
-          fitScale={morph.fitScale}
-          durationMs={500}
-          bounce={morph.bounce}
-        />
-      )}
+      <MorphFormationView
+        source={morph.source}
+        target={morph.target}
+        fitScale={morph.fitScale}
+        durationMs={500}
+        bounce={morph.bounce}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- emit feature-flagged draw3d telemetry traces and collect environment + classification data
- synthesize fallback point cloud and keep r3f canvas mounted on clear/undo

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7ed46f4832898dac701366ff2f7