### PR TITLE
feat: refine Dreamdust fragment ink fallback

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -90,7 +90,9 @@ void main() {
   vec3 inkTint = vec3(0.0);
   float inkMix = 0.0;
   float inkSizeBoost = 0.0;
-  if (uVertexInkOk > 0.5 && uInkIntensity > 0.0) {
+  bool vertexInkSupported = uVertexInkOk > 0.5;
+  bool applyVertexInk = vertexInkSupported && uInkIntensity > 0.0;
+  if (applyVertexInk) {
     DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
     float localIntensity = inkSample.intensity * uInkIntensity;
     if (localIntensity > 1e-5) {
@@ -169,7 +171,9 @@ void main() {
     color = dreamdustApplyInkTint(color, vInkTint, vInkMix);
   }
 
-  if (uVertexInkOk <= 0.5 && uInkIntensity > 0.0) {
+  bool vertexInkSupported = uVertexInkOk > 0.5;
+  bool applyFragmentInk = !vertexInkSupported && uInkIntensity > 0.0;
+  if (applyFragmentInk) {
     DreamdustInkSample fragInk = dreamdustSampleInk(uInkTex, vInkUv);
     float localIntensity = fragInk.intensity * uInkIntensity;
     if (localIntensity > 1e-5) {


### PR DESCRIPTION
## Summary
- gate Dreamdust vertex ink sampling behind a boolean flag so the fragment-only fallback is explicit when vertex textures are unavailable

## Testing
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: existing repository type errors in canvas-r3f and store packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cb43d906d48328b39ff341dbe9a83c