### PR TITLE
fix: stabilize dreamdust stroke capture handle

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -48,14 +48,18 @@ const StrokeCaptureCanvas = React.forwardRef<StrokeCaptureCanvasHandle>((_, ref)
     subscribersRef.current.forEach((handler) => handler(segment))
   }, [])
 
-  React.useImperativeHandle(ref, () => ({
-    subscribe(handler: StrokeCaptureSubscriber) {
-      subscribersRef.current.add(handler)
-      return () => {
-        subscribersRef.current.delete(handler)
-      }
-    },
-  }))
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      subscribe(handler: StrokeCaptureSubscriber) {
+        subscribersRef.current.add(handler)
+        return () => {
+          subscribersRef.current.delete(handler)
+        }
+      },
+    }),
+    [],
+  )
 
   React.useEffect(() => {
     const canvas = canvasRef.current


### PR DESCRIPTION
## Summary
- make the StrokeCaptureCanvas imperative handle stable so the host ref callback no longer loops in strict mode

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Next.js cannot download Google Fonts in this environment)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cae3f11f148328b64e44f439864700