### PR TITLE
chore(dreamdust): add GLSL chunks and normalized depth alpha

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -1,250 +1,145 @@
 /**
- * Shared GLSL chunks for the Dreamdust renderer.
+ * Shared Dreamdust GLSL chunks for shader composition.
  *
- * Each chunk is a raw GLSL string intended to be interpolated into shader sources.
+ * Each chunk is exported as a raw GLSL string and is intended to be interpolated
+ * into shader sources. Helper identifiers follow the `dd_` / `DD_` naming
+ * convention to avoid collisions with reserved names.
  */
-
-/**
- * Branchless 3D hash utilities (based on iq-style hash functions).
- *
- * @glslUniforms None
- */
-export const NOISE_HASH = /* glsl */ `
-vec3 hash33(vec3 p) {
-  const vec3 HASHSCALE3 = vec3(0.1031, 0.1030, 0.0973);
-  p = fract(p * HASHSCALE3);
-  p += dot(p, p.yzx + 33.33);
-  return fract((p.xxy + p.yzz) * p.zyx);
-}
-
-float hash13(vec3 p) {
-  return hash33(p).x;
-}
-`
-
-/**
- * 2D fractal brownian motion built on top of {@link NOISE_HASH} helpers.
- *
- * @glslUniforms None
- */
-export const FBM2 = /* glsl */ `
-#ifndef FBM2_MAX_OCTAVES
-#define FBM2_MAX_OCTAVES 8
-#endif
-
-float fbmNoise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-
-  float n00 = hash13(vec3(i, 0.0));
-  float n10 = hash13(vec3(i + vec2(1.0, 0.0), 0.0));
-  float n01 = hash13(vec3(i + vec2(0.0, 1.0), 0.0));
-  float n11 = hash13(vec3(i + vec2(1.0), 0.0));
-
-  vec2 u = f * f * (3.0 - 2.0 * f);
-
-  float x1 = mix(n00, n10, u.x);
-  float x2 = mix(n01, n11, u.x);
-
-  return mix(x1, x2, u.y);
-}
-
-float fbm2(vec2 p, float lacunarity, float gain, int octaves) {
-  float amplitude = 0.5;
-  float frequency = 1.0;
-  float sum = 0.0;
-  int cappedOctaves = min(octaves, FBM2_MAX_OCTAVES);
-
-  for (int i = 0; i < FBM2_MAX_OCTAVES; ++i) {
-    if (i >= cappedOctaves) {
-      break;
-    }
-
-    sum += amplitude * fbmNoise2(p * frequency);
-    frequency *= lacunarity;
-    amplitude *= gain;
-  }
-
-  return sum;
-}
-`
-
-/**
- * Converts absolute screen-space pixels into clip-space coordinates.
- *
- * @glslUniforms uViewport (vec2) viewport resolution in pixels
- */
-export const SCREEN_PX_TO_CLIP = /* glsl */ `
-vec2 screenPxToClip(vec2 screenPx) {
-  vec2 viewport = max(uViewport, vec2(1.0));
-  vec2 clip = (screenPx / viewport) * 2.0 - 1.0;
-  clip.y = -clip.y;
-  return clip;
-}
-`
 
 /**
  * Saturation helper that clamps a scalar to the [0, 1] range.
  *
  * @glslUniforms None
  */
-export const SAT = /* glsl */ `
-#define SAT(x) clamp(x, 0.0, 1.0)
-`
+export const DD_SAT = /* glsl */ `
+float dd_saturate(float dd_value) {
+  return clamp(dd_value, 0.0, 1.0);
+}
+
+#define DD_SAT(x) dd_saturate(x)
+`;
 
 /**
  * Linear remap helper that transforms a scalar between ranges.
  *
  * @glslUniforms None
  */
-export const REMAP = /* glsl */ `
-#define REMAP(x, a, b) ((b).x + ((x) - (a).x) * ((b).y - (b).x) / max((a).y - (a).x, 1e-5))
-`
+export const DD_REMAP = /* glsl */ `
+float dd_remap(float dd_value, vec2 dd_fromRange, vec2 dd_toRange) {
+  float dd_range = max(dd_fromRange.y - dd_fromRange.x, 1e-5);
+  float dd_normalized = (dd_value - dd_fromRange.x) / dd_range;
+  return mix(dd_toRange.x, dd_toRange.y, dd_normalized);
+}
 
-export const glslChunks = {
-  hash: NOISE_HASH,
-  fbm2: FBM2,
-  screenPxToClip: SCREEN_PX_TO_CLIP,
-  sat: SAT,
-  remap: REMAP,
-} as const
-
-export type GlslChunkKey = keyof typeof glslChunks
+#define DD_REMAP(value, fromRange, toRange) dd_remap(value, fromRange, toRange)
+`;
 
 /**
- * DREAMDUST_* chunks — public exports expected by DreamdustMaterial (PR #129)
- * These are defined here so both the new material and any future shaders can
- * consume a consistent set of helper snippets. We retain our existing helper
- * snippets above (NOISE_HASH/FBM2/SCREEN_PX_TO_CLIP/SAT/REMAP) for reuse.
+ * Branchless 3D hash utilities (based on IQ-style hash functions).
+ *
+ * @glslUniforms None
  */
