### PR TITLE
feat(dreamdust): merge ink interaction + GLSL fixes into feature

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -557,9 +557,10 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     setUniform('uNoiseScale', 0.0025)
     setUniform('uNoiseSpeed', 0.24)
     setUniform('uDriftAmp', 16)
-    setUniform('uSizeGain', 1)
+    // Ink gains tuned for quick, readable reactions
+    setUniform('uSizeGain', 0.35)
     setUniform('uOffsetGain', 1)
-    setUniform('uTintGain', 1)
+    setUniform('uTintGain', 0.08)
   }, [setUniform])
 
   React.useEffect(() => {

--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -1216,6 +1216,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             padding: '10px 12px',
             borderRadius: 8,
             pointerEvents: 'auto',
+            // Ensure debug UI renders above InkField overlay and page overlays
+            zIndex: 4,
             width: 220,
           }}
         >

--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -329,6 +329,17 @@ function PointsMesh({
     loggedAttrsRef.current = true
   }, [])
 
+  // Log instance count once (fallback path)
+  React.useEffect(() => {
+    const g = geomRef.current
+    if (!g) return
+    try {
+      const pos = g.getAttribute('position') as THREE.BufferAttribute | undefined
+      const count = pos ? pos.count : 0
+      if (count > 0) console.log('[PC] instances:', count)
+    } catch {}
+  }, [])
+
   React.useEffect(() => {
     if (!onMaterialValid) return
     let raf = 0
@@ -556,11 +567,11 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     setUniform('uDepthBias', 0.14)
     setUniform('uNoiseScale', 0.0025)
     setUniform('uNoiseSpeed', 0.24)
-    setUniform('uDriftAmp', 16)
-    // Ink gains tuned for quick, readable reactions
-    setUniform('uSizeGain', 0.35)
-    setUniform('uOffsetGain', 1)
-    setUniform('uTintGain', 0.08)
+    // Stronger contrast on first draw: halve base drift, boost ink gains
+    setUniform('uDriftAmp', 8)
+    setUniform('uSizeGain', 1.0)
+    setUniform('uOffsetGain', 5.0)
+    setUniform('uTintGain', 0.2)
   }, [setUniform])
 
   React.useEffect(() => {
@@ -579,6 +590,24 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   React.useEffect(() => {
     updateInkTexture(inkTex)
   }, [inkTex, updateInkTexture])
+
+  // One-time debug of ink mapping and caps at first stroke
+  const loggedInkInfoRef = React.useRef(false)
+  React.useEffect(() => {
+    if (loggedInkInfoRef.current) return
+    if (inkIntensity > 0.0) {
+      try {
+        const vtx = uniforms.uVertexInkOk?.value ?? 0
+        const vp = uniforms.uViewport?.value ?? [0, 0]
+        console.log('[PC] ink debug', {
+          vertexInkOk: vtx > 0.5,
+          uViewport: vp,
+          inkIntensity,
+        })
+      } catch {}
+      loggedInkInfoRef.current = true
+    }
+  }, [inkIntensity, uniforms])
 
   React.useEffect(() => {
     setUniform('uInkIntensity', inkIntensity)
@@ -871,6 +900,15 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     }
   }, [sceneId])
 
+  // Reduce console noise when prebaked present
+  React.useEffect(() => {
+    if (prebakedStatus === 'present') {
+      try {
+        console.log('[PC] prebaked present; using positions/colors, fallback images not required')
+      } catch {}
+    }
+  }, [prebakedStatus])
+
   // Debug panel state (optional via ?debug=1)
   const [debugVisible, setDebugVisible] = React.useState(false)
   const [ui, setUi] = React.useState<{
@@ -981,6 +1019,21 @@ export default function PointCloudStage(props: PointCloudStageProps) {
 
     return { positions: outPos, colors: outCol, keptCount: outCount, cap }
   }, [pointBudget, prebaked, ui.keepRatio])
+
+  // Log a single instances line after decimation
+  const loggedInstancesRef = React.useRef(false)
+  React.useEffect(() => {
+    if (loggedInstancesRef.current) return
+    const count = renderBuffers
+      ? Math.floor(renderBuffers.positions.length / 3)
+      : prebaked
+        ? prebaked.count
+        : 0
+    if (count > 0) {
+      console.log('[PC] instances:', count)
+      loggedInstancesRef.current = true
+    }
+  }, [prebaked, renderBuffers])
 
   // Compose world-space debug flips with the PCA quaternion so toggles work live
   const appliedQuaternion = React.useMemo(() => {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -82,27 +82,34 @@ void main() {
   }
 
   vec4 worldPos = dreamdustUnproject(aUv, depthNorm);
-  worldPos.xyz += dreamdustDrift(worldPos.xyz, uTime, uNoiseScale, uNoiseSpeed, uDriftAmp);
+
+  // Ink sampling comes first to modulate drift near strokes
+  vec3 inkTint = vec3(0.0);
+  float inkMix = 0.0;
+  float inkSizeBoost = 0.0;
+  float localIntensity = 0.0;
+  bool vertexInkSupported = uVertexInkOk > 0.5;
+  bool applyVertexInk = vertexInkSupported && uInkIntensity > 0.0;
+  DreamdustInkSample inkS;
+  if (applyVertexInk) {
+    inkS = dreamdustSampleInk(uInkTex, aUv);
+    localIntensity = inkS.intensity * uInkIntensity;
+  }
+
+  // Modulate drift amplitude by local ink intensity for a smokey swirl
+  float driftAmp = uDriftAmp * (1.0 + localIntensity * 0.4);
+  worldPos.xyz += dreamdustDrift(worldPos.xyz, uTime, uNoiseScale, uNoiseSpeed, driftAmp);
 
   vec4 viewPos = viewMatrix * worldPos;
   float viewDist = max(1e-3, -viewPos.z);
 
-  vec3 inkTint = vec3(0.0);
-  float inkMix = 0.0;
-  float inkSizeBoost = 0.0;
-  bool vertexInkSupported = uVertexInkOk > 0.5;
-  bool applyVertexInk = vertexInkSupported && uInkIntensity > 0.0;
-  if (applyVertexInk) {
-    DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
-    float localIntensity = inkSample.intensity * uInkIntensity;
-    if (localIntensity > 1e-5) {
-      float pxScale = viewDist / max(1e-3, uFocal);
-      vec2 offsetView = inkSample.offset * (uInkOffsetGain * localIntensity * pxScale);
-      viewPos.xy += offsetView;
-      inkSizeBoost = inkSample.swell * localIntensity * uInkSizeGain;
-      inkTint = inkSample.tint;
-      inkMix = localIntensity * uInkTintGain;
-    }
+  if (applyVertexInk && localIntensity > 1e-5) {
+    float pxScale = viewDist / max(1e-3, uFocal);
+    vec2 offsetView = inkS.offset * (uInkOffsetGain * localIntensity * pxScale);
+    viewPos.xy += offsetView;
+    inkSizeBoost = inkS.swell * localIntensity * uInkSizeGain;
+    inkTint = inkS.tint;
+    inkMix = localIntensity * uInkTintGain;
   }
 
   float atten = clamp(uFocal / viewDist, uMinSize, uMaxSize);

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkField.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkField.ts
@@ -127,7 +127,7 @@ export const createInkField = (size = 128, dpr = 1): InkField => {
 
     const resolvedPoints = points.map(resolvePoint);
     const mode = determineCoordinateMode(resolvedPoints);
-    const baseRadius = Math.max(resolvedSize * 0.08, 1);
+    const baseRadius = Math.max(resolvedSize * 0.10, 1);
     const radius = Math.max(baseRadius * normalizedPressure, 0.5);
     const step = Math.max(radius * 0.5, 1);
 

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -20,7 +20,7 @@ type CanvasTextureLike = {
 const FIELD_SIZE = 128
 const MAX_DPR = 1.5
 const UPLOAD_HZ = 60
-const DECAY_BASE = 0.96
+const DECAY_BASE = 0.98
 const INTENSITY_EPSILON = 0.01
 const INTENSITY_IDLE_ZERO_MS = 2400
 const DEFAULT_PRESSURE = 0.5
@@ -50,7 +50,7 @@ export function InkFieldHost(): React.JSX.Element {
   const lastStrokeRef = React.useRef(0)
   const intensityRef = React.useRef(0)
   const vertexInkOkRef = React.useRef<boolean | null>(null)
-  const [drawEnabled, setDrawEnabled] = React.useState(false)
+  const [drawEnabled, setDrawEnabled] = React.useState(true)
 
   const handleStrokeStart = React.useCallback(
     (_point: StrokePoint) => {
@@ -261,12 +261,12 @@ export function InkFieldHost(): React.JSX.Element {
         position: 'absolute',
         inset: 0,
         zIndex: 2,
-        // By default, allow events only on the explicit controls below
-        pointerEvents: 'none',
+        // Default to capturing input for drawing
+        pointerEvents: 'auto',
       }}
     >
       <StrokeCaptureCanvas
-        enabled={drawEnabled}
+        enabled={true}
         onStrokeStart={handleStrokeStart}
         onStrokeSegment={handleStrokeSegment}
       />

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -51,6 +51,9 @@ export function InkFieldHost(): React.JSX.Element {
   const intensityRef = React.useRef(0)
   const vertexInkOkRef = React.useRef<boolean | null>(null)
   const [drawEnabled, setDrawEnabled] = React.useState(true)
+  const [showHeatmap, setShowHeatmap] = React.useState(false)
+  const heatmapRef = React.useRef<HTMLCanvasElement | null>(null)
+  const loggedInkOnceRef = React.useRef(false)
 
   const handleStrokeStart = React.useCallback(
     (_point: StrokePoint) => {
@@ -59,6 +62,20 @@ export function InkFieldHost(): React.JSX.Element {
       if (intensityRef.current !== 1) {
         intensityRef.current = 1
         setInkIntensity(1)
+      }
+      // One-time debug of caps/viewport/intensity on first stroke
+      if (!loggedInkOnceRef.current) {
+        try {
+          const state = getR3FStateOrNull()
+          const vpW = state?.viewport.width ?? 0
+          const vpH = state?.viewport.height ?? 0
+          console.log('[PC] ink debug (host)', {
+            vertexInkOk: !!vertexInkOkRef.current,
+            uViewport: [vpW, vpH],
+            inkIntensity: 1,
+          })
+        } catch {}
+        loggedInkOnceRef.current = true
       }
     },
     [setInkIntensity],
@@ -254,6 +271,32 @@ export function InkFieldHost(): React.JSX.Element {
     }
   }, [setInkIntensity, setInkTex])
 
+  // Heatmap preview of the ink texture (scaled up for visibility)
+  React.useEffect(() => {
+    if (!showHeatmap) return
+    if (typeof window === 'undefined') return
+    let raf = 0
+    const draw = () => {
+      const canvas = heatmapRef.current
+      const tex = textureRef.current as unknown as { image?: HTMLCanvasElement | OffscreenCanvas }
+      if (canvas && tex?.image) {
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          const src = tex.image as HTMLCanvasElement
+          const scale = 2
+          canvas.width = 128 * scale
+          canvas.height = 128 * scale
+          ;(ctx as any).imageSmoothingEnabled = false
+          ctx.clearRect(0, 0, canvas.width, canvas.height)
+          ctx.drawImage(src, 0, 0, 128, 128, 0, 0, 128 * scale, 128 * scale)
+        }
+      }
+      raf = window.requestAnimationFrame(draw)
+    }
+    raf = window.requestAnimationFrame(draw)
+    return () => window.cancelAnimationFrame(raf)
+  }, [showHeatmap])
+
   return (
     <div
       aria-hidden
@@ -270,6 +313,19 @@ export function InkFieldHost(): React.JSX.Element {
         onStrokeStart={handleStrokeStart}
         onStrokeSegment={handleStrokeSegment}
       />
+      {showHeatmap && (
+        <canvas
+          ref={heatmapRef}
+          style={{
+            position: 'absolute',
+            left: 12,
+            bottom: 12,
+            zIndex: 3,
+            border: '1px solid rgba(255,255,255,0.2)',
+            background: 'rgba(0,0,0,0.3)',
+          }}
+        />
+      )}
       {/* Simple Draw toggle; lives above canvas and canvas overlay */}
       <div
         style={{
@@ -278,7 +334,7 @@ export function InkFieldHost(): React.JSX.Element {
           bottom: 12,
           zIndex: 3,
           pointerEvents: 'auto',
-        }}
+          }}
       >
         <button
           type="button"
@@ -295,6 +351,23 @@ export function InkFieldHost(): React.JSX.Element {
           }}
         >
           {drawEnabled ? 'Draw: On' : 'Draw: Off'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowHeatmap((v) => !v)}
+          style={{
+            marginLeft: 8,
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: 12,
+            padding: '6px 10px',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.25)',
+            background: showHeatmap ? 'rgba(32,96,192,0.85)' : 'rgba(0,0,0,0.55)',
+            color: '#fff',
+            cursor: 'pointer',
+          }}
+        >
+          {showHeatmap ? 'Heatmap: On' : 'Heatmap: Off'}
         </button>
       </div>
     </div>

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -50,6 +50,7 @@ export function InkFieldHost(): React.JSX.Element {
   const lastStrokeRef = React.useRef(0)
   const intensityRef = React.useRef(0)
   const vertexInkOkRef = React.useRef<boolean | null>(null)
+  const [drawEnabled, setDrawEnabled] = React.useState(false)
 
   const handleStrokeStart = React.useCallback(
     (_point: StrokePoint) => {
@@ -260,13 +261,42 @@ export function InkFieldHost(): React.JSX.Element {
         position: 'absolute',
         inset: 0,
         zIndex: 2,
+        // By default, allow events only on the explicit controls below
         pointerEvents: 'none',
       }}
     >
       <StrokeCaptureCanvas
+        enabled={drawEnabled}
         onStrokeStart={handleStrokeStart}
         onStrokeSegment={handleStrokeSegment}
       />
+      {/* Simple Draw toggle; lives above canvas and canvas overlay */}
+      <div
+        style={{
+          position: 'absolute',
+          right: 12,
+          bottom: 12,
+          zIndex: 3,
+          pointerEvents: 'auto',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setDrawEnabled((v) => !v)}
+          style={{
+            fontFamily: 'var(--font-mono, monospace)',
+            fontSize: 12,
+            padding: '6px 10px',
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.25)',
+            background: drawEnabled ? 'rgba(16,160,32,0.85)' : 'rgba(0,0,0,0.55)',
+            color: '#fff',
+            cursor: 'pointer',
+          }}
+        >
+          {drawEnabled ? 'Draw: On' : 'Draw: Off'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
@@ -19,6 +19,11 @@ export type StrokeSegment = {
 export type StrokeCaptureCanvasProps = {
   className?: string
   style?: React.CSSProperties
+  /**
+   * When false, the canvas ignores pointer input (pointer-events: none).
+   * When true, it accepts input and switches pointer capture while drawing.
+   */
+  enabled?: boolean
   onStrokeStart?(point: StrokePoint): void
   onStrokeSegment?(segment: StrokeSegment): void
   onStrokeEnd?(): void
@@ -53,6 +58,7 @@ const resolvePressure = (event: PointerEvent): number => {
 export function StrokeCaptureCanvas({
   className,
   style,
+  enabled = false,
   onStrokeStart,
   onStrokeSegment,
   onStrokeEnd,
@@ -198,6 +204,10 @@ export function StrokeCaptureCanvas({
       if (event.pointerType === 'mouse' && event.button !== 0) {
         return
       }
+      // Respect gating: ignore pointer when disabled
+      if (!enabled) {
+        return
+      }
       if (isDrawingRef.current && pointerIdRef.current !== event.pointerId) {
         return
       }
@@ -215,6 +225,7 @@ export function StrokeCaptureCanvas({
       lastSmoothedRef.current = point
 
       try {
+        // Capture only after explicit start (left button / enabled)
         canvas.setPointerCapture(event.pointerId)
       } catch {
         // ignore pointer capture failures (e.g., Safari)
@@ -310,7 +321,8 @@ export function StrokeCaptureCanvas({
         height: '100%',
         display: 'block',
         touchAction: 'none',
-        pointerEvents: 'auto',
+        // Gate pointer interactions: default none; enable only when armed/drawing
+        pointerEvents: isDrawingRef.current || enabled ? 'auto' : 'none',
         background: 'transparent',
         ...style,
       }}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -136,17 +136,7 @@ vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
 }
 `
 
-// Optional map for consumers expecting a chunk registry
-export const glslChunks = {
-  noise: DREAMDUST_NOISE_CHUNK,
-  drift: DREAMDUST_DRIFT_CHUNK,
-  inkSample: DREAMDUST_INK_SAMPLE_CHUNK,
-  depthFade: DREAMDUST_DEPTH_FADE_CHUNK,
-  pointShape: DREAMDUST_POINT_SHAPE_CHUNK,
-  color: DREAMDUST_COLOR_CHUNK,
-} as const
-
-export type GlslChunkKey = keyof typeof glslChunks
+// (registry removed; DREAMDUST_* chunks are imported directly by consumers)
 /**
  * Shared Dreamdust GLSL chunks for shader composition.
  *
@@ -246,31 +236,8 @@ float dd_noise2Fbm(vec2 dd_p, float dd_lacunarity, float dd_gain, int dd_octaves
   return dd_sum;
 }
 
-<<<<<<< Updated upstream
 #define DD_NOISE2_FBM(p, lacunarity, gain, octaves) dd_noise2Fbm(p, lacunarity, gain, octaves)
 `;
-=======
-float dd_noise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n00 = dreamdustHash(vec3(i, 0.0));
-  float n10 = dreamdustHash(vec3(i + vec2(1.0, 0.0), 0.0));
-  float n01 = dreamdustHash(vec3(i + vec2(0.0, 1.0), 0.0));
-  float n11 = dreamdustHash(vec3(i + vec2(1.0), 0.0));
-
-  float nx0 = mix(n00, n10, f.x);
-  float nx1 = mix(n01, n11, f.x);
-
-  return mix(nx0, nx1, f.y);
-}
-
-float dd_noise2(vec3 p) {
-  return dd_noise2(p.xy + vec2(p.z));
-}
-`
->>>>>>> Stashed changes
 
 /**
  * Converts absolute screen-space pixels into clip-space coordinates.
@@ -284,7 +251,6 @@ vec2 dd_screenPxToClip(vec2 dd_screenPx) {
   dd_clip.y = -dd_clip.y;
   return dd_clip;
 }
-<<<<<<< Updated upstream
 
 #define DD_SCREEN_PX_TO_CLIP(px) dd_screenPxToClip(px)
 `;
@@ -305,28 +271,6 @@ float dd_depthAlpha(float dd_distNorm, float dd_k) {
 
 #define DD_DEPTH_ALPHA(distNorm, k) dd_depthAlpha(distNorm, k)
 `;
-=======
-`
-
-export const DREAMDUST_INK_SAMPLE_CHUNK = /* glsl */ `
-struct DreamdustInkSample {
-  vec2 offset;
-  float swell;
-  float intensity;
-  vec3 tint;
-};
-
-DreamdustInkSample dreamdustSampleInk(sampler2D tex, vec2 uv) {
-  vec4 ink = texture2D(tex, uv);
-  DreamdustInkSample inkS;
-  inkS.offset = ink.rg * 2.0 - 1.0;
-  inkS.swell = ink.b;
-  inkS.intensity = ink.a;
-  inkS.tint = ink.rgb;
-  return inkS;
-}
-`
->>>>>>> Stashed changes
 
 export const glslChunks = {
   sat: DD_SAT,
@@ -337,34 +281,4 @@ export const glslChunks = {
   depthAlpha: DD_DEPTH_ALPHA,
 } as const;
 
-<<<<<<< Updated upstream
 export type GlslChunkKey = keyof typeof glslChunks;
-=======
-float dd_depthAlpha(float depthNorm, float bias) {
-  if (bias <= 0.0) {
-    return 1.0;
-  }
-  return clamp(exp(-depthNorm * bias), 0.0, 1.0);
-}
-
-#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
-`
-
-export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `
-float dreamdustPointShape(vec2 coord) {
-  vec2 delta = coord * 2.0 - 1.0;
-  float r2 = dot(delta, delta);
-  float core = smoothstep(1.0, 0.0, r2);
-  float feather = smoothstep(1.0, 0.6, r2);
-  return core * feather;
-}
-`
-
-export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
-vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
-  float mixAmt = clamp(amount, 0.0, 1.0);
-  vec3 tinted = baseColor + tintColor * mixAmt;
-  return mix(baseColor, tinted, mixAmt);
-}
-`
->>>>>>> Stashed changes


### PR DESCRIPTION
Changes: default Draw ON; ~2–3s decay; larger brush; ink‑driven drift; stronger stroke gains; single instances log; ink debug + Heatmap toggle; prebaked note.
Baseline: install OK; typecheck thin-slice ran; lint ran (warn‑only); build OK; smoke OK.
Manual verify: open /quiz/archetype-v1?pc=scene-02&debug=1; strokes react immediately; instances log prints once; Heatmap toggle available.