### PR TITLE
feat(rounds): Round 1 orchestrator hook

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -7,10 +7,11 @@ import { getRootState } from '@react-three/fiber'
 import type { PerspectiveCamera } from 'three'
 import { tweenCamera } from './components/anim/camera'
 import RoundCountdown from './components/overlays/RoundCountdown'
+import useRoundOne from './rounds/useRoundOne'
 
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
-  const [showRound, setShowRound] = useState(false)
+  const round = useRoundOne()
   useEffect(() => {
     // telemetry stub
     console.log('[Landing] viewed')
@@ -20,11 +21,13 @@ export default function Home() {
 
   useEffect(() => {
     if (!preloading) {
-      setShowRound(true)
       const { camera } = getRootState()
-      tweenCamera(camera as PerspectiveCamera)
+      tweenCamera(camera as PerspectiveCamera).then(() => {
+        round.hyperdriveDone()
+        round.startCountdown()
+      })
     }
-  }, [preloading])
+  }, [preloading, round])
 
   const BackgroundBrain = useMemo(
     () => dynamic(() => import('./components/BackgroundBrain'), { ssr: false }),
@@ -34,7 +37,7 @@ export default function Home() {
   const router = useRouter()
   const cancelRef = useRef(false)
   const begin = useCallback(() => {
-    if (preloading || cancelRef.current) return
+    if (preloading || cancelRef.current || round.state !== 'drawingEnabled') return
     const canvas = document.querySelector('canvas') as HTMLCanvasElement | null
     const state = canvas ? getRootState(canvas) : undefined
     const cam = state?.camera as PerspectiveCamera | undefined
@@ -53,17 +56,17 @@ export default function Home() {
     }).finally(() => {
       router.push('/quiz/archetype-v1')
     })
-  }, [preloading, router])
+  }, [preloading, router, round.state])
   useEffect(() => {
     cancelRef.current = false
     const onKey = (e: KeyboardEvent) => {
-      if ((e.code === 'Space' || e.code === 'Enter') && !preloading) {
+      if ((e.code === 'Space' || e.code === 'Enter') && round.state === 'drawingEnabled') {
         e.preventDefault()
         begin()
       }
     }
     const onClick = () => {
-      if (!preloading) begin()
+      if (round.state === 'drawingEnabled') begin()
     }
     window.addEventListener('keydown', onKey)
     window.addEventListener('click', onClick)
@@ -72,7 +75,7 @@ export default function Home() {
       window.removeEventListener('keydown', onKey)
       window.removeEventListener('click', onClick)
     }
-  }, [preloading, begin])
+  }, [round.state, begin])
 
   return (
     <main
@@ -184,8 +187,8 @@ export default function Home() {
       )}
 
       {/* Round 1 countdown overlay */}
-      {showRound && (
-        <RoundCountdown onDone={() => setShowRound(false)} />
+      {round.state === 'countdown' && (
+        <RoundCountdown onDone={round.enableDrawing} />
       )}
     </main>
   )

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -12,6 +12,7 @@ import useRoundOne from './rounds/useRoundOne'
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
   const round = useRoundOne()
+  const { hyperdriveDone, startCountdown } = round
   useEffect(() => {
     // telemetry stub
     console.log('[Landing] viewed')
@@ -23,11 +24,11 @@ export default function Home() {
     if (!preloading) {
       const { camera } = getRootState()
       tweenCamera(camera as PerspectiveCamera).then(() => {
-        round.hyperdriveDone()
-        round.startCountdown()
+        hyperdriveDone()
+        startCountdown()
       })
     }
-  }, [preloading, round])
+  }, [preloading, hyperdriveDone, startCountdown])
 
   const BackgroundBrain = useMemo(
     () => dynamic(() => import('./components/BackgroundBrain'), { ssr: false }),

--- a/apps/cryptiq-mindmap-demo/app/rounds/useRoundOne.ts
+++ b/apps/cryptiq-mindmap-demo/app/rounds/useRoundOne.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { Draw3DResult } from '../draw3d/modules/types'
+
+interface TraceWindow extends Window {
+  __draw3dTraces?: unknown
+}
+
+export type RoundOneState =
+  | 'idle'
+  | 'hyperdriveDone'
+  | 'countdown'
+  | 'drawingEnabled'
+  | 'resultReceived'
+  | 'progressShown'
+
+export interface RoundOneHook {
+  state: RoundOneState
+  result: Draw3DResult | null
+  hyperdriveDone: () => void
+  startCountdown: () => void
+  enableDrawing: () => void
+  onResult: (r?: Draw3DResult) => void
+  showProgress: () => void
+}
+
+export default function useRoundOne(): RoundOneHook {
+  const [state, setState] = useState<RoundOneState>('idle')
+  const [result, setResult] = useState<Draw3DResult | null>(null)
+
+  const hyperdriveDone = useCallback(() => setState('hyperdriveDone'), [])
+  const startCountdown = useCallback(() => setState('countdown'), [])
+  const enableDrawing = useCallback(() => setState('drawingEnabled'), [])
+  const onResult = useCallback((r?: Draw3DResult) => {
+    let next = r
+    if (!next && typeof window !== 'undefined') {
+      const traces = (window as TraceWindow).__draw3dTraces
+      if (Array.isArray(traces)) {
+        next = traces[traces.length - 1]
+      } else {
+        next = traces
+      }
+    }
+    if (next) setResult(next)
+    setState('resultReceived')
+  }, [])
+  const showProgress = useCallback(() => setState('progressShown'), [])
+
+  useEffect(() => {
+    if (state !== 'drawingEnabled' || result) return
+    const id = window.setInterval(() => {
+      const traces = (window as TraceWindow).__draw3dTraces
+      const last = Array.isArray(traces)
+        ? traces[traces.length - 1]
+        : traces
+      if (last) {
+        onResult(last as Draw3DResult)
+      }
+    }, 500)
+    return () => clearInterval(id)
+  }, [state, onResult, result])
+
+  return {
+    state,
+    result,
+    hyperdriveDone,
+    startCountdown,
+    enableDrawing,
+    onResult,
+    showProgress,
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Round 1 orchestrator hook with fallback result lookup
- drive landing page countdown and draw transition via new hook

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/...`)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c49d0ac3788328afa5a8a24d9b7e7b