### PR TITLE
chore(camera): add tween util; wire hyperdrive on Begin

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three'
+
+export type TweenCameraParams = {
+  camera: THREE.PerspectiveCamera
+  to: { position: [number, number, number]; lookAt: [number, number, number] }
+  durationMs?: number
+  easing?: (t: number) => number
+  cancelRef?: { current: boolean }
+}
+
+export function easeInOutCubic(t: number) {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+}
+
+export function tweenCamera({
+  camera,
+  to,
+  durationMs = 1000,
+  easing = easeInOutCubic,
+  cancelRef,
+}: TweenCameraParams) {
+  const fromPos = camera.position.clone()
+  const fromLook = camera
+    .position
+    .clone()
+    .add(camera.getWorldDirection(new THREE.Vector3()))
+  const toPos = new THREE.Vector3(...to.position)
+  const toLook = new THREE.Vector3(...to.lookAt)
+
+  return new Promise<void>((resolve) => {
+    const start = performance.now()
+    let raf = 0
+    const step = (now: number) => {
+      if (cancelRef?.current) {
+        cancelAnimationFrame(raf)
+        resolve()
+        return
+      }
+      const t = Math.min(1, (now - start) / durationMs)
+      const k = easing(t)
+
+      const pos = fromPos.clone().lerp(toPos, k)
+      const look = fromLook.clone().lerp(toLook, k)
+
+      camera.position.copy(pos)
+      camera.lookAt(look.x, look.y, look.z)
+      camera.updateProjectionMatrix()
+
+      if (t < 1) {
+        raf = requestAnimationFrame(step)
+      } else {
+        resolve()
+      }
+    }
+    raf = requestAnimationFrame(step)
+  })
+}
+

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
+import { getRootState } from '@react-three/fiber'
+import type { PerspectiveCamera } from 'three'
+import { tweenCamera } from './components/anim/camera'
 
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
@@ -19,16 +22,47 @@ export default function Home() {
   )
 
   const router = useRouter()
+  const cancelRef = useRef(false)
+  const begin = useCallback(() => {
+    if (preloading || cancelRef.current) return
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement | null
+    const state = canvas ? getRootState(canvas) : undefined
+    const cam = state?.camera as PerspectiveCamera | undefined
+    if (!cam) {
+      router.push('/quiz/archetype-v1')
+      return
+    }
+    tweenCamera({
+      camera: cam,
+      to: {
+        position: [cam.position.x, cam.position.y, cam.position.z * 0.3],
+        lookAt: [0, 0, 0],
+      },
+      durationMs: 1200,
+      cancelRef,
+    }).finally(() => {
+      router.push('/quiz/archetype-v1')
+    })
+  }, [preloading, router])
   useEffect(() => {
+    cancelRef.current = false
     const onKey = (e: KeyboardEvent) => {
-      if (e.code === 'Space' && !preloading) {
+      if ((e.code === 'Space' || e.code === 'Enter') && !preloading) {
         e.preventDefault()
-        router.push('/quiz/archetype-v1')
+        begin()
       }
     }
+    const onClick = () => {
+      if (!preloading) begin()
+    }
     window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [preloading, router])
+    window.addEventListener('click', onClick)
+    return () => {
+      cancelRef.current = true
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('click', onClick)
+    }
+  }, [preloading, begin])
 
   return (
     <main


### PR DESCRIPTION
## Summary
- add tweenCamera utility with easeInOutCubic and cancellation support
- call tweenCamera on Begin to zoom toward origin before navigating

## Testing
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warnings)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed: could not fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c47061e2048328baf0b465a89dcefb