### PR TITLE
feat: add Dreamdust GL caps helpers

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/capabilities.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/capabilities.ts
@@ -7,7 +7,11 @@ export type DreamdustCaps = {
 
 type GLContext = WebGLRenderingContext | WebGL2RenderingContext
 
-function safeGetParameter<T>(gl: GLContext, parameter: number, fallback: T): T {
+function safeGetParameter<T>(
+  gl: GLContext,
+  parameter: number,
+  fallback: () => T,
+): T {
   try {
     const value = gl.getParameter(parameter) as T | null | undefined
     if (value !== null && value !== undefined) {
@@ -16,11 +20,11 @@ function safeGetParameter<T>(gl: GLContext, parameter: number, fallback: T): T {
   } catch {
     // Ignore errors and use the fallback value below.
   }
-  return fallback
+  return fallback()
 }
 
 export function detectVertexTextureSupport(gl: GLContext): boolean {
-  const units = safeGetParameter<number>(gl, gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS, 0)
+  const units = safeGetParameter<number>(gl, gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS, () => 0)
   return units > 0
 }
 
@@ -28,14 +32,14 @@ export function readCaps(gl: GLContext): DreamdustCaps {
   const aliasedPointSizeRange = safeGetParameter<Float32Array>(
     gl,
     gl.ALIASED_POINT_SIZE_RANGE,
-    new Float32Array([1, 1]),
+    () => new Float32Array([1, 1]),
   )
-  const maxVertexAttribs = safeGetParameter<number>(gl, gl.MAX_VERTEX_ATTRIBS, 0)
-  const maxTextureSize = safeGetParameter<number>(gl, gl.MAX_TEXTURE_SIZE, 0)
+  const maxVertexAttribs = safeGetParameter<number>(gl, gl.MAX_VERTEX_ATTRIBS, () => 0)
+  const maxTextureSize = safeGetParameter<number>(gl, gl.MAX_TEXTURE_SIZE, () => 0)
   const maxVertexTextureImageUnits = safeGetParameter<number>(
     gl,
     gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS,
-    0,
+    () => 0,
   )
 
   return {


### PR DESCRIPTION
## Summary
- update the Dreamdust GL capabilities helper to lazily compute fallbacks
- preserve safe parameter access for WebGL1/2 contexts without side effects

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: exits with existing canvas/store type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cafba061408328b48284ee2d0c6118