### PR TITLE
feat(labelMap): add curated set + aliases

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/data/labelMap.ts
@@ -1,37 +1,37 @@
-export const ALIASES: Record<string, string> = {
-  ship: 'boat',
-  cellphone: 'phone',
-  mobile: 'phone',
-  telephone: 'phone',
-  mug: 'cup',
-  leaf: 'flower',
-  airplane: 'plane',
-  eyeglasses: 'glasses',
-};
+const CURATED_LIST: Array<[string, ...string[]]> = [
+  ['house', 'home', 'building'],
+  ['cat', 'kitty', 'kitten', 'feline'],
+  ['circle', 'round', 'ring'],
+  ['triangle', 'pyramid', 'delta'],
+  ['star', 'asterisk'],
+  ['face', 'smile', 'smiley', 'head', 'emoji'],
+  ['apple'],
+  ['balloon'],
+  ['bird'],
+  ['boat', 'ship'],
+  ['book'],
+  ['car'],
+  ['cup', 'mug'],
+  ['fish'],
+  ['flower', 'leaf'],
+  ['glasses', 'eyeglasses'],
+  ['heart'],
+  ['moon'],
+  ['phone', 'cellphone', 'mobile', 'telephone'],
+  ['plane', 'airplane'],
+  ['shoe'],
+  ['sun'],
+  ['tree'],
+  ['umbrella'],
+];
 
-export const CURATED = new Set<string>([
-  'apple',
-  'balloon',
-  'bird',
-  'boat',
-  'book',
-  'car',
-  'cat',
-  'cup',
-  'fish',
-  'flower',
-  'glasses',
-  'heart',
-  'house',
-  'moon',
-  'phone',
-  'plane',
-  'shoe',
-  'star',
-  'sun',
-  'tree',
-  'umbrella',
-]);
+export const CURATED = new Set<string>(CURATED_LIST.map(([primary]) => primary));
+
+export const ALIASES: Record<string, string> = Object.fromEntries(
+  CURATED_LIST.flatMap(([primary, ...aliases]) =>
+    aliases.map((alias) => [alias, primary]),
+  ),
+);
 
 const TRACE =
   typeof window !== 'undefined' &&


### PR DESCRIPTION
## Summary
- expand curated labels with shapes and faces and derive alias map

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton/IBM Plex Mono fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1efc0e55c8328b4a082c23339ded4