### PR TITLE
docs(draw3d): readiness/runbook/integration seam

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-brief.md
@@ -142,3 +142,10 @@ apps/cryptiq-mindmap-demo/
 2. Harden cloud sampling (adaptive threshold/stride; guaranteed min‑count) and log cloud/target counts.
 3. Add explicit context‑loss prevention/handlers to `MorphFormationView` and avoid remounts.
 4. Add a CI‑safe smoke that boots `/draw3d` (no inference).
+
+## 12) Readiness & Runbook
+
+- **Integration seam**: `AppHost` exposes `onResult(result)` after each commit so host apps can receive the normalized label, confidence, counts, timings, and formation fit.
+- **Formation asset spec**: curated labels resolve to `/formations/<label>.json` with `{ positions: number[] | number[][] }` normalized to `-1..1`.
+- **Trace fields & collection**: running with `?trace=1` records `strokeEnd`, timer events, `raster` (`threshold`,`stride`,`minCount`), `classify` (`normalized`,`topK`), and `morph` (`targetCount`,`visibleCount`,`fitScale`,`env.dpr`,`fps`).
+- **Prod sanity checklist**: ensure no WebGL context loss, traces log actual raster config, formations load for curated labels, and `/draw3d` sustains ≥30 FPS on a phone.

--- a/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-consolidated-info.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/draw-to-3d-consolidated-info.md
@@ -409,3 +409,39 @@ Still missing before merge:
 - No context loss; no mid‑stroke commit; FPS stable (≥30 on mobile).
 
 ---
+## Integration seam (`onResult`)
+
+- `AppHost` emits `onResult(result: Draw3DResult)` once per commit with:
+  - `label`: normalized label or `unknown`
+  - `confidence`: top confidence score
+  - `counts`: `{ raster, target, visible }`
+  - `timings`: `{ loadMs?, inferMs?, morphMs? }`
+  - `formation`: `{ buffer, fitScale }`
+- Enables Cryptiq Mindmap to react to recognized drawings.
+
+## Formation asset spec
+
+- Location: `apps/cryptiq-mindmap-demo/public/formations/<label>.json`
+- Format:
+  ```json
+  { "positions": number[] | number[][] }
+  ```
+- Values normalized to `-1..1` around origin; keep files tiny (<2 KB) with no extra keys.
+
+## Trace fields & collection
+
+- Enable by visiting `/draw3d?trace=1` or setting `NEXT_PUBLIC_DRAW3D_DEBUG_UI=1`.
+- Each commit logs:
+  - `strokeEnd`, `timerScheduled`, `timerFired`, `commitFired`
+  - `raster`: `count`, `threshold`, `stride`, `minCount`
+  - `classify`: `normalized`, `topK`
+  - `morph`: `targetCount`, `visibleCount`, `fitScale`, `env` (`dpr`), `fps`
+- "Copy trace" button copies the JSON for diagnostics.
+
+## Production sanity checklist
+
+- Build the demo (`pnpm --filter cryptiq-mindmap-demo run build`) and open `/draw3d` on phone and desktop.
+- Confirm formation JSON exists for each curated label; unknown uses stroke cloud.
+- `onResult` payload logs once per commit.
+- No console warnings (`willReadFrequently`, hydration, context loss).
+- FPS ≥30 on phone; instance counts obey env caps; traces log actual raster config.


### PR DESCRIPTION
## Summary
- add readiness & runbook section covering integration seam, formation asset spec, trace collection, and production checklist
- document onResult integration seam, formation JSON spec, trace fields, and production sanity checklist in consolidated info

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed: failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1efe5cda083289ac9b6db94e83fdc