### PR TITLE
feat(dreamdust): consolidate caps detection and add single-shot DPR/caps log

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -18,8 +18,9 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass'
 import { applyPerspectiveFit, depthNormScaleFromRadius } from './anim/camera'
 import { createDreamdustMaterial } from './dreamdust/DreamdustMaterial'
-import { detectVertexTextureSupport } from './dreamdust/capabilities'
+import { getDreamdustCaps } from './dreamdust/capabilities'
 import { useDreamdustCtx } from './dreamdust/context'
+import { logOnce } from './dreamdust/metrics'
 import { useDreamdustUniforms } from './dreamdust/useDreamdustUniforms'
 import { applyDprClamp, pointCap } from './pointcloud/budget'
 
@@ -337,7 +338,7 @@ function PointsMesh({
       const pos = g.getAttribute('position') as THREE.BufferAttribute | undefined
       const count = pos ? pos.count : 0
       if (count > 0) console.log('[PC] instances:', count)
-    } catch {}
+    } catch { /* noop */ }
   }, [])
 
   React.useEffect(() => {
@@ -356,7 +357,7 @@ function PointsMesh({
         // Guard log to surface shader-compile stalls early during bring-up
         try {
           console.warn('[PC] material program not ready yet; waiting…')
-        } catch {}
+        } catch { /* noop */ }
       }
       raf = requestAnimationFrame(check)
     }
@@ -437,7 +438,7 @@ function BloomPass({
     return () => {
       try {
         comp.dispose()
-      } catch {}
+      } catch { /* noop */ }
       composerRef.current = null
     }
   }, [gl, scene, camera, strength, radius, threshold])
@@ -604,7 +605,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
           uViewport: vp,
           inkIntensity,
         })
-      } catch {}
+      } catch { /* noop */ }
       loggedInkInfoRef.current = true
     }
   }, [inkIntensity, uniforms])
@@ -670,7 +671,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             const cbuf = await cr.arrayBuffer()
             colors = new Uint8Array(cbuf)
           }
-        } catch {}
+        } catch { /* noop */ }
         if (!cancelled) {
           console.log('[PC] prebaked positions', {
             bytes: buf.byteLength,
@@ -905,7 +906,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     if (prebakedStatus === 'present') {
       try {
         console.log('[PC] prebaked present; using positions/colors, fallback images not required')
-      } catch {}
+      } catch { /* noop */ }
     }
   }, [prebakedStatus])
 
@@ -948,13 +949,13 @@ export default function PointCloudStage(props: PointCloudStageProps) {
       if (p && p.get('debug') === '1') setDebugVisible(true)
       const saved = typeof window !== 'undefined' ? window.localStorage.getItem('pcDebug') : null
       if (saved) setUi({ ...ui, ...JSON.parse(saved) })
-    } catch {}
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    } catch { /* noop */ }
+     
   }, [])
   React.useEffect(() => {
     try {
       if (typeof window !== 'undefined') window.localStorage.setItem('pcDebug', JSON.stringify(ui))
-    } catch {}
+    } catch { /* noop */ }
   }, [
     ui.thickness,
     ui.pointSizeScale,
@@ -1144,8 +1145,19 @@ export default function PointCloudStage(props: PointCloudStageProps) {
           console.log('[PC] pointer down', e.clientX, e.clientY)
         }}
         onCreated={({ gl }) => {
-          const clampedDpr = applyDprClamp(gl, 2)
-          console.log('[PC] DPR clamp applied', clampedDpr.toFixed(2))
+          const dprClamp = applyDprClamp(gl, 2)
+          const caps = getDreamdustCaps(gl.domElement)
+          setUniform('uVertexInkOk', caps.vertexInkOk ? 1 : 0)
+          if (dreamdustCtx) {
+            dreamdustCtx.setVertexInkOk(caps.vertexInkOk)
+          }
+          logOnce('caps', {
+            vertexInkOk: caps.vertexInkOk,
+            floatOk: caps.floatOk,
+            aliasedPointSizeRange: Array.from(caps.aliasedPointSizeRange),
+            dpr: caps.dpr,
+            dprClamp,
+          })
           // ACES tone mapping for nicer highlights
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
@@ -1158,19 +1170,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             if (gl.debug) gl.debug.checkShaderErrors = true
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            const ctx = gl.getContext && gl.getContext()
-            if (ctx) {
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              const range = ctx.getParameter(ctx.ALIASED_POINT_SIZE_RANGE)
-              console.log('[PC] ALIASED_POINT_SIZE_RANGE', range)
-              const vertexInk = detectVertexTextureSupport(ctx)
-              setUniform('uVertexInkOk', vertexInk ? 1 : 0)
-              if (dreamdustCtx) dreamdustCtx.setVertexInkOk(vertexInk)
-            }
-          } catch {}
+          } catch { /* noop */ }
           // ensure browser gesture handling doesn't block wheel/touch
           gl.domElement.style.touchAction = 'none'
           gl.domElement.style.pointerEvents = 'auto'

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/capabilities.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/capabilities.ts
@@ -7,6 +7,15 @@ export type DreamdustCaps = {
 
 type GLContext = WebGLRenderingContext | WebGL2RenderingContext
 
+export type DreamdustRuntimeCaps = {
+  vertexInkOk: boolean
+  floatOk: boolean
+  aliasedPointSizeRange: Float32Array
+  dpr: number
+}
+
+const DEFAULT_POINT_SIZE_RANGE: readonly [number, number] = [1, 1]
+
 function safeGetParameter<T>(
   gl: GLContext,
   parameter: number,
@@ -28,6 +37,38 @@ export function detectVertexTextureSupport(gl: GLContext): boolean {
   return units > 0
 }
 
+function detectFloatTextureSupport(gl: GLContext): boolean {
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return true
+  }
+
+  if (typeof gl.getExtension !== 'function') {
+    return false
+  }
+
+  const extensionNames: readonly string[] = [
+    'OES_texture_float',
+    'OES_texture_float_linear',
+    'WEBGL_color_buffer_float',
+    'EXT_color_buffer_float',
+    'OES_texture_half_float',
+    'OES_texture_half_float_linear',
+    'EXT_color_buffer_half_float',
+  ]
+
+  for (const name of extensionNames) {
+    try {
+      if (gl.getExtension(name)) {
+        return true
+      }
+    } catch {
+      // Ignore extension query errors and continue.
+    }
+  }
+
+  return false
+}
+
 export function readCaps(gl: GLContext): DreamdustCaps {
   const aliasedPointSizeRange = safeGetParameter<Float32Array>(
     gl,
@@ -47,5 +88,53 @@ export function readCaps(gl: GLContext): DreamdustCaps {
     maxVertexAttribs,
     maxTextureSize,
     maxVertexTextureImageUnits,
+  }
+}
+
+function createFallbackRuntimeCaps(dpr: number): DreamdustRuntimeCaps {
+  return {
+    vertexInkOk: false,
+    floatOk: false,
+    aliasedPointSizeRange: new Float32Array(DEFAULT_POINT_SIZE_RANGE),
+    dpr,
+  }
+}
+
+export function getDreamdustCaps(
+  canvas: HTMLCanvasElement | null | undefined,
+): DreamdustRuntimeCaps {
+  const rawDpr =
+    typeof window !== 'undefined' && typeof window.devicePixelRatio === 'number'
+      ? window.devicePixelRatio
+      : 1
+  const dpr = Number.isFinite(rawDpr) && rawDpr > 0 ? rawDpr : 1
+
+  if (!canvas || typeof canvas.getContext !== 'function') {
+    return createFallbackRuntimeCaps(dpr)
+  }
+
+  let gl: GLContext | null = null
+
+  try {
+    gl =
+      (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
+      (canvas.getContext('webgl') as WebGLRenderingContext | null)
+  } catch {
+    gl = null
+  }
+
+  if (!gl) {
+    return createFallbackRuntimeCaps(dpr)
+  }
+
+  const { aliasedPointSizeRange } = readCaps(gl)
+  const vertexInkOk = detectVertexTextureSupport(gl)
+  const floatOk = detectFloatTextureSupport(gl)
+
+  return {
+    vertexInkOk,
+    floatOk,
+    aliasedPointSizeRange,
+    dpr,
   }
 }

--- a/apps/cryptiq-mindmap-demo/app/debug/caps/page.tsx
+++ b/apps/cryptiq-mindmap-demo/app/debug/caps/page.tsx
@@ -3,14 +3,15 @@
 import * as React from 'react'
 
 import {
-  detectVertexTextureSupport,
+  getDreamdustCaps,
   readCaps,
   type DreamdustCaps,
+  type DreamdustRuntimeCaps,
 } from '../../components/dreamdust/capabilities'
 
 type CapsState = {
   caps: DreamdustCaps | null
-  vertexInkSupported: boolean | null
+  bundle: DreamdustRuntimeCaps | null
   error: string | null
 }
 
@@ -31,12 +32,11 @@ function formatRange(range: Float32Array): string {
 }
 
 export default function Page(): JSX.Element {
-  const [{ caps, vertexInkSupported, error }, setCapsState] =
-    React.useState<CapsState>({
-      caps: null,
-      vertexInkSupported: null,
-      error: null,
-    })
+  const [{ caps, bundle, error }, setCapsState] = React.useState<CapsState>({
+    caps: null,
+    bundle: null,
+    error: null,
+  })
   const [devicePixelRatio, setDevicePixelRatio] = React.useState<number | null>(
     null,
   )
@@ -55,6 +55,7 @@ export default function Page(): JSX.Element {
     window.addEventListener('resize', updateDpr)
 
     const canvas = document.createElement('canvas')
+    const runtimeCaps = getDreamdustCaps(canvas)
     const gl =
       (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
       (canvas.getContext('webgl') as WebGLRenderingContext | null)
@@ -62,13 +63,13 @@ export default function Page(): JSX.Element {
     if (!gl) {
       setCapsState({
         caps: null,
-        vertexInkSupported: null,
+        bundle: runtimeCaps,
         error: 'WebGL context unavailable',
       })
     } else {
       setCapsState({
         caps: readCaps(gl),
-        vertexInkSupported: detectVertexTextureSupport(gl),
+        bundle: runtimeCaps,
         error: null,
       })
     }
@@ -104,7 +105,7 @@ export default function Page(): JSX.Element {
   const rows: Array<{ label: string; value: string }> = []
 
   rows.push({
-    label: 'Device Pixel Ratio',
+    label: 'Device Pixel Ratio (current)',
     value:
       devicePixelRatio === null
         ? '—'
@@ -114,22 +115,37 @@ export default function Page(): JSX.Element {
     label: 'FPS',
     value: fps === null ? '—' : fps.toFixed(1),
   })
-  rows.push({
-    label: 'Vertex Ink Supported',
-    value:
-      vertexInkSupported === null
-        ? '—'
-        : vertexInkSupported
-          ? 'Yes'
-          : 'No',
-  })
+
+  if (bundle) {
+    rows.push(
+      {
+        label: 'Device Pixel Ratio (snapshot)',
+        value: bundle.dpr.toFixed(2).replace(/\.00$/, ''),
+      },
+      {
+        label: 'Vertex Ink Supported',
+        value: bundle.vertexInkOk ? 'Yes' : 'No',
+      },
+      {
+        label: 'Float Textures Supported',
+        value: bundle.floatOk ? 'Yes' : 'No',
+      },
+      {
+        label: 'Aliased Point Size Range',
+        value: formatRange(bundle.aliasedPointSizeRange),
+      },
+    )
+  } else {
+    rows.push(
+      { label: 'Device Pixel Ratio (snapshot)', value: '—' },
+      { label: 'Vertex Ink Supported', value: '—' },
+      { label: 'Float Textures Supported', value: '—' },
+      { label: 'Aliased Point Size Range', value: '—' },
+    )
+  }
 
   if (caps) {
     rows.push(
-      {
-        label: 'Aliased Point Size Range',
-        value: formatRange(caps.aliasedPointSizeRange),
-      },
       { label: 'Max Vertex Attribs', value: caps.maxVertexAttribs.toString() },
       { label: 'Max Texture Size', value: caps.maxTextureSize.toString() },
       {


### PR DESCRIPTION
## Summary
- bundle Dreamdust runtime capability detection into `getDreamdustCaps` so both the renderer and debug UI can share the same snapshot
- log the caps snapshot (including DPR clamp, float textures, and aliased point range) once when the Dreamdust stage mounts
- surface the new snapshot data on `/debug/caps`, alongside the existing raw GL limits

## Testing
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: existing repo-wide TS config lacks many `three` typings; see command output)*
- `pnpm --filter cryptiq-mindmap-demo run lint` *(fails: existing lint warnings/errors across untouched files; see command output)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2f9a3d6883289c4eb4bf7f2e5604