### PR TITLE
chore(trace): SSR-safe Copy trace (HUD-only)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -80,19 +80,19 @@ export default function HUD({
         >
           Undo
         </button>
+        {devControls && (
+          <button
+            style={{ marginRight: 4, fontSize: 10 }}
+            onClick={onClassify}
+            disabled={!onClassify || !!busy}
+          >
+            Classify
+          </button>
+        )}
         {(devControls || (showCopyTrace && mounted)) && (
-          <>
-            <button
-              style={{ marginRight: 4, fontSize: 10 }}
-              onClick={onClassify}
-              disabled={!onClassify || !!busy}
-            >
-              Classify
-            </button>
-            <button style={{ marginRight: 4, fontSize: 10 }} onClick={onCopyTrace}>
-              Copy trace
-            </button>
-          </>
+          <button style={{ marginRight: 4, fontSize: 10 }} onClick={onCopyTrace}>
+            Copy trace
+          </button>
         )}
         {busy && <span style={{ marginLeft: 4 }}>inference…</span>}
       </div>


### PR DESCRIPTION
## Summary
- isolate Classify control behind `devControls`
- render Copy trace only after mount and when `devControls || (showCopyTrace && mounted)`

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1efb973988328990f1a0a108630aa