### PR TITLE
chore(formations): add validator + script

### DIFF
--- a/apps/cryptiq-mindmap-demo/scripts/formations/validate.ts
+++ b/apps/cryptiq-mindmap-demo/scripts/formations/validate.ts
@@ -17,7 +17,9 @@ function flatten(input: unknown): number[] {
 
 async function main() {
   const dir = path.resolve(__dirname, '../../public/formations');
-  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json') && f !== 'unknown.json');
   let failed = false;
   for (const file of files) {
     const fp = path.join(dir, file);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "smoke": "node -e \"console.log('smoke ok')\"",
     "smoke:brain": "playwright test tests/brain.smoke.spec.ts --reporter=line",
     "test:smoke:draw3d": "playwright test tests/draw3d.smoke.spec.ts --reporter=line",
-    "vggt:readme": "node -e \"require('fs').createReadStream('tools/vggt-cli/README.md').pipe(process.stdout)\""
+    "vggt:readme": "node -e \"require('fs').createReadStream('tools/vggt-cli/README.md').pipe(process.stdout)\"",
+    "validate:formations": "node --import=tsx apps/cryptiq-mindmap-demo/scripts/formations/validate.ts"
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary
- add CLI to validate formation JSONs
- expose validator via `pnpm run validate:formations`

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warn)
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch `Anton` and `IBM Plex Mono` fonts)*
- `pnpm run smoke`
- `pnpm run validate:formations`


------
https://chatgpt.com/codex/tasks/task_e_68c1efd794688328b6bcc93de69d0086