-export const DREAMDUST_NOISE_CHUNK = /* glsl */ `
-float dreamdustHash(vec3 p) {
-  p = fract(p * 0.3183099 + vec3(0.1, 0.2, 0.3));
-  p *= 17.0;
-  return fract(p.x * p.y * p.z * (p.x + p.y + p.z + 1.0));
+export const DD_HASH3 = /* glsl */ `
+vec3 dd_hash33(vec3 dd_p) {
+  vec3 dd_hashScale3 = vec3(0.1031, 0.1030, 0.0973);
+  vec3 dd_q = fract(dd_p * dd_hashScale3);
+  dd_q += dot(dd_q, dd_q.yzx + 33.33);
+  return fract((dd_q.xxy + dd_q.yzz) * dd_q.zyx);
 }
 
-float dreamdustNoise3d(vec3 p) {
-  vec3 i = floor(p);
-  vec3 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n000 = dreamdustHash(i + vec3(0.0, 0.0, 0.0));
-  float n100 = dreamdustHash(i + vec3(1.0, 0.0, 0.0));
-  float n010 = dreamdustHash(i + vec3(0.0, 1.0, 0.0));
-  float n110 = dreamdustHash(i + vec3(1.0, 1.0, 0.0));
-  float n001 = dreamdustHash(i + vec3(0.0, 0.0, 1.0));
-  float n101 = dreamdustHash(i + vec3(1.0, 0.0, 1.0));
-  float n011 = dreamdustHash(i + vec3(0.0, 1.0, 1.0));
-  float n111 = dreamdustHash(i + vec3(1.0, 1.0, 1.0));
-
-  float nx00 = mix(n000, n100, f.x);
-  float nx10 = mix(n010, n110, f.x);
-  float nx01 = mix(n001, n101, f.x);
-  float nx11 = mix(n011, n111, f.x);
-
-  float nxy0 = mix(nx00, nx10, f.y);
-  float nxy1 = mix(nx01, nx11, f.y);
-
-  return mix(nxy0, nxy1, f.z);
+float dd_hash13(vec3 dd_p) {
+  return dd_hash33(dd_p).x;
 }
 
-float dreamdustFbm(vec3 p) {
-  float value = 0.0;
-  float amplitude = 0.5;
-  for (int i = 0; i < 4; i++) {
-    value += dreamdustNoise3d(p) * amplitude;
-    p *= 2.0;
-    amplitude *= 0.5;
+#define DD_HASH3(p) dd_hash33(p)
+`;
+
+/**
+ * 2D fractal brownian motion built on top of {@link DD_HASH3} helpers.
+ *
+ * @glslUniforms None
+ */
+export const DD_NOISE2_FBM = /* glsl */ `
+float dd_noise2Value(vec2 dd_p) {
+  vec2 dd_i = floor(dd_p);
+  vec2 dd_f = fract(dd_p);
+
+  float dd_n00 = dd_hash13(vec3(dd_i, 0.0));
+  float dd_n10 = dd_hash13(vec3(dd_i + vec2(1.0, 0.0), 0.0));
+  float dd_n01 = dd_hash13(vec3(dd_i + vec2(0.0, 1.0), 0.0));
+  float dd_n11 = dd_hash13(vec3(dd_i + vec2(1.0), 0.0));
+
+  vec2 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_x1 = mix(dd_n00, dd_n10, dd_u.x);
+  float dd_x2 = mix(dd_n01, dd_n11, dd_u.x);
+
+  return mix(dd_x1, dd_x2, dd_u.y);
+}
+
+float dd_noise2Fbm(vec2 dd_p, float dd_lacunarity, float dd_gain, int dd_octaves) {
+  const int dd_maxOctaves = 8;
+  int dd_capped = min(dd_octaves, dd_maxOctaves);
+  float dd_amplitude = 0.5;
+  float dd_frequency = 1.0;
+  float dd_sum = 0.0;
+
+  for (int dd_index = 0; dd_index < dd_maxOctaves; ++dd_index) {
+    if (dd_index >= dd_capped) {
+      break;
+    }
+
+    dd_sum += dd_amplitude * dd_noise2Value(dd_p * dd_frequency);
+    dd_frequency *= dd_lacunarity;
+    dd_amplitude *= dd_gain;
   }
-  return value;
+
+  return dd_sum;
 }
 
-float dd_noise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n00 = dreamdustHash(vec3(i, 0.0));
-  float n10 = dreamdustHash(vec3(i + vec2(1.0, 0.0), 0.0));
-  float n01 = dreamdustHash(vec3(i + vec2(0.0, 1.0), 0.0));
-  float n11 = dreamdustHash(vec3(i + vec2(1.0), 0.0));
-
-  float nx0 = mix(n00, n10, f.x);
-  float nx1 = mix(n01, n11, f.x);
-
-  return mix(nx0, nx1, f.y);
-}
-
-float dd_noise2(vec3 p) {
-  return dd_noise2(p.xy + vec2(p.z));
-}
+#define DD_NOISE2_FBM(p, lacunarity, gain, octaves) dd_noise2Fbm(p, lacunarity, gain, octaves)
 `;
 
-export const DREAMDUST_DRIFT_CHUNK = /* glsl */ `
-vec3 dreamdustDrift(vec3 pos, float time, float scale, float speed, float amp) {
-  vec3 base = pos * scale + vec3(0.0, 0.0, time * speed);
-  float nx = dreamdustFbm(base + vec3(37.2, 11.8, 5.4));
-  float ny = dreamdustFbm(base + vec3(5.3, 27.1, 19.7));
-  float nz = dreamdustFbm(base + vec3(11.1, 41.3, 7.9));
-  vec3 dir = vec3(nx, ny, nz) * 2.0 - 1.0;
-  float len = max(1e-3, length(dir));
-  dir /= len;
-  return dir * amp;
+/**
+ * Converts absolute screen-space pixels into clip-space coordinates.
+ *
+ * @glslUniforms uViewport (vec2) viewport resolution in pixels
+ */
+export const DD_SCREEN_PX_TO_CLIP = /* glsl */ `
+vec2 dd_screenPxToClip(vec2 dd_screenPx) {
+  vec2 dd_viewport = max(uViewport, vec2(1.0));
+  vec2 dd_clip = (dd_screenPx / dd_viewport) * 2.0 - 1.0;
+  dd_clip.y = -dd_clip.y;
+  return dd_clip;
 }
+
+#define DD_SCREEN_PX_TO_CLIP(px) dd_screenPxToClip(px)
 `;
 
-export const DREAMDUST_INK_SAMPLE_CHUNK = /* glsl */ `
-struct DreamdustInkSample {
-  vec2 offset;
-  float swell;
-  float intensity;
-  vec3 tint;
-};
-
-DreamdustInkSample dreamdustSampleInk(sampler2D tex, vec2 uv) {
-  vec4 ink = texture2D(tex, uv);
-  DreamdustInkSample sample;
-  sample.offset = ink.rg * 2.0 - 1.0;
-  sample.swell = ink.b;
-  sample.intensity = ink.a;
-  sample.tint = ink.rgb;
-  return sample;
+/**
+ * Depth fade helper that normalizes camera-space distance before attenuation.
+ *
+ * @glslUniforms uDepthNormScale (float) depth normalization scale
+ */
+export const DD_DEPTH_ALPHA = /* glsl */ `
+float dd_depthNorm(float dd_viewDist) {
+  return clamp(dd_viewDist * uDepthNormScale, 0.0, 10.0);
 }
+
+float dd_depthAlpha(float dd_distNorm, float dd_k) {
+  return exp(-dd_k * dd_distNorm);
+}
+
+#define DD_DEPTH_ALPHA(distNorm, k) dd_depthAlpha(distNorm, k)
 `;
 
-export const DREAMDUST_DEPTH_FADE_CHUNK = /* glsl */ `
-float dreamdustDepthFade(float viewDist, float bias) {
-  if (bias <= 0.0) {
-    return 1.0;
-  }
-  return clamp(exp(-viewDist * bias), 0.0, 1.0);
-}
+export const glslChunks = {
+  sat: DD_SAT,
+  remap: DD_REMAP,
+  hash3: DD_HASH3,
+  fbm2: DD_NOISE2_FBM,
+  screenPxToClip: DD_SCREEN_PX_TO_CLIP,
+  depthAlpha: DD_DEPTH_ALPHA,
+} as const;
 
-float dd_depthAlpha(float depthNorm, float bias) {
-  if (bias <= 0.0) {
-    return 1.0;
-  }
-  return clamp(exp(-depthNorm * bias), 0.0, 1.0);
-}
-
-#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
-`;
-
-export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `
-float dreamdustPointShape(vec2 coord) {
-  vec2 delta = coord * 2.0 - 1.0;
-  float r2 = dot(delta, delta);
-  float core = smoothstep(1.0, 0.0, r2);
-  float feather = smoothstep(1.0, 0.6, r2);
-  return core * feather;
-}
-`;
-
-export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
-vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
-  float mixAmt = clamp(amount, 0.0, 1.0);
-  vec3 tinted = baseColor + tintColor * mixAmt;
-  return mix(baseColor, tinted, mixAmt);
-}
-`;
+export type GlslChunkKey = keyof typeof glslChunks;


### PR DESCRIPTION
## Summary
- replace Dreamdust GLSL chunk exports with dd_/DD_-prefixed helpers and macros
- add normalized depth fade helper and screen-to-clip conversion with documented uniforms
- expose updated chunk map for Dreamdust shaders

## Testing
- `pnpm -w typecheck` *(fails: command not found in workspace)*
- `pnpm -w run type-check` *(fails: existing quiz slice type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cb102beb708328bfa4afe12ecea25f