### PR TITLE
chore(types): export Draw3DResult

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
@@ -15,3 +15,13 @@ export type DoodleCanvasHandle = {
   toCanvas(): HTMLCanvasElement | null
   getInkMetrics(): InkMetrics
 }
+
+export type Draw3DResult = {
+  label: string
+  confidence: number
+  topK: Array<{ label: string; confidence: number }>
+  formation: Float32Array
+  fitScale: number
+  counts: { cloud: number; target: number }
+  timings: { pre: number; load: number; infer: number }
+}


### PR DESCRIPTION
## Summary
- export Draw3DResult type for draw3d modules

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1efde59d083289ad08bf13bd2a842