### PR TITLE
feat(progress): pill and camera zoom choreography

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
@@ -55,3 +55,26 @@ export function tweenCamera({
     raf = requestAnimationFrame(step)
   })
 }
+
+export async function zoomOutAndIn(camera: THREE.PerspectiveCamera, cancelRef?: { current: boolean }) {
+  const startPos = camera.position.clone()
+  const startLook = startPos.clone().add(camera.getWorldDirection(new THREE.Vector3()))
+
+  // zoom out
+  const outPos = startPos.clone().multiplyScalar(2)
+  const outLook = startLook.clone().multiplyScalar(2)
+  await tweenCamera({
+    camera,
+    to: { position: [outPos.x, outPos.y, outPos.z], lookAt: [outLook.x, outLook.y, outLook.z] },
+    durationMs: 800,
+    cancelRef,
+  })
+
+  // zoom into stub next node
+  await tweenCamera({
+    camera,
+    to: { position: [1, 0, 2], lookAt: [0, 0, 0] },
+    durationMs: 800,
+    cancelRef,
+  })
+}

--- a/apps/cryptiq-mindmap-demo/app/components/ui/ProgressPill.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/ui/ProgressPill.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function ProgressPill({ show }: { show: boolean }) {
+  const [visible, setVisible] = useState(show)
+  useEffect(() => {
+    if (show) setVisible(true)
+  }, [show])
+
+  const handleEnd = () => {
+    if (!show) setVisible(false)
+  }
+
+  return (
+    <div
+      onTransitionEnd={handleEnd}
+      style={{
+        position: 'absolute',
+        top: 24,
+        right: 24,
+        padding: '6px 12px',
+        borderRadius: 9999,
+        background: 'rgba(0,0,0,0.6)',
+        color: '#fff',
+        fontFamily: 'var(--font-mono), "IBM Plex Mono", monospace',
+        fontSize: 14,
+        lineHeight: '16px',
+        opacity: show ? 1 : 0,
+        transform: `scale(${show ? 1 : 0.9})`,
+        transition: 'opacity 0.3s ease, transform 0.3s ease',
+        display: visible ? 'flex' : 'none',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 5,
+      }}
+    >
+      1/8
+    </div>
+  )
+}
+

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -5,12 +5,14 @@ import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { getRootState } from '@react-three/fiber'
 import type { PerspectiveCamera } from 'three'
-import { tweenCamera } from './components/anim/camera'
+import { tweenCamera, zoomOutAndIn } from './components/anim/camera'
+import ProgressPill from './components/ui/ProgressPill'
 import RoundCountdown from './components/overlays/RoundCountdown'
 
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
   const [showRound, setShowRound] = useState(false)
+  const [showProgress, setShowProgress] = useState(false)
   useEffect(() => {
     // telemetry stub
     console.log('[Landing] viewed')
@@ -21,8 +23,6 @@ export default function Home() {
   useEffect(() => {
     if (!preloading) {
       setShowRound(true)
-      const { camera } = getRootState()
-      tweenCamera(camera as PerspectiveCamera)
     }
   }, [preloading])
 
@@ -33,6 +33,12 @@ export default function Home() {
 
   const router = useRouter()
   const cancelRef = useRef(false)
+  const handleMorphEnd = useCallback(async () => {
+    const { camera } = getRootState()
+    setShowProgress(true)
+    await zoomOutAndIn(camera as PerspectiveCamera)
+    setShowProgress(false)
+  }, [])
   const begin = useCallback(() => {
     if (preloading || cancelRef.current) return
     const canvas = document.querySelector('canvas') as HTMLCanvasElement | null
@@ -185,8 +191,15 @@ export default function Home() {
 
       {/* Round 1 countdown overlay */}
       {showRound && (
-        <RoundCountdown onDone={() => setShowRound(false)} />
+        <RoundCountdown
+          onDone={() => {
+            setShowRound(false)
+            handleMorphEnd()
+          }}
+        />
       )}
+
+      <ProgressPill show={showProgress} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add progress pill component with fade/scale transitions
- choreograph camera zoom sequence and trigger after round completion

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: unable to fetch Google Fonts)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c49d1548588328a562d90350a40aae