### PR TITLE
feat(dreamdust): add DreamdustMaterial GLSL wrapper

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -1,0 +1,183 @@
+import { ShaderMaterial } from 'three'
+import type { IUniform, ShaderMaterialParameters } from 'three'
+
+import {
+  DREAMDUST_COLOR_CHUNK,
+  DREAMDUST_DEPTH_FADE_CHUNK,
+  DREAMDUST_DRIFT_CHUNK,
+  DREAMDUST_INK_SAMPLE_CHUNK,
+  DREAMDUST_NOISE_CHUNK,
+  DREAMDUST_POINT_SHAPE_CHUNK,
+} from './glsl/chunks'
+
+type UniformRecord = Record<string, IUniform>
+
+type DreamdustMaterialOptions = {
+  unproject: boolean
+}
+
+const VERTEX_SHADER = /* glsl */ `
+precision highp float;
+
+uniform float uBaseSize;
+uniform float uFocal;
+uniform float uMinSize;
+uniform float uMaxSize;
+uniform float uDepthMin;
+uniform float uDepthMax;
+uniform float uGamma;
+uniform float uInvertDepth;
+uniform float uTime;
+uniform float uNoiseScale;
+uniform float uNoiseSpeed;
+uniform float uDriftAmp;
+uniform float uInkIntensity;
+uniform float uInkOffsetGain;
+uniform float uInkSizeGain;
+uniform float uInkTintGain;
+uniform float uDepthBias;
+uniform float uVertexInkOk;
+uniform float uHasCapture;
+uniform float uZNearNdc;
+uniform float uZFarNdc;
+uniform mat4 uPVInvCapture;
+
+uniform sampler2D uInkTex;
+
+attribute vec2 aUv;
+attribute float aDepth;
+attribute vec3 color;
+
+varying vec3 vColor;
+varying float vDepthAlpha;
+varying vec3 vNoiseCoord;
+varying vec3 vInkTint;
+varying float vInkMix;
+
+${DREAMDUST_NOISE_CHUNK}
+${DREAMDUST_DRIFT_CHUNK}
+${DREAMDUST_INK_SAMPLE_CHUNK}
+${DREAMDUST_DEPTH_FADE_CHUNK}
+
+vec4 dreamdustUnproject(vec2 captureUv, float depth01) {
+#ifdef USE_UNPROJECT
+  if (uHasCapture > 0.5) {
+    vec2 ndc = captureUv * 2.0 - 1.0;
+    vec4 wNear = uPVInvCapture * vec4(ndc.x, ndc.y, uZNearNdc, 1.0);
+    vec4 wFar = uPVInvCapture * vec4(ndc.x, ndc.y, uZFarNdc, 1.0);
+    wNear.xyz /= max(1e-6, wNear.w);
+    wFar.xyz /= max(1e-6, wFar.w);
+    wNear.w = 1.0;
+    wFar.w = 1.0;
+    return mix(wNear, wFar, depth01);
+  }
+#endif
+  return modelMatrix * vec4(position, 1.0);
+}
+
+void main() {
+  float depthNorm = clamp((aDepth - uDepthMin) / max(1e-5, (uDepthMax - uDepthMin)), 0.0, 1.0);
+  depthNorm = pow(depthNorm, uGamma);
+  if (uInvertDepth > 0.5) {
+    depthNorm = 1.0 - depthNorm;
+  }
+
+  vec4 worldPos = dreamdustUnproject(aUv, depthNorm);
+  worldPos.xyz += dreamdustDrift(worldPos.xyz, uTime, uNoiseScale, uNoiseSpeed, uDriftAmp);
+
+  vec4 viewPos = viewMatrix * worldPos;
+  float viewDist = max(1e-3, -viewPos.z);
+
+  vec3 inkTint = vec3(0.0);
+  float inkMix = 0.0;
+  float inkSizeBoost = 0.0;
+  if (uVertexInkOk > 0.5 && uInkIntensity > 0.0) {
+    DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
+    float localIntensity = inkSample.intensity * uInkIntensity;
+    if (localIntensity > 1e-5) {
+      float pxScale = viewDist / max(1e-3, uFocal);
+      vec2 offsetView = inkSample.offset * (uInkOffsetGain * localIntensity * pxScale);
+      viewPos.xy += offsetView;
+      inkSizeBoost = inkSample.swell * localIntensity * uInkSizeGain;
+      inkTint = inkSample.tint;
+      inkMix = localIntensity * uInkTintGain;
+    }
+  }
+
+  float atten = clamp(uFocal / viewDist, uMinSize, uMaxSize);
+  gl_PointSize = max(0.0, uBaseSize * atten + inkSizeBoost);
+
+  vColor = color;
+  vDepthAlpha = dreamdustDepthFade(viewDist, uDepthBias);
+  vNoiseCoord = worldPos.xyz * uNoiseScale;
+  vInkTint = inkTint;
+  vInkMix = inkMix;
+
+  gl_Position = projectionMatrix * viewPos;
+}
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+precision highp float;
+
+uniform float uTime;
+uniform float uNoiseSpeed;
+uniform float uNoiseThreshold;
+
+varying vec3 vColor;
+varying float vDepthAlpha;
+varying vec3 vNoiseCoord;
+varying vec3 vInkTint;
+varying float vInkMix;
+
+${DREAMDUST_NOISE_CHUNK}
+${DREAMDUST_POINT_SHAPE_CHUNK}
+${DREAMDUST_COLOR_CHUNK}
+
+void main() {
+  float shape = dreamdustPointShape(gl_PointCoord);
+  if (shape <= 0.0) {
+    discard;
+  }
+
+  float noiseValue = dreamdustNoise3d(vNoiseCoord + vec3(0.0, 0.0, uTime * uNoiseSpeed));
+  float reveal = smoothstep(uNoiseThreshold - 0.12, uNoiseThreshold + 0.02, noiseValue);
+  float alpha = shape * vDepthAlpha * reveal;
+  if (alpha <= 0.0) {
+    discard;
+  }
+
+  vec3 color = vColor;
+  if (vInkMix > 1e-5) {
+    color = dreamdustApplyInkTint(color, vInkTint, vInkMix);
+  }
+
+  gl_FragColor = vec4(color, alpha);
+}
+`;
+
+export function createDreamdustMaterial(
+  uniforms: UniformRecord,
+  opts: DreamdustMaterialOptions
+) {
+  const defines: ShaderMaterialParameters['defines'] = opts.unproject
+    ? { USE_UNPROJECT: 1 }
+    : {}
+
+  const params: ShaderMaterialParameters = {
+    uniforms,
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: FRAGMENT_SHADER,
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    toneMapped: false,
+    defines,
+  }
+
+  const material = new ShaderMaterial(params)
+  material.uniforms = uniforms
+  return material
+}
+
+export type { DreamdustMaterialOptions }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -1,0 +1,102 @@
+export const DREAMDUST_NOISE_CHUNK = /* glsl */ `
+float dreamdustHash(vec3 p) {
+  p = fract(p * 0.3183099 + vec3(0.1, 0.2, 0.3));
+  p *= 17.0;
+  return fract(p.x * p.y * p.z * (p.x + p.y + p.z + 1.0));
+}
+
+float dreamdustNoise3d(vec3 p) {
+  vec3 i = floor(p);
+  vec3 f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+
+  float n000 = dreamdustHash(i + vec3(0.0, 0.0, 0.0));
+  float n100 = dreamdustHash(i + vec3(1.0, 0.0, 0.0));
+  float n010 = dreamdustHash(i + vec3(0.0, 1.0, 0.0));
+  float n110 = dreamdustHash(i + vec3(1.0, 1.0, 0.0));
+  float n001 = dreamdustHash(i + vec3(0.0, 0.0, 1.0));
+  float n101 = dreamdustHash(i + vec3(1.0, 0.0, 1.0));
+  float n011 = dreamdustHash(i + vec3(0.0, 1.0, 1.0));
+  float n111 = dreamdustHash(i + vec3(1.0, 1.0, 1.0));
+
+  float nx00 = mix(n000, n100, f.x);
+  float nx10 = mix(n010, n110, f.x);
+  float nx01 = mix(n001, n101, f.x);
+  float nx11 = mix(n011, n111, f.x);
+
+  float nxy0 = mix(nx00, nx10, f.y);
+  float nxy1 = mix(nx01, nx11, f.y);
+
+  return mix(nxy0, nxy1, f.z);
+}
+
+float dreamdustFbm(vec3 p) {
+  float value = 0.0;
+  float amplitude = 0.5;
+  for (int i = 0; i < 4; i++) {
+    value += dreamdustNoise3d(p) * amplitude;
+    p *= 2.0;
+    amplitude *= 0.5;
+  }
+  return value;
+}
+`;
+
+export const DREAMDUST_DRIFT_CHUNK = /* glsl */ `
+vec3 dreamdustDrift(vec3 pos, float time, float scale, float speed, float amp) {
+  vec3 base = pos * scale + vec3(0.0, 0.0, time * speed);
+  float nx = dreamdustFbm(base + vec3(37.2, 11.8, 5.4));
+  float ny = dreamdustFbm(base + vec3(5.3, 27.1, 19.7));
+  float nz = dreamdustFbm(base + vec3(11.1, 41.3, 7.9));
+  vec3 dir = vec3(nx, ny, nz) * 2.0 - 1.0;
+  float len = max(1e-3, length(dir));
+  dir /= len;
+  return dir * amp;
+}
+`;
+
+export const DREAMDUST_INK_SAMPLE_CHUNK = /* glsl */ `
+struct DreamdustInkSample {
+  vec2 offset;
+  float swell;
+  float intensity;
+  vec3 tint;
+};
+
+DreamdustInkSample dreamdustSampleInk(sampler2D tex, vec2 uv) {
+  vec4 ink = texture2D(tex, uv);
+  DreamdustInkSample sample;
+  sample.offset = ink.rg * 2.0 - 1.0;
+  sample.swell = ink.b;
+  sample.intensity = ink.a;
+  sample.tint = ink.rgb;
+  return sample;
+}
+`;
+
+export const DREAMDUST_DEPTH_FADE_CHUNK = /* glsl */ `
+float dreamdustDepthFade(float viewDist, float bias) {
+  if (bias <= 0.0) {
+    return 1.0;
+  }
+  return clamp(exp(-viewDist * bias), 0.0, 1.0);
+}
+`;
+
+export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `
+float dreamdustPointShape(vec2 coord) {
+  vec2 delta = coord * 2.0 - 1.0;
+  float r2 = dot(delta, delta);
+  float core = smoothstep(1.0, 0.0, r2);
+  float feather = smoothstep(1.0, 0.6, r2);
+  return core * feather;
+}
+`;
+
+export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
+vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
+  float mixAmt = clamp(amount, 0.0, 1.0);
+  vec3 tinted = baseColor + tintColor * mixAmt;
+  return mix(baseColor, tinted, mixAmt);
+}
+`;


### PR DESCRIPTION
## Summary
- add a Dreamdust-specific ShaderMaterial factory with optional PV⁻¹ unprojection, drift, reveal, and ink tint handling
- factor GLSL helper chunks for noise-driven drift, ink sampling, depth fade, point shaping, and tint blending

## Testing
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint *(fails: existing lint errors in unrelated files)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js font downloads blocked in sandbox)*
- pnpm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68c9a09cb33c8328b122e1455e94e141