### PR TITLE
refactor(dreamdust): extend context for cascade and UI flags

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
@@ -4,7 +4,12 @@ import * as React from 'react'
 
 type InkTexture = import('three').Texture | null
 
+type CascadeColor = [number, number, number]
+
+type StartCascade = (color: CascadeColor) => void
+
 type DreamdustContextValue = {
+  startCascade: StartCascade
   inkTex?: InkTexture
   inkIntensity: number
   setInkTex: React.Dispatch<React.SetStateAction<InkTexture | undefined>>
@@ -22,14 +27,20 @@ const DreamdustContext = React.createContext<DreamdustContextValue | undefined>(
 )
 
 export function DreamdustProvider({ children }: React.PropsWithChildren) {
+  const cascadeStarterRef = React.useRef<StartCascade>(() => {})
   const [inkTex, setInkTex] = React.useState<InkTexture>()
   const [inkIntensity, setInkIntensity] = React.useState<number>(1)
   const [vertexInkOk, setVertexInkOk] = React.useState<boolean>(false)
   const [controlsLocked, setControlsLocked] = React.useState(false)
   const [heatmapVisible, setHeatmapVisible] = React.useState(false)
 
+  const startCascade = React.useCallback<StartCascade>((color) => {
+    cascadeStarterRef.current(color)
+  }, [])
+
   const value = React.useMemo(
     () => ({
+      startCascade,
       inkTex,
       inkIntensity,
       setInkTex,
@@ -41,7 +52,14 @@ export function DreamdustProvider({ children }: React.PropsWithChildren) {
       heatmapVisible,
       setHeatmapVisible,
     }),
-    [inkTex, inkIntensity, vertexInkOk, controlsLocked, heatmapVisible],
+    [
+      startCascade,
+      inkTex,
+      inkIntensity,
+      vertexInkOk,
+      controlsLocked,
+      heatmapVisible,
+    ],
   )
 
   return (


### PR DESCRIPTION
## Summary
- expose a placeholder startCascade callback on the Dreamdust context
- keep ink texture/intensity setters while surfacing vertex/cascade UI flags through context

## Testing
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint *(fails: existing lint errors in repo)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot fetch Google Fonts in CI sandbox)*
- pnpm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68cc43de9d708328bb121876ddbffb79