### PR TITLE
feat(overlay): round countdown prompt (SSR-safe)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
@@ -1,0 +1,12 @@
+'use client'
+
+import type { PerspectiveCamera } from 'three'
+
+export function tweenCamera(
+  camera: PerspectiveCamera,
+  position: [number, number, number] = [0, 0, 5],
+  lookAt: [number, number, number] = [0, 0, 0]
+) {
+  camera.position.set(...position)
+  camera.lookAt(...lookAt)
+}

--- a/apps/cryptiq-mindmap-demo/app/components/overlays/RoundCountdown.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/overlays/RoundCountdown.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface RoundCountdownProps {
+  seconds?: number
+  title?: string
+  hint?: string
+  onDone: () => void
+}
+
+export default function RoundCountdown({
+  seconds = 3,
+  title = 'Draw the first thing you see',
+  hint = '(House)',
+  onDone,
+}: RoundCountdownProps) {
+  const [mounted, setMounted] = useState(false)
+  const [time, setTime] = useState(seconds)
+
+  // avoid hydration mismatch
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // countdown logic
+  useEffect(() => {
+    if (!mounted) return
+    if (time <= 0) {
+      onDone()
+      return
+    }
+    const id = window.setTimeout(() => setTime((t) => t - 1), 1000)
+    return () => clearTimeout(id)
+  }, [time, mounted, onDone])
+
+  if (!mounted) return null
+
+  const radius = 54
+  const circumference = 2 * Math.PI * radius
+  const progress = time / seconds
+  const dashOffset = circumference * (1 - progress)
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'rgba(0,0,0,0.7)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        color: '#FFFFFF',
+        zIndex: 100,
+        pointerEvents: 'auto',
+      }}
+    >
+      <div style={{ position: 'relative', width: 120, height: 120 }}>
+        <svg width={120} height={120} style={{ transform: 'rotate(-90deg)' }}>
+          <circle
+            cx={60}
+            cy={60}
+            r={radius}
+            stroke="#444"
+            strokeWidth={6}
+            fill="none"
+          />
+          <circle
+            cx={60}
+            cy={60}
+            r={radius}
+            stroke="#fff"
+            strokeWidth={6}
+            fill="none"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            style={{ transition: 'stroke-dashoffset 1s linear' }}
+          />
+        </svg>
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 32,
+            fontFamily: 'var(--font-mono), "IBM Plex Mono", monospace',
+            fontWeight: 600,
+            lineHeight: '32px',
+            userSelect: 'none',
+          }}
+        >
+          {time}
+        </div>
+      </div>
+      <div
+        style={{
+          marginTop: 24,
+          textAlign: 'center',
+          fontFamily: 'var(--font-mono), "IBM Plex Mono", monospace',
+        }}
+      >
+        <div style={{ fontSize: 20, lineHeight: '24px', marginBottom: 4 }}>{title}</div>
+        <div style={{ fontSize: 16, lineHeight: '20px', opacity: 0.7 }}>{hint}</div>
+      </div>
+    </div>
+  )
+}

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
+import { getRootState } from '@react-three/fiber'
+import type { PerspectiveCamera } from 'three'
+import { tweenCamera } from './components/anim/camera'
 import RoundCountdown from './components/overlays/RoundCountdown'
 
 export default function Home() {
@@ -16,7 +19,11 @@ export default function Home() {
   }, [])
 
   useEffect(() => {
-    if (!preloading) setShowRound(true)
+    if (!preloading) {
+      setShowRound(true)
+      const { camera } = getRootState()
+      tweenCamera(camera as PerspectiveCamera)
+    }
   }, [preloading])
 
   const BackgroundBrain = useMemo(

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -3,15 +3,21 @@
 import { useEffect, useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
+import RoundCountdown from './components/overlays/RoundCountdown'
 
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
+  const [showRound, setShowRound] = useState(false)
   useEffect(() => {
     // telemetry stub
     console.log('[Landing] viewed')
     const t = setTimeout(() => setPreloading(false), 2200)
     return () => clearTimeout(t)
   }, [])
+
+  useEffect(() => {
+    if (!preloading) setShowRound(true)
+  }, [preloading])
 
   const BackgroundBrain = useMemo(
     () => dynamic(() => import('./components/BackgroundBrain'), { ssr: false }),
@@ -137,6 +143,11 @@ export default function Home() {
           aria-hidden
           style={{ position: 'absolute', inset: 0, background: '#00041A', zIndex: 20 }}
         />
+      )}
+
+      {/* Round 1 countdown overlay */}
+      {showRound && (
+        <RoundCountdown onDone={() => setShowRound(false)} />
       )}
     </main>
   )


### PR DESCRIPTION
## Summary
- add SSR-safe RoundCountdown overlay component
- show countdown after preloader completes on landing page

## Testing
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c470694c1c83289e7124ff1c647de9