### PR TITLE
feat(dreamdust): normalized depth fade + reveal gate

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -3,11 +3,11 @@ import type { IUniform, ShaderMaterialParameters } from 'three'
 
 import {
   DREAMDUST_COLOR_CHUNK,
-  DREAMDUST_DEPTH_FADE_CHUNK,
   DREAMDUST_DRIFT_CHUNK,
   DREAMDUST_INK_SAMPLE_CHUNK,
   DREAMDUST_NOISE_CHUNK,
   DREAMDUST_POINT_SHAPE_CHUNK,
+  DREAMDUST_DEPTH_FADE_CHUNK,
 } from './glsl/chunks'
 
 type UniformRecord = Record<string, IUniform>
@@ -35,7 +35,6 @@ uniform float uInkIntensity;
 uniform float uInkOffsetGain;
 uniform float uInkSizeGain;
 uniform float uInkTintGain;
-uniform float uDepthBias;
 uniform float uVertexInkOk;
 uniform float uHasCapture;
 uniform float uZNearNdc;
@@ -49,16 +48,15 @@ attribute float aDepth;
 attribute vec3 color;
 
 varying vec3 vColor;
-varying float vDepthAlpha;
 varying vec3 vNoiseCoord;
 varying vec3 vInkTint;
 varying float vInkMix;
 varying vec2 vInkUv;
+varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_DRIFT_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
-${DREAMDUST_DEPTH_FADE_CHUNK}
 
 vec4 dreamdustUnproject(vec2 captureUv, float depth01) {
 #ifdef USE_UNPROJECT
@@ -109,11 +107,11 @@ void main() {
   gl_PointSize = max(0.0, uBaseSize * atten + inkSizeBoost);
 
   vColor = color;
-  vDepthAlpha = dreamdustDepthFade(viewDist, uDepthBias);
   vNoiseCoord = worldPos.xyz * uNoiseScale;
   vInkTint = inkTint;
   vInkMix = inkMix;
   vInkUv = aUv;
+  vPosMV = viewPos.xyz;
 
   gl_Position = projectionMatrix * viewPos;
 }
@@ -128,20 +126,23 @@ uniform float uNoiseThreshold;
 uniform float uInkIntensity;
 uniform float uInkTintGain;
 uniform float uVertexInkOk;
+uniform float uDepthBias;
+uniform float uDepthNormScale;
 
 uniform sampler2D uInkTex;
 
 varying vec3 vColor;
-varying float vDepthAlpha;
 varying vec3 vNoiseCoord;
 varying vec3 vInkTint;
 varying float vInkMix;
 varying vec2 vInkUv;
+varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_POINT_SHAPE_CHUNK}
 ${DREAMDUST_COLOR_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
+${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
   float shape = dreamdustPointShape(gl_PointCoord);
@@ -149,9 +150,16 @@ void main() {
     discard;
   }
 
-  float noiseValue = dreamdustNoise3d(vNoiseCoord + vec3(0.0, 0.0, uTime * uNoiseSpeed));
-  float reveal = smoothstep(uNoiseThreshold - 0.12, uNoiseThreshold + 0.02, noiseValue);
-  float alpha = shape * vDepthAlpha * reveal;
+  vec3 posMV = vPosMV;
+  float distNorm = clamp(-posMV.z * uDepthNormScale, 0.0, 10.0);
+
+  vec2 revealCoord = vec2(vNoiseCoord.x + uTime * uNoiseSpeed, vNoiseCoord.y);
+  if (dd_noise2(revealCoord) < uNoiseThreshold) {
+    discard;
+  }
+
+  float alpha = shape;
+  alpha *= DD_DEPTH_ALPHA(distNorm, uDepthBias);
   if (alpha <= 0.0) {
     discard;
   }
@@ -181,6 +189,10 @@ export function createDreamdustMaterial(
   uniforms: UniformRecord,
   opts: DreamdustMaterialOptions
 ) {
+  if (uniforms.uDepthNormScale === undefined) {
+    uniforms.uDepthNormScale = { value: 1 } as IUniform
+  }
+
   const defines: ShaderMaterialParameters['defines'] = opts.unproject
     ? { USE_UNPROJECT: 1 }
     : {}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -159,6 +159,26 @@ float dreamdustFbm(vec3 p) {
   }
   return value;
 }
+
+float dd_noise2(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+
+  float n00 = dreamdustHash(vec3(i, 0.0));
+  float n10 = dreamdustHash(vec3(i + vec2(1.0, 0.0), 0.0));
+  float n01 = dreamdustHash(vec3(i + vec2(0.0, 1.0), 0.0));
+  float n11 = dreamdustHash(vec3(i + vec2(1.0), 0.0));
+
+  float nx0 = mix(n00, n10, f.x);
+  float nx1 = mix(n01, n11, f.x);
+
+  return mix(nx0, nx1, f.y);
+}
+
+float dd_noise2(vec3 p) {
+  return dd_noise2(p.xy + vec2(p.z));
+}
 `;
 
 export const DREAMDUST_DRIFT_CHUNK = /* glsl */ `
@@ -200,6 +220,15 @@ float dreamdustDepthFade(float viewDist, float bias) {
   }
   return clamp(exp(-viewDist * bias), 0.0, 1.0);
 }
+
+float dd_depthAlpha(float depthNorm, float bias) {
+  if (bias <= 0.0) {
+    return 1.0;
+  }
+  return clamp(exp(-depthNorm * bias), 0.0, 1.0);
+}
+
+#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
 `;
 
 export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `


### PR DESCRIPTION
## Summary
- compute Dreamdust depth fading in the fragment shader using normalized view depth and the new DD_DEPTH_ALPHA helper
- gate fragments with a normalized reveal noise threshold while keeping ink tint handling intact
- extend the shared GLSL chunks with dd_noise2 and dd_depthAlpha helpers plus a default depth-norm uniform bootstrap

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cafb5e362c832895ea20767be25d62