### PR TITLE
feat(dreamdusk): add StrokeCaptureCanvas and InkFieldHost components

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -5,173 +5,25 @@ import * as React from 'react'
 import { getR3FStateOrNull } from '../anim/r3fSafe'
 import { detectVertexTextureSupport } from './capabilities'
 import { createInkField, type InkField } from './InkField'
+import { StrokeCaptureCanvas, type StrokePoint, type StrokeSegment } from './StrokeCaptureCanvas'
 import { useDreamdustCtx } from './context'
 
-const DEFAULT_PRESSURE = 0.5
+type RendererLike = {
+  getContext: () => WebGLRenderingContext | WebGL2RenderingContext
+}
+
+type CanvasTextureLike = {
+  needsUpdate?: boolean
+  dispose?: () => void
+}
+
+const FIELD_SIZE = 128
+const MAX_DPR = 1.5
+const UPLOAD_HZ = 60
+const DECAY_BASE = 0.96
 const INTENSITY_EPSILON = 0.01
 const INTENSITY_IDLE_ZERO_MS = 2400
-const DECAY_BASE = 0.96
-
-interface StrokePoint {
-  x: number
-  y: number
-}
-
-interface StrokeSegment {
-  points: StrokePoint[]
-  pressure: number
-}
-
-type StrokeCaptureSubscriber = (segment: StrokeSegment) => void
-
-type StrokeCaptureCanvasHandle = {
-  subscribe(handler: StrokeCaptureSubscriber): () => void
-}
-
-function clamp01(value: number): number {
-  if (value <= 0) return 0
-  if (value >= 1) return 1
-  return value
-}
-
-const StrokeCaptureCanvas = React.forwardRef<StrokeCaptureCanvasHandle>((_, ref) => {
-  const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
-  const subscribersRef = React.useRef(new Set<StrokeCaptureSubscriber>())
-  const pointerIdRef = React.useRef<number | null>(null)
-  const lastPointRef = React.useRef<StrokePoint | null>(null)
-
-  const emitSegment = React.useCallback((points: StrokePoint[], pressure: number) => {
-    if (!points.length) return
-    const normalizedPressure = pressure > 0 ? pressure : DEFAULT_PRESSURE
-    const clampedPressure = clamp01(normalizedPressure)
-    const segment: StrokeSegment = { points, pressure: clampedPressure }
-    subscribersRef.current.forEach((handler) => handler(segment))
-  }, [])
-
-  React.useImperativeHandle(
-    ref,
-    () => ({
-      subscribe(handler: StrokeCaptureSubscriber) {
-        subscribersRef.current.add(handler)
-        return () => {
-          subscribersRef.current.delete(handler)
-        }
-      },
-    }),
-    [],
-  )
-
-  React.useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return undefined
-
-    const resize = () => {
-      const parent = canvas.parentElement
-      if (!parent) return
-      const rect = parent.getBoundingClientRect()
-      canvas.width = rect.width
-      canvas.height = rect.height
-    }
-
-    resize()
-    window.addEventListener('resize', resize)
-
-    const resolvePoint = (event: PointerEvent): StrokePoint | null => {
-      const rect = canvas.getBoundingClientRect()
-      const width = rect.width || 1
-      const height = rect.height || 1
-      if (width <= 0 || height <= 0) {
-        return null
-      }
-      const x = clamp01((event.clientX - rect.left) / width)
-      const y = clamp01((event.clientY - rect.top) / height)
-      return { x, y }
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (pointerIdRef.current !== null && pointerIdRef.current !== event.pointerId) {
-        return
-      }
-      const point = resolvePoint(event)
-      if (!point) return
-      pointerIdRef.current = event.pointerId
-      lastPointRef.current = point
-      try {
-        canvas.setPointerCapture(event.pointerId)
-      } catch {
-        // ignore pointer capture failures (e.g., Safari)
-      }
-      emitSegment([point], event.pressure)
-      event.preventDefault()
-    }
-
-    const handlePointerMove = (event: PointerEvent) => {
-      if (pointerIdRef.current !== event.pointerId) return
-      const point = resolvePoint(event)
-      if (!point) return
-      const lastPoint = lastPointRef.current
-      lastPointRef.current = point
-      if (lastPoint) {
-        emitSegment([lastPoint, point], event.pressure)
-      } else {
-        emitSegment([point], event.pressure)
-      }
-      event.preventDefault()
-    }
-
-    const finishStroke = (event: PointerEvent) => {
-      if (pointerIdRef.current !== event.pointerId) return
-      pointerIdRef.current = null
-      lastPointRef.current = null
-      try {
-        if (canvas.hasPointerCapture(event.pointerId)) {
-          canvas.releasePointerCapture(event.pointerId)
-        }
-      } catch {
-        // ignore errors when releasing pointer capture
-      }
-      event.preventDefault()
-    }
-
-    canvas.addEventListener('pointerdown', handlePointerDown, { passive: false })
-    canvas.addEventListener('pointermove', handlePointerMove, { passive: false })
-    canvas.addEventListener('pointerup', finishStroke, { passive: false })
-    canvas.addEventListener('pointercancel', finishStroke, { passive: false })
-    canvas.addEventListener('pointerleave', finishStroke, { passive: false })
-
-    return () => {
-      window.removeEventListener('resize', resize)
-      canvas.removeEventListener('pointerdown', handlePointerDown)
-      canvas.removeEventListener('pointermove', handlePointerMove)
-      canvas.removeEventListener('pointerup', finishStroke)
-      canvas.removeEventListener('pointercancel', finishStroke)
-      canvas.removeEventListener('pointerleave', finishStroke)
-    }
-  }, [emitSegment])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'block',
-        pointerEvents: 'auto',
-        touchAction: 'none',
-        background: 'transparent',
-        cursor: 'crosshair',
-      }}
-    />
-  )
-})
-
-StrokeCaptureCanvas.displayName = 'StrokeCaptureCanvas'
-
-function decayRateFromDelta(deltaMs: number): number {
-  if (deltaMs <= 0) return DECAY_BASE
-  const steps = Math.max(1, (deltaMs / 1000) * 60)
-  return Math.pow(DECAY_BASE, steps)
-}
+const DEFAULT_PRESSURE = 0.5
 
 function nowMs(): number {
   if (typeof performance !== 'undefined') {
@@ -180,24 +32,74 @@ function nowMs(): number {
   return Date.now()
 }
 
-export function InkFieldHost(): JSX.Element {
+function decayRateFromDelta(deltaMs: number): number {
+  if (deltaMs <= 0) {
+    return DECAY_BASE
+  }
+  const steps = Math.max(1, (deltaMs / 1000) * 60)
+  return Math.pow(DECAY_BASE, steps)
+}
+
+export function InkFieldHost(): React.JSX.Element {
   const { setInkTex, setInkIntensity, setVertexInkOk } = useDreamdustCtx()
-  const [captureHandle, setCaptureHandle] = React.useState<StrokeCaptureCanvasHandle | null>(null)
+  type InkTexState = Parameters<typeof setInkTex>[0]
 
   const inkFieldRef = React.useRef<InkField | null>(null)
-  const rendererRef = React.useRef<import('three').WebGLRenderer | null>(null)
-  const textureRef = React.useRef<import('three').CanvasTexture | null>(null)
-  const lastStrokeRef = React.useRef<number>(0)
-  const intensityRef = React.useRef<number>(0)
+  const rendererRef = React.useRef<RendererLike | null>(null)
+  const textureRef = React.useRef<CanvasTextureLike | null>(null)
+  const lastStrokeRef = React.useRef(0)
+  const intensityRef = React.useRef(0)
   const vertexInkOkRef = React.useRef<boolean | null>(null)
 
-  const lastHandleRef = React.useRef<StrokeCaptureCanvasHandle | null>(null)
-  const handleCaptureRef = React.useCallback((handle: StrokeCaptureCanvasHandle | null) => {
-    if (lastHandleRef.current !== handle) {
-      lastHandleRef.current = handle
-      setCaptureHandle(handle)
-    }
-  }, [])
+  const handleStrokeStart = React.useCallback(
+    (_point: StrokePoint) => {
+      const now = nowMs()
+      lastStrokeRef.current = now
+      if (intensityRef.current !== 1) {
+        intensityRef.current = 1
+        setInkIntensity(1)
+      }
+    },
+    [setInkIntensity],
+  )
+
+  const handleStrokeSegment = React.useCallback(
+    (segment: StrokeSegment) => {
+      const field = inkFieldRef.current
+      if (!field) {
+        return
+      }
+
+      const pressure = segment.pressure > 0 ? segment.pressure : DEFAULT_PRESSURE
+      field.drawStroke(
+        [
+          { x: segment.from.x, y: segment.from.y },
+          { x: segment.to.x, y: segment.to.y },
+        ],
+        pressure,
+      )
+
+      const now = nowMs()
+      lastStrokeRef.current = now
+      if (intensityRef.current !== 1) {
+        intensityRef.current = 1
+        setInkIntensity(1)
+      }
+
+      const renderer = rendererRef.current
+      if (renderer) {
+        const texture = field.toCanvasTexture(
+          renderer as Parameters<InkField['toCanvasTexture']>[0],
+          UPLOAD_HZ,
+        )
+        if (textureRef.current !== texture) {
+          textureRef.current = texture
+          setInkTex(texture as InkTexState)
+        }
+      }
+    },
+    [setInkIntensity, setInkTex],
+  )
 
   React.useEffect(() => {
     setInkIntensity(0)
@@ -213,91 +115,103 @@ export function InkFieldHost(): JSX.Element {
   }, [setInkIntensity, setInkTex, setVertexInkOk])
 
   React.useEffect(() => {
-    if (typeof window === 'undefined') return
-    const dpr = Math.min(window.devicePixelRatio || 1, 1.5)
-    const field = createInkField(128, dpr)
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR)
+    const field = createInkField(FIELD_SIZE, dpr)
     inkFieldRef.current = field
+
     return () => {
+      if (inkFieldRef.current === field) {
+        inkFieldRef.current = null
+      }
       field.dispose()
-      inkFieldRef.current = null
     }
   }, [])
 
   React.useEffect(() => {
-    if (typeof window === 'undefined') return
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
     let cancelled = false
     let frame = 0
 
     const tryAcquireRenderer = () => {
-      if (cancelled) return
-      const state = getR3FStateOrNull()
-      const renderer = state?.gl ?? null
-      if (renderer) {
-        rendererRef.current = renderer
-        const gl = renderer.getContext()
-        const supported = detectVertexTextureSupport(gl)
-        if (vertexInkOkRef.current !== supported) {
-          vertexInkOkRef.current = supported
-          setVertexInkOk(supported)
-        }
-        const field = inkFieldRef.current
-        if (field) {
-          const texture = field.toCanvasTexture(renderer, 60)
-          textureRef.current = texture
-          setInkTex(texture)
-        }
+      if (cancelled) {
         return
       }
-      frame = window.requestAnimationFrame(tryAcquireRenderer)
+
+      const state = getR3FStateOrNull()
+      const renderer = state?.gl ?? null
+      if (!renderer) {
+        frame = window.requestAnimationFrame(tryAcquireRenderer)
+        return
+      }
+
+      rendererRef.current = renderer
+      const gl = renderer.getContext()
+      const supported = detectVertexTextureSupport(gl)
+      if (vertexInkOkRef.current !== supported) {
+        vertexInkOkRef.current = supported
+        setVertexInkOk(supported)
+      }
+
+      const field = inkFieldRef.current
+      if (field) {
+        const texture = field.toCanvasTexture(
+          renderer as Parameters<InkField['toCanvasTexture']>[0],
+          UPLOAD_HZ,
+        )
+        if (!cancelled) {
+          textureRef.current = texture
+          setInkTex(texture as InkTexState)
+        }
+      }
     }
 
     frame = window.requestAnimationFrame(tryAcquireRenderer)
 
     return () => {
       cancelled = true
-      if (frame) window.cancelAnimationFrame(frame)
+      if (frame) {
+        window.cancelAnimationFrame(frame)
+      }
     }
   }, [setInkTex, setVertexInkOk])
 
   React.useEffect(() => {
-    if (!captureHandle) return undefined
-    const field = inkFieldRef.current
-    if (!field) return undefined
-
-    const unsubscribe = captureHandle.subscribe((segment) => {
-      if (!segment.points.length) return
-      const activeField = inkFieldRef.current
-      if (!activeField) return
-      activeField.drawStroke(segment.points, segment.pressure)
-      const now = nowMs()
-      lastStrokeRef.current = now
-      intensityRef.current = 1
-      setInkIntensity(1)
-    })
-
-    return () => {
-      unsubscribe()
+    if (typeof window === 'undefined') {
+      return undefined
     }
-  }, [captureHandle, setInkIntensity])
 
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return
+    let cancelled = false
     let frame = 0
     let lastTick = nowMs()
 
     const loop = (timestamp: number) => {
+      if (cancelled) {
+        return
+      }
+
+      const delta = timestamp - lastTick
+      lastTick = timestamp
+
       const field = inkFieldRef.current
       if (field) {
-        const delta = timestamp - lastTick
-        lastTick = timestamp
-        const rate = decayRateFromDelta(delta)
-        field.decay(rate)
+        const decayRate = decayRateFromDelta(delta)
+        field.decay(decayRate)
         const renderer = rendererRef.current
         if (renderer) {
-          const texture = field.toCanvasTexture(renderer, 60)
-          if (textureRef.current !== texture) {
+          const texture = field.toCanvasTexture(
+            renderer as Parameters<InkField['toCanvasTexture']>[0],
+            UPLOAD_HZ,
+          )
+          if (!cancelled && textureRef.current !== texture) {
             textureRef.current = texture
-            setInkTex(texture)
+            setInkTex(texture as InkTexState)
           }
         }
       }
@@ -310,18 +224,20 @@ export function InkFieldHost(): JSX.Element {
           targetIntensity = 1
         } else if (idle < INTENSITY_IDLE_ZERO_MS) {
           targetIntensity = Math.exp(-idle / 900)
-        } else {
-          targetIntensity = 0
         }
       }
 
-      const current = intensityRef.current
-      if (Math.abs(targetIntensity - current) > INTENSITY_EPSILON) {
-        intensityRef.current = targetIntensity
-        setInkIntensity(targetIntensity)
-      } else if (targetIntensity === 0 && current !== 0) {
-        intensityRef.current = 0
-        setInkIntensity(0)
+      const currentIntensity = intensityRef.current
+      if (Math.abs(targetIntensity - currentIntensity) > INTENSITY_EPSILON) {
+        if (!cancelled) {
+          intensityRef.current = targetIntensity
+          setInkIntensity(targetIntensity)
+        }
+      } else if (targetIntensity === 0 && currentIntensity !== 0) {
+        if (!cancelled) {
+          intensityRef.current = 0
+          setInkIntensity(0)
+        }
       }
 
       frame = window.requestAnimationFrame(loop)
@@ -330,7 +246,10 @@ export function InkFieldHost(): JSX.Element {
     frame = window.requestAnimationFrame(loop)
 
     return () => {
-      if (frame) window.cancelAnimationFrame(frame)
+      cancelled = true
+      if (frame) {
+        window.cancelAnimationFrame(frame)
+      }
     }
   }, [setInkIntensity, setInkTex])
 
@@ -344,7 +263,10 @@ export function InkFieldHost(): JSX.Element {
         pointerEvents: 'none',
       }}
     >
-      <StrokeCaptureCanvas ref={handleCaptureRef} />
+      <StrokeCaptureCanvas
+        onStrokeStart={handleStrokeStart}
+        onStrokeSegment={handleStrokeSegment}
+      />
     </div>
   )
 }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import type { CSSProperties } from 'react'
+import * as React from 'react'
 
 export type StrokePoint = {
   x: number
@@ -19,150 +18,179 @@ export type StrokeSegment = {
 
 export type StrokeCaptureCanvasProps = {
   className?: string
-  style?: CSSProperties
-  strokeStyle?: string
-  lineWidth?: number
+  style?: React.CSSProperties
   onStrokeStart?(point: StrokePoint): void
   onStrokeSegment?(segment: StrokeSegment): void
   onStrokeEnd?(): void
 }
 
-const DEFAULT_STROKE_STYLE = 'rgba(255,255,255,0.8)'
-const DEFAULT_LINE_WIDTH = 16
 const MAX_DPR = 1.5
+const DEFAULT_PRESSURE = 0.5
 
-const StrokeCaptureCanvas = ({
+const clamp01 = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  if (value <= 0) return 0
+  if (value >= 1) return 1
+  return value
+}
+
+const resolvePressure = (event: PointerEvent): number => {
+  const { pressure, buttons, pointerType } = event
+  if (typeof pressure === 'number' && pressure > 0) {
+    return pressure > 1 ? 1 : pressure
+  }
+  if (pointerType === 'mouse') {
+    return buttons ? DEFAULT_PRESSURE : 0
+  }
+  if (typeof pressure === 'number') {
+    return pressure
+  }
+  return DEFAULT_PRESSURE
+}
+
+export function StrokeCaptureCanvas({
   className,
   style,
-  strokeStyle = DEFAULT_STROKE_STYLE,
-  lineWidth = DEFAULT_LINE_WIDTH,
   onStrokeStart,
   onStrokeSegment,
   onStrokeEnd,
-}: StrokeCaptureCanvasProps) => {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
-  const dprRef = useRef(1)
-  const isDrawingRef = useRef(false)
-  const lastPointRef = useRef<StrokePoint | null>(null)
+}: StrokeCaptureCanvasProps): React.JSX.Element {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
+  const pointerIdRef = React.useRef<number | null>(null)
+  const isDrawingRef = React.useRef(false)
+  const lastPointRef = React.useRef<StrokePoint | null>(null)
+  const lastSmoothedRef = React.useRef<StrokePoint | null>(null)
 
-  const startCallbackRef = useRef<((point: StrokePoint) => void) | null>(
-    onStrokeStart ?? null,
+  const startCallbackRef = React.useRef<StrokeCaptureCanvasProps['onStrokeStart']>(
+    onStrokeStart,
   )
-  const segmentCallbackRef = useRef<((segment: StrokeSegment) => void) | null>(
-    onStrokeSegment ?? null,
+  const segmentCallbackRef = React.useRef<StrokeCaptureCanvasProps['onStrokeSegment']>(
+    onStrokeSegment,
   )
-  const endCallbackRef = useRef<(() => void) | null>(onStrokeEnd ?? null)
-  const strokeStyleRef = useRef(strokeStyle)
-  const lineWidthRef = useRef(lineWidth)
+  const endCallbackRef = React.useRef<StrokeCaptureCanvasProps['onStrokeEnd']>(
+    onStrokeEnd,
+  )
 
-  useEffect(() => {
-    startCallbackRef.current = onStrokeStart ?? null
+  React.useEffect(() => {
+    startCallbackRef.current = onStrokeStart
   }, [onStrokeStart])
 
-  useEffect(() => {
-    segmentCallbackRef.current = onStrokeSegment ?? null
+  React.useEffect(() => {
+    segmentCallbackRef.current = onStrokeSegment
   }, [onStrokeSegment])
 
-  useEffect(() => {
-    endCallbackRef.current = onStrokeEnd ?? null
+  React.useEffect(() => {
+    endCallbackRef.current = onStrokeEnd
   }, [onStrokeEnd])
 
-  useEffect(() => {
-    strokeStyleRef.current = strokeStyle
-  }, [strokeStyle])
-
-  useEffect(() => {
-    lineWidthRef.current = lineWidth
-  }, [lineWidth])
-
-  useEffect(() => {
+  React.useEffect(() => {
     if (typeof window === 'undefined') {
-      return
+      return undefined
     }
 
     const canvas = canvasRef.current
-    if (!canvas) return
-
-    const context = canvas.getContext('2d')
-    if (!context) return
-
-    ctxRef.current = context
-
-    const applyStrokeStyle = () => {
-      const ctx = ctxRef.current
-      if (!ctx) return
-      ctx.lineCap = 'round'
-      ctx.lineJoin = 'round'
-      ctx.strokeStyle = strokeStyleRef.current
-      ctx.lineWidth = lineWidthRef.current * dprRef.current
+    if (!canvas) {
+      return undefined
     }
 
-    const rect = () => canvas.getBoundingClientRect()
+    const updateCanvasSize = () => {
+      if (!canvasRef.current) {
+        return
+      }
+      const rect = canvasRef.current.getBoundingClientRect()
+      const width = rect.width || 0
+      const height = rect.height || 0
 
-    const resize = () => {
-      dprRef.current = Math.min(window.devicePixelRatio || 1, MAX_DPR)
-      const { width, height } = rect()
-      const nextWidth = Math.max(Math.floor(width * dprRef.current), 1)
-      const nextHeight = Math.max(Math.floor(height * dprRef.current), 1)
-      if (canvas.width !== nextWidth) {
-        canvas.width = nextWidth
+      const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR)
+      const nextWidth = Math.max(1, Math.round(width * dpr))
+      const nextHeight = Math.max(1, Math.round(height * dpr))
+      if (canvasRef.current.width !== nextWidth) {
+        canvasRef.current.width = nextWidth
       }
-      if (canvas.height !== nextHeight) {
-        canvas.height = nextHeight
+      if (canvasRef.current.height !== nextHeight) {
+        canvasRef.current.height = nextHeight
       }
-      context.setTransform(dprRef.current, 0, 0, dprRef.current, 0, 0)
-      context.clearRect(0, 0, canvas.width, canvas.height)
-      applyStrokeStyle()
     }
 
-    resize()
+    updateCanvasSize()
 
     let resizeFrame = 0
-    const onResize = () => {
-      if (resizeFrame) cancelAnimationFrame(resizeFrame)
-      resizeFrame = requestAnimationFrame(() => {
+    const handleResize = () => {
+      if (resizeFrame) {
+        window.cancelAnimationFrame(resizeFrame)
+      }
+      resizeFrame = window.requestAnimationFrame(() => {
         resizeFrame = 0
-        resize()
+        updateCanvasSize()
       })
     }
 
-    window.addEventListener('resize', onResize)
+    window.addEventListener('resize', handleResize)
 
-    const toPoint = (event: PointerEvent): StrokePoint => {
-      const bounds = rect()
-      const x = event.clientX - bounds.left
-      const y = event.clientY - bounds.top
-      let pressure = event.pressure
-      if (pressure === undefined) {
-        pressure = event.buttons ? 0.5 : 0
-      } else if (pressure === 0 && event.buttons) {
-        pressure = 0.5
+    const resolvePoint = (event: PointerEvent): StrokePoint | null => {
+      const canvasElement = canvasRef.current
+      if (!canvasElement) {
+        return null
       }
+      const rect = canvasElement.getBoundingClientRect()
+      const width = rect.width || 0
+      const height = rect.height || 0
+      if (width <= 0 || height <= 0) {
+        return null
+      }
+
+      const normalizedX = clamp01((event.clientX - rect.left) / width)
+      const normalizedY = clamp01((event.clientY - rect.top) / height)
+      const pressure = resolvePressure(event)
+
       return {
-        x,
-        y,
+        x: normalizedX,
+        y: normalizedY,
         pressure,
         t: event.timeStamp,
       }
     }
 
-    const drawSegment = (from: StrokePoint, to: StrokePoint) => {
-      const ctx = ctxRef.current
-      if (!ctx) return
-      applyStrokeStyle()
-      ctx.beginPath()
-      ctx.moveTo(from.x, from.y)
-      const mx = (from.x + to.x) / 2
-      const my = (from.y + to.y) / 2
-      ctx.quadraticCurveTo(from.x, from.y, mx, my)
-      ctx.stroke()
-    }
+    const finishStroke = (event?: PointerEvent) => {
+      if (!isDrawingRef.current) {
+        return
+      }
 
-    const finishStroke = () => {
-      if (!isDrawingRef.current) return
+      const pointerId = pointerIdRef.current
+      if (pointerId !== null && canvas.hasPointerCapture?.(pointerId)) {
+        try {
+          canvas.releasePointerCapture(pointerId)
+        } catch {
+          // Ignore capture release errors (e.g., Safari quirks)
+        }
+      }
+
+      let terminalPoint = lastPointRef.current
+      if (event) {
+        const maybePoint = resolvePoint(event)
+        if (maybePoint) {
+          terminalPoint = maybePoint
+        }
+      }
+
+      if (terminalPoint && lastSmoothedRef.current && segmentCallbackRef.current) {
+        const from = lastSmoothedRef.current
+        const to = terminalPoint
+        const pressure = to.pressure > 0 ? to.pressure : from.pressure || DEFAULT_PRESSURE
+        segmentCallbackRef.current({
+          from: { ...from, t: to.t },
+          to: { ...to },
+          pressure,
+          t: to.t,
+        })
+      }
+
       isDrawingRef.current = false
+      pointerIdRef.current = null
       lastPointRef.current = null
+      lastSmoothedRef.current = null
       endCallbackRef.current?.()
     }
 
@@ -170,56 +198,88 @@ const StrokeCaptureCanvas = ({
       if (event.pointerType === 'mouse' && event.button !== 0) {
         return
       }
+      if (isDrawingRef.current && pointerIdRef.current !== event.pointerId) {
+        return
+      }
+
+      const point = resolvePoint(event)
+      if (!point) {
+        return
+      }
+
       event.preventDefault()
-      canvas.setPointerCapture(event.pointerId)
-      const point = toPoint(event)
+
+      pointerIdRef.current = event.pointerId
       isDrawingRef.current = true
       lastPointRef.current = point
-      applyStrokeStyle()
+      lastSmoothedRef.current = point
+
+      try {
+        canvas.setPointerCapture(event.pointerId)
+      } catch {
+        // ignore pointer capture failures (e.g., Safari)
+      }
+
       startCallbackRef.current?.(point)
     }
 
     const handlePointerMove = (event: PointerEvent) => {
-      if (!isDrawingRef.current) return
-      event.preventDefault()
-      const point = toPoint(event)
-      const last = lastPointRef.current
-      if (!last) {
-        lastPointRef.current = point
+      if (!isDrawingRef.current || pointerIdRef.current !== event.pointerId) {
         return
       }
-      drawSegment(last, point)
-      segmentCallbackRef.current?.({
-        from: last,
-        to: point,
-        pressure: point.pressure,
+
+      const point = resolvePoint(event)
+      if (!point) {
+        return
+      }
+
+      const lastPoint = lastPointRef.current
+      if (!lastPoint) {
+        lastPointRef.current = point
+        lastSmoothedRef.current = point
+        return
+      }
+
+      const smoothingStart = lastSmoothedRef.current ?? lastPoint
+      const midPoint: StrokePoint = {
+        x: (lastPoint.x + point.x) / 2,
+        y: (lastPoint.y + point.y) / 2,
+        pressure: point.pressure > 0 ? point.pressure : lastPoint.pressure || DEFAULT_PRESSURE,
         t: point.t,
-      })
+      }
+
+      if (segmentCallbackRef.current) {
+        const segment: StrokeSegment = {
+          from: {
+            x: smoothingStart.x,
+            y: smoothingStart.y,
+            pressure: smoothingStart.pressure,
+            t: lastPoint.t,
+          },
+          to: midPoint,
+          pressure: midPoint.pressure,
+          t: point.t,
+        }
+        segmentCallbackRef.current(segment)
+      }
+
       lastPointRef.current = point
+      lastSmoothedRef.current = midPoint
     }
 
     const handlePointerUp = (event: PointerEvent) => {
-      if (!isDrawingRef.current) return
-      event.preventDefault()
-      if (canvas.hasPointerCapture?.(event.pointerId)) {
-        try {
-          canvas.releasePointerCapture(event.pointerId)
-        } catch {
-          // ignore release errors
-        }
+      if (!isDrawingRef.current || pointerIdRef.current !== event.pointerId) {
+        return
       }
-      finishStroke()
+      event.preventDefault()
+      finishStroke(event)
     }
 
     const handlePointerCancel = (event: PointerEvent) => {
-      if (canvas.hasPointerCapture?.(event.pointerId)) {
-        try {
-          canvas.releasePointerCapture(event.pointerId)
-        } catch {
-          // ignore release errors
-        }
+      if (pointerIdRef.current !== event.pointerId) {
+        return
       }
-      finishStroke()
+      finishStroke(event)
     }
 
     canvas.addEventListener('pointerdown', handlePointerDown, { passive: false })
@@ -229,15 +289,15 @@ const StrokeCaptureCanvas = ({
     canvas.addEventListener('pointerleave', handlePointerCancel)
 
     return () => {
-      window.removeEventListener('resize', onResize)
-      if (resizeFrame) cancelAnimationFrame(resizeFrame)
+      window.removeEventListener('resize', handleResize)
+      if (resizeFrame) {
+        window.cancelAnimationFrame(resizeFrame)
+      }
       canvas.removeEventListener('pointerdown', handlePointerDown)
       canvas.removeEventListener('pointermove', handlePointerMove)
       canvas.removeEventListener('pointerup', handlePointerUp)
       canvas.removeEventListener('pointercancel', handlePointerCancel)
       canvas.removeEventListener('pointerleave', handlePointerCancel)
-      finishStroke()
-      ctxRef.current = null
     }
   }, [])
 
@@ -245,9 +305,15 @@ const StrokeCaptureCanvas = ({
     <canvas
       ref={canvasRef}
       className={className}
-      style={{ ...style, touchAction: 'none' }}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'block',
+        touchAction: 'none',
+        pointerEvents: 'auto',
+        background: 'transparent',
+        ...style,
+      }}
     />
   )
 }
-
-export default StrokeCaptureCanvas


### PR DESCRIPTION
## Summary
- add a StrokeCaptureCanvas overlay that normalizes pointer input, clamps DPR, and emits smoothed stroke segments to consumers
- wire InkFieldHost to the canvas, instantiate the InkField, and stream texture/intensity updates into the Dreamdust context while tracking renderer support

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing workspace type errors around three.js and renderer command types)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3e5f11808328b9f709164ab5527e