### PR TITLE
feat(HUD): optional dev label/confidence

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/ui/HUD.tsx
@@ -39,6 +39,11 @@ export default function HUD({
     const text = JSON.stringify(trace ?? [])
     navigator.clipboard.writeText(text).catch(() => {})
   }
+  const lastTrace =
+    mounted && typeof window !== 'undefined'
+      ? (window as any).__draw3dTraces?.at?.(-1) ??
+        (window as any).__draw3dTraces
+      : null
   return (
     <div
       style={{
@@ -58,6 +63,12 @@ export default function HUD({
       <div>infer: {inferMs}ms</div>
       <div>fps: {fps}</div>
       <div>instances: {instances}</div>
+      {mounted && (devControls || showCopyTrace) && lastTrace?.classify && (
+        <div>
+          label: {lastTrace.classify.normalized} (
+          {(lastTrace.classify.topK?.[0]?.confidence ?? 0).toFixed(2)})
+        </div>
+      )}
       <div style={{ marginTop: 4 }}>
         <button
           style={{ marginRight: 4, fontSize: 10 }}


### PR DESCRIPTION
## Summary
- show last classification label and confidence in HUD when dev controls or tracing active
- pull latest trace from `window.__draw3dTraces` after mount to avoid hydration mismatch

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` (warnings)
- `pnpm --filter cryptiq-mindmap-demo run build` (fails: Failed to fetch Anton from Google Fonts)
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c330e8cc008328a32f0d8fe3a4b9c4