### PR TITLE
feat(integration): apply onResult to Mindmap adapter

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/integration/mindmapAdapter.ts
+++ b/apps/cryptiq-mindmap-demo/app/integration/mindmapAdapter.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import type { Draw3DResult } from '../draw3d/modules/types'
+
+type MindmapNode = {
+  id: string
+  label: string
+  hits: number
+  lastConfidence: number
+  lastUpdatedAt: number
+  formationSize: number
+}
+
+const nodesByLabel = new Map<string, MindmapNode>()
+const promptQueue: string[] = []
+let nextNodeIndex = 1
+
+const now = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+
+const sanitizeLabel = (label: string) => {
+  const trimmed = label.trim()
+  return trimmed.length > 0 ? trimmed : 'unknown'
+}
+
+const titleCase = (value: string) =>
+  value
+    .split(/\s+/)
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(' ')
+    .trim()
+
+const toPercent = (confidence: number) =>
+  Math.round(Math.max(0, Math.min(1, confidence)) * 100)
+
+export function applyResult(result: Draw3DResult): { nodeId: string; commentary: string } {
+  const label = sanitizeLabel(result.label || 'unknown')
+  const key = label.toLowerCase()
+  const timestamp = now()
+  const formationSize = Math.floor(result.formation.length / 3)
+  const previous = nodesByLabel.get(key)
+  const node: MindmapNode = previous
+    ? {
+        ...previous,
+        hits: previous.hits + 1,
+        lastConfidence: result.confidence,
+        lastUpdatedAt: timestamp,
+        formationSize,
+      }
+    : {
+        id: `node-${nextNodeIndex++}`,
+        label,
+        hits: 1,
+        lastConfidence: result.confidence,
+        lastUpdatedAt: timestamp,
+        formationSize,
+      }
+
+  nodesByLabel.set(key, node)
+
+  const displayLabel = titleCase(label)
+  const confidencePct = toPercent(result.confidence)
+  const change = previous ? 'updated' : 'added'
+  const commentary = `${displayLabel} ${change} · ${confidencePct}% confidence`
+
+  const nextCandidate = result.topK.find(
+    (candidate) => candidate.label.toLowerCase() !== key
+  )
+  const prompt = nextCandidate
+    ? `Sketch how ${displayLabel} relates to ${titleCase(nextCandidate.label)}.`
+    : `Sketch something connected to ${displayLabel}.`
+
+  promptQueue.push(prompt)
+
+  console.log('[mindmap] commentary', commentary)
+  console.log('[mindmap] node', {
+    id: node.id,
+    label: node.label,
+    hits: node.hits,
+    confidence: confidencePct,
+    formationSize,
+  })
+  console.log('[mindmap] queued prompt', { prompt, queueLength: promptQueue.length })
+
+  return { nodeId: node.id, commentary }
+}

--- a/apps/cryptiq-mindmap-demo/app/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/page.tsx
@@ -9,11 +9,12 @@ import { tweenCamera } from './components/anim/camera'
 import ProgressPill from './components/ui/ProgressPill'
 import RoundCountdown from './components/overlays/RoundCountdown'
 import useRoundOne from './rounds/useRoundOne'
+import { applyResult } from './integration/mindmapAdapter'
 
 export default function Home() {
   const [preloading, setPreloading] = useState(true)
   const round = useRoundOne()
-  const { hyperdriveDone, startCountdown } = round
+  const { hyperdriveDone, startCountdown, result } = round
   const [showProgress] = useState(false)
   useEffect(() => {
     // telemetry stub
@@ -31,6 +32,12 @@ export default function Home() {
       })
     }
   }, [preloading, hyperdriveDone, startCountdown])
+
+  useEffect(() => {
+    if (!result) return
+    const outcome = applyResult(result)
+    console.log('[mindmap] applied', outcome)
+  }, [result])
 
   const BackgroundBrain = useMemo(
     () => dynamic(() => import('./components/BackgroundBrain'), { ssr: false }),


### PR DESCRIPTION
## Summary
- add a client-side mindmap adapter that stores basic node metadata, logs commentary, and queues follow-up prompts for each Draw3D result
- invoke the adapter from the landing page whenever Round One emits a new Draw3D result so each commit produces commentary output

## Testing
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint
- NEXT_DISABLE_FONT_DOWNLOADS=1 pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85df84a6083289011d7d4b240b898