### PR TITLE
chore(demo): add build/start scripts and sanity guide

### DIFF
--- a/docs/cryptiq-mindmap/prod-sanity-guide.md
+++ b/docs/cryptiq-mindmap/prod-sanity-guide.md
@@ -1,0 +1,8 @@
+# Demo Production Sanity Guide
+
+Use this checklist to verify the demo build in production:
+
+- **No hydration warning** appears in the browser console.
+- Performance trace reveals the actual raster configuration.
+- Mobile devices sustain **at least 30 FPS**.
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "smoke:brain": "playwright test tests/brain.smoke.spec.ts --reporter=line",
     "test:smoke:draw3d": "playwright test tests/draw3d.smoke.spec.ts --reporter=line",
     "vggt:readme": "node -e \"require('fs').createReadStream('tools/vggt-cli/README.md').pipe(process.stdout)\"",
-    "validate:formations": "node --import=tsx apps/cryptiq-mindmap-demo/scripts/formations/validate.ts"
+    "validate:formations": "node --import=tsx apps/cryptiq-mindmap-demo/scripts/formations/validate.ts",
+    "build:demo": "pnpm --filter cryptiq-mindmap-demo run build",
+    "start:demo": "pnpm --filter cryptiq-mindmap-demo run start"
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary
- add demo build/start scripts to root package
- add demo prod sanity checklist

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Anton/IBM Plex Mono font files)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c330ef1ee88328bc34d58ea9b4957e