### PR TITLE
feat(integration): expose onResult(Draw3DResult)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/AppHost.tsx
@@ -273,7 +273,7 @@ export default function AppHost({ onResult }: AppHostProps) {
         onResult?.({
           label: normalized || 'unknown',
           confidence: preds[0]?.confidence ?? 0,
-          topK: preds as any,
+          topK: preds.map((p) => ({ label: p.label, confidence: p.confidence })),
           formation: target,
           fitScale: fitScale ?? 1,
           counts: { cloud: cloudCount, target: target.length / 3 },

--- a/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
+++ b/apps/cryptiq-mindmap-demo/app/draw3d/modules/types.ts
@@ -16,7 +16,7 @@ export type DoodleCanvasHandle = {
   getInkMetrics(): InkMetrics
 }
 
-export interface Draw3DResult {
+export type Draw3DResult = {
   label: string
   confidence: number
   topK: Array<{ label: string; confidence: number }>


### PR DESCRIPTION
## Summary
- expose `onResult` callback in `AppHost` to surface `Draw3DResult`
- define `Draw3DResult` type for result metadata

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(warn: Unexpected any)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(failed: fetch font file from fonts.gstatic.com)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4987c228483289070c2eff4e9132d