### PR TITLE
Expose typed camera helpers for Dreamdust

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/anim/camera.ts
@@ -26,12 +26,19 @@ export function easeInOutCubic(t: number) {
  *   To fit a sphere of radius `r`, ensure `r <= d * tan(fov / 2)` → `d >= r / tan(fov / 2)`.
  *   Horizontal fit uses `tan(fov / 2) * aspect`, so take the tighter (max) constraint.
  */
-export function fitPerspective(
+export type FitPerspective = (
   fovDeg: number,
   radius: number,
   aspect: number,
-  margin = 1.1
-): number {
+  margin?: number
+) => number
+
+export const fitPerspective: FitPerspective = (
+  fovDeg,
+  radius,
+  aspect,
+  margin = 1.1,
+) => {
   const safeFovDeg = Math.min(179.999, Math.max(1e-3, fovDeg))
   const safeAspect = Math.max(FIT_EPSILON, aspect)
   const safeMargin = Math.max(0, margin)
@@ -131,17 +138,21 @@ export function applyPerspectiveFit(
  * Values smaller than one retain their proportional scale, while larger radii are
  * clamped to avoid excessively small depth precision values.
  */
-export function depthNormScaleFromRadius(radius: number): number {
+export type DepthNormScaleFromRadius = (radius: number) => number
+
+export const depthNormScaleFromRadius: DepthNormScaleFromRadius = (radius) => {
   return 1 / Math.max(1, radius)
 }
 
-export function tweenCamera({
+export type TweenCamera = (params: TweenCameraParams) => Promise<void>
+
+export const tweenCamera: TweenCamera = ({
   camera,
   to,
   durationMs = 1000,
   easing = easeInOutCubic,
   cancelRef,
-}: TweenCameraParams) {
+}) => {
   const fromPos = camera.position.clone()
   const fromLook = camera
     .position

--- a/apps/cryptiq-mindmap-demo/app/components/anim/r3fSafe.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/anim/r3fSafe.ts
@@ -19,3 +19,14 @@ export function getR3FStateOrNull(): RootState | null {
   }
 }
 
+export type WithR3FCallback<T> = (state: RootState) => T
+export type WithR3FFallback<T> = () => T
+
+export function withR3F<T>(callback: WithR3FCallback<T>, fallback?: WithR3FFallback<T>): T | null {
+  const state = getR3FStateOrNull()
+  if (state) {
+    return callback(state)
+  }
+  return fallback ? fallback() : null
+}
+


### PR DESCRIPTION
## Summary
- add explicit typings for the perspective fit and depth normalization helpers
- export a typed tweenCamera signature for downstream callers
- introduce a typed withR3F helper to safely access the current RootState

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2fabc0048328954cea886b6226a8