### PR TITLE
PR-13 — Caps/debug route

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/debug/caps/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/debug/caps/page.tsx
@@ -30,7 +30,7 @@ function formatRange(range: Float32Array): string {
   return `[${Array.from(range).map((value) => value.toFixed(2)).join(', ')}]`
 }
 
-export default function CapsPage(): JSX.Element {
+export default function Page(): JSX.Element {
   const [{ caps, vertexInkSupported, error }, setCapsState] =
     React.useState<CapsState>({
       caps: null,


### PR DESCRIPTION
## Summary
- add a client-only /debug/caps route that inspects WebGL caps when available
- report device pixel ratio, a simple FPS estimate, and vertex ink texture support alongside caps data

## Testing
- `corepack enable`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint` *(fails: existing lint errors in unrelated files)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Next.js font downloads blocked in sandbox)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cb47e5cc188328a283aa8d09de3d58