### PR TITLE
feat(dreamdust): add ink context/provider

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import * as React from 'react'
+
+type InkTexture = import('three').Texture | null | undefined
+
+type DreamdustContextValue = {
+  inkTex?: import('three').Texture | null
+  inkIntensity: number
+  setInkTex: React.Dispatch<React.SetStateAction<InkTexture>>
+  setInkIntensity: React.Dispatch<React.SetStateAction<number>>
+  vertexInkOk: boolean
+  setVertexInkOk: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const DreamdustContext = React.createContext<DreamdustContextValue | undefined>(
+  undefined,
+)
+
+export function DreamdustProvider({ children }: React.PropsWithChildren) {
+  const [inkTex, setInkTex] = React.useState<InkTexture>()
+  const [inkIntensity, setInkIntensity] = React.useState<number>(1)
+  const [vertexInkOk, setVertexInkOk] = React.useState<boolean>(false)
+
+  const value = React.useMemo(
+    () => ({
+      inkTex,
+      inkIntensity,
+      setInkTex,
+      setInkIntensity,
+      vertexInkOk,
+      setVertexInkOk,
+    }),
+    [inkTex, inkIntensity, vertexInkOk],
+  )
+
+  return (
+    <DreamdustContext.Provider value={value}>
+      {children}
+    </DreamdustContext.Provider>
+  )
+}
+
+export function useDreamdustCtx() {
+  const context = React.useContext(DreamdustContext)
+  if (!context) {
+    throw new Error('useDreamdustCtx must be used within a DreamdustProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- add a Dreamdust React context provider for ink texture/intensity state
- expose a consumer hook without introducing three.js runtime imports for SSR safety

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cb663bcc8328a0e708a8f385f75c