### PR TITLE
feat: introduce Dreamdust shader base with safe defaults

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -17,7 +17,7 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
 // @ts-ignore
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass'
 import { applyPerspectiveFit, depthNormScaleFromRadius } from './anim/camera'
-import { createDreamdustMaterial } from './dreamdust/DreamdustMaterial'
+import { makeDreamdustMaterial } from './dreamdust/DreamdustMaterial'
 import { getDreamdustCaps } from './dreamdust/capabilities'
 import { useDreamdustCtx } from './dreamdust/context'
 import { logOnce } from './dreamdust/metrics'
@@ -681,12 +681,20 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   }, [setUniform, vertexInkOk])
 
   const fallbackMaterial = React.useMemo(
-    () => createDreamdustMaterial(uniforms, { unproject: true }),
-    [uniforms]
+    () =>
+      makeDreamdustMaterial(uniforms, {
+        unproject: true,
+        vertexInkOk,
+      }),
+    [uniforms, vertexInkOk],
   )
   const prebakedMaterial = React.useMemo(
-    () => createDreamdustMaterial(uniforms, { unproject: false }),
-    [uniforms]
+    () =>
+      makeDreamdustMaterial(uniforms, {
+        unproject: false,
+        vertexInkOk,
+      }),
+    [uniforms, vertexInkOk],
   )
 
   React.useEffect(() => () => fallbackMaterial.dispose(), [fallbackMaterial])

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -77,6 +77,7 @@ varying vec3 vColor;
 varying float vRevealMix;
 varying vec3 vInkTint;
 varying float vInkMix;
+varying vec2 vInkUv;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
@@ -132,6 +133,7 @@ void main() {
 
   vColor = color;
   vRevealMix = revealMix;
+  vInkUv = aUv;
   vPosMV = viewPos.xyz;
 
 #ifdef USE_VERTEX_INK
@@ -154,15 +156,20 @@ uniform float uGamma;
 uniform float uTintGain;
 uniform float uDepthBias;
 uniform float uDepthNormScale;
+uniform float uInkIntensity;
+
+uniform sampler2D uInkTex;
 
 varying vec3 vColor;
 varying float vRevealMix;
 varying vec3 vInkTint;
 varying float vInkMix;
+varying vec2 vInkUv;
 varying vec3 vPosMV;
 
 ${DREAMDUST_SOFT_SPRITE_CHUNK}
 ${DREAMDUST_DEPTH_FADE_CHUNK}
+${DREAMDUST_INK_SAMPLE_CHUNK}
 
 void main() {
   float sprite = dreamdustSoftSprite(gl_PointCoord);
@@ -185,6 +192,21 @@ void main() {
   if (tintMix > 1e-5) {
     color = mix(color, vInkTint, tintMix);
   }
+
+#ifndef USE_VERTEX_INK
+  if (tintMix <= 1e-5 && uInkIntensity > 1e-5) {
+    DreamdustInkSample fragInk = dreamdustSampleInk(uInkTex, vInkUv);
+    float fragIntensity = fragInk.intensity * uInkIntensity;
+    float fragTintMix = clamp(fragIntensity * uTintGain, 0.0, 1.0);
+    if (fragTintMix > 1e-5) {
+      color = mix(color, fragInk.tint, fragTintMix);
+      tintMix = fragTintMix;
+    }
+    if (fragIntensity > 1e-5) {
+      alpha *= clamp(fragIntensity, 0.0, 1.0);
+    }
+  }
+#endif
 
   gl_FragColor = vec4(color, alpha);
 }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -1,19 +1,46 @@
-import { ShaderMaterial } from 'three'
+import { Matrix4, ShaderMaterial } from 'three'
 import type { IUniform, ShaderMaterialParameters } from 'three'
 
 import {
-  DREAMDUST_COLOR_CHUNK,
-  DREAMDUST_DRIFT_CHUNK,
+  DREAMDUST_DEPTH_FADE_CHUNK,
   DREAMDUST_INK_SAMPLE_CHUNK,
   DREAMDUST_NOISE_CHUNK,
-  DREAMDUST_POINT_SHAPE_CHUNK,
-  DREAMDUST_DEPTH_FADE_CHUNK,
+  DREAMDUST_SOFT_SPRITE_CHUNK,
 } from './glsl/chunks'
 
 type UniformRecord = Record<string, IUniform>
 
 type DreamdustMaterialOptions = {
   unproject: boolean
+  vertexInkOk?: boolean
+}
+
+const FALLBACK_NUMBER_UNIFORMS: Record<string, number> = {
+  uBaseSize: 4,
+  uFocal: 600,
+  uMinSize: 0.75,
+  uMaxSize: 6.0,
+  uDepthMin: 0,
+  uDepthMax: 1,
+  uGamma: 1,
+  uInvertDepth: 0,
+  uReveal: 1,
+  uBreath: 0,
+  uSizeGain: 0,
+  uOffsetGain: 0,
+  uDepthNormScale: 1e-3,
+  uDepthBias: 0,
+  uHasCapture: 0,
+  uZNearNdc: -1,
+  uZFarNdc: 1,
+  uInkIntensity: 0,
+  uTintGain: 0,
+}
+
+function ensureUniform(uniforms: UniformRecord, name: string, value: unknown) {
+  if (uniforms[name] === undefined) {
+    uniforms[name] = { value } as IUniform
+  }
 }
 
 const VERTEX_SHADER = /* glsl */ `
@@ -27,19 +54,18 @@ uniform float uDepthMin;
 uniform float uDepthMax;
 uniform float uGamma;
 uniform float uInvertDepth;
-uniform float uTime;
-uniform float uNoiseScale;
-uniform float uNoiseSpeed;
-uniform float uDriftAmp;
-uniform float uInkIntensity;
-uniform float uInkOffsetGain;
-uniform float uInkSizeGain;
-uniform float uInkTintGain;
-uniform float uVertexInkOk;
+uniform float uReveal;
+uniform float uBreath;
+uniform float uSizeGain;
+uniform float uOffsetGain;
+uniform float uDepthNormScale;
 uniform float uHasCapture;
 uniform float uZNearNdc;
 uniform float uZFarNdc;
 uniform mat4 uPVInvCapture;
+#ifdef USE_VERTEX_INK
+uniform float uInkIntensity;
+#endif
 
 uniform sampler2D uInkTex;
 
@@ -48,14 +74,12 @@ attribute float aDepth;
 attribute vec3 color;
 
 varying vec3 vColor;
-varying vec3 vNoiseCoord;
+varying float vRevealMix;
 varying vec3 vInkTint;
 varying float vInkMix;
-varying vec2 vInkUv;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
-${DREAMDUST_DRIFT_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
 
 vec4 dreamdustUnproject(vec2 captureUv, float depth01) {
@@ -76,51 +100,48 @@ vec4 dreamdustUnproject(vec2 captureUv, float depth01) {
 
 void main() {
   float depthNorm = clamp((aDepth - uDepthMin) / max(1e-5, (uDepthMax - uDepthMin)), 0.0, 1.0);
-  depthNorm = pow(depthNorm, uGamma);
+  depthNorm = pow(depthNorm, max(uGamma, 1e-5));
   if (uInvertDepth > 0.5) {
     depthNorm = 1.0 - depthNorm;
   }
 
   vec4 worldPos = dreamdustUnproject(aUv, depthNorm);
 
-  // Ink sampling comes first to modulate drift near strokes
-  vec3 inkTint = vec3(0.0);
-  float inkMix = 0.0;
-  float inkSizeBoost = 0.0;
-  float localIntensity = 0.0;
-  bool vertexInkSupported = uVertexInkOk > 0.5;
-  bool applyVertexInk = vertexInkSupported && uInkIntensity > 0.0;
-  DreamdustInkSample inkS;
-  if (applyVertexInk) {
-    inkS = dreamdustSampleInk(uInkTex, aUv);
-    localIntensity = inkS.intensity * uInkIntensity;
-  }
+  vec3 revealSeed = vec3(aUv * 173.0, depthNorm * 91.0 + 0.17);
+  float reveal = clamp(uReveal, 0.0, 1.0);
+  float jitter = dd_hash13(revealSeed);
+  float revealNorm = clamp(reveal * 1.1 - jitter, 0.0, 1.0);
+  float revealMix = revealNorm * revealNorm * (3.0 - 2.0 * revealNorm);
 
-  // Modulate drift amplitude by local ink intensity for a smokey swirl
-  float driftAmp = uDriftAmp * (1.0 + localIntensity * 0.4);
-  worldPos.xyz += dreamdustDrift(worldPos.xyz, uTime, uNoiseScale, uNoiseSpeed, driftAmp);
+  vec3 mistDir = dd_hash33_signed(revealSeed + vec3(37.0, 11.0, 5.0));
+  float mistRadius = mix(90.0, 6.0, revealMix);
+  vec3 mistPos = worldPos.xyz + mistDir * (mistRadius + depthNorm * 20.0);
+  vec3 finalPos = mix(mistPos, worldPos.xyz, revealMix);
 
-  vec4 viewPos = viewMatrix * worldPos;
+  float breath = clamp(uBreath, -1.0, 1.0);
+  float breathOffset = breath * uOffsetGain;
+  finalPos.xy += mistDir.xy * breathOffset;
+
+  vec4 viewPos = viewMatrix * vec4(finalPos, 1.0);
   float viewDist = max(1e-3, -viewPos.z);
 
-  if (applyVertexInk && localIntensity > 1e-5) {
-    float pxScale = viewDist / max(1e-3, uFocal);
-    vec2 offsetView = inkS.offset * (uInkOffsetGain * localIntensity * pxScale);
-    viewPos.xy += offsetView;
-    inkSizeBoost = inkS.swell * localIntensity * uInkSizeGain;
-    inkTint = inkS.tint;
-    inkMix = localIntensity * uInkTintGain;
-  }
-
   float atten = clamp(uFocal / viewDist, uMinSize, uMaxSize);
-  gl_PointSize = max(0.0, uBaseSize * atten + inkSizeBoost);
+  float breathSize = 1.0 + breath * uSizeGain;
+  float revealSize = mix(0.45, 1.0, revealMix);
+  gl_PointSize = max(0.0, uBaseSize * atten * breathSize * revealSize);
 
   vColor = color;
-  vNoiseCoord = worldPos.xyz * uNoiseScale;
-  vInkTint = inkTint;
-  vInkMix = inkMix;
-  vInkUv = aUv;
+  vRevealMix = revealMix;
   vPosMV = viewPos.xyz;
+
+#ifdef USE_VERTEX_INK
+  DreamdustInkSample dd_ink = dreamdustSampleInk(uInkTex, aUv);
+  vInkTint = dd_ink.tint;
+  vInkMix = dd_ink.intensity * uInkIntensity;
+#else
+  vInkTint = vec3(0.0);
+  vInkMix = 0.0;
+#endif
 
   gl_Position = projectionMatrix * viewPos;
 }
@@ -129,86 +150,68 @@ void main() {
 const FRAGMENT_SHADER = /* glsl */ `
 precision highp float;
 
-uniform float uTime;
-uniform float uNoiseSpeed;
-uniform float uNoiseThreshold;
-uniform float uInkIntensity;
-uniform float uInkTintGain;
-uniform float uVertexInkOk;
+uniform float uGamma;
+uniform float uTintGain;
 uniform float uDepthBias;
 uniform float uDepthNormScale;
 
-uniform sampler2D uInkTex;
-
 varying vec3 vColor;
-varying vec3 vNoiseCoord;
+varying float vRevealMix;
 varying vec3 vInkTint;
 varying float vInkMix;
-varying vec2 vInkUv;
 varying vec3 vPosMV;
 
-${DREAMDUST_NOISE_CHUNK}
-${DREAMDUST_POINT_SHAPE_CHUNK}
-${DREAMDUST_COLOR_CHUNK}
-${DREAMDUST_INK_SAMPLE_CHUNK}
+${DREAMDUST_SOFT_SPRITE_CHUNK}
 ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
-  float shape = dreamdustPointShape(gl_PointCoord);
-  if (shape <= 0.0) {
+  float sprite = dreamdustSoftSprite(gl_PointCoord);
+  if (sprite <= 0.0) {
     discard;
   }
 
-  vec3 posMV = vPosMV;
-  float distNorm = clamp(-posMV.z * uDepthNormScale, 0.0, 10.0);
+  float alpha = pow(sprite, max(uGamma, 1e-3));
+  alpha *= vRevealMix;
 
-  vec2 revealCoord = vec2(vNoiseCoord.x + uTime * uNoiseSpeed, vNoiseCoord.y);
-  if (dd_noise2(revealCoord) < uNoiseThreshold) {
-    discard;
-  }
-
-  float alpha = shape;
+  float distNorm = clamp(-vPosMV.z * uDepthNormScale, 0.0, 10.0);
   alpha *= DD_DEPTH_ALPHA(distNorm, uDepthBias);
-  if (alpha <= 0.0) {
+
+  if (alpha <= 1e-4) {
     discard;
   }
 
+  float tintMix = clamp(vInkMix * uTintGain, 0.0, 1.0);
   vec3 color = vColor;
-  if (vInkMix > 1e-5) {
-    color = dreamdustApplyInkTint(color, vInkTint, vInkMix);
-  }
-
-  bool vertexInkSupported = uVertexInkOk > 0.5;
-  bool applyFragmentInk = !vertexInkSupported && uInkIntensity > 0.0;
-  if (applyFragmentInk) {
-    DreamdustInkSample fragInk = dreamdustSampleInk(uInkTex, vInkUv);
-    float localIntensity = fragInk.intensity * uInkIntensity;
-    if (localIntensity > 1e-5) {
-      float tintMix = localIntensity * uInkTintGain;
-      if (tintMix > 1e-5) {
-        color = dreamdustApplyInkTint(color, fragInk.tint, tintMix);
-      }
-      alpha *= clamp(localIntensity, 0.0, 1.0);
-    }
+  if (tintMix > 1e-5) {
+    color = mix(color, vInkTint, tintMix);
   }
 
   gl_FragColor = vec4(color, alpha);
 }
 `;
 
-export function createDreamdustMaterial(
+export function makeDreamdustMaterial(
   uniforms: UniformRecord,
-  opts: DreamdustMaterialOptions
+  opts: DreamdustMaterialOptions,
 ) {
-  if (uniforms.uDepthNormScale === undefined) {
-    uniforms.uDepthNormScale = { value: 1 } as IUniform
+  const vertexInkOk = opts.vertexInkOk ?? false
+
+  for (const [name, value] of Object.entries(FALLBACK_NUMBER_UNIFORMS)) {
+    ensureUniform(uniforms, name, value)
   }
 
-  const defines: ShaderMaterialParameters['defines'] = opts.unproject
-    ? { USE_UNPROJECT: 1 }
-    : {}
+  ensureUniform(uniforms, 'uPVInvCapture', new Matrix4())
+  ensureUniform(uniforms, 'uInkTex', null)
 
-  const params: ShaderMaterialParameters = {
+  const defines: ShaderMaterialParameters['defines'] = {}
+  if (opts.unproject) {
+    defines.USE_UNPROJECT = 1
+  }
+  if (vertexInkOk) {
+    defines.USE_VERTEX_INK = 1
+  }
+
+  const material = new ShaderMaterial({
     uniforms,
     vertexShader: VERTEX_SHADER,
     fragmentShader: FRAGMENT_SHADER,
@@ -217,17 +220,27 @@ export function createDreamdustMaterial(
     depthTest: true,
     toneMapped: false,
     defines,
-  }
+  })
 
-  const material = new ShaderMaterial(params)
   material.uniforms = uniforms
   material.defines = material.defines ?? {}
+
   if (opts.unproject) {
     material.defines.USE_UNPROJECT = 1
   } else {
     delete material.defines.USE_UNPROJECT
   }
+
+  if (vertexInkOk) {
+    material.defines.USE_VERTEX_INK = 1
+  } else {
+    delete material.defines.USE_VERTEX_INK
+  }
+
   return material
 }
+
+/** @deprecated Use {@link makeDreamdustMaterial} instead. */
+export const createDreamdustMaterial = makeDreamdustMaterial
 
 export type { DreamdustMaterialOptions }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -1,12 +1,14 @@
 /**
- * Unified Dreamdust GLSL chunks
- * - Provides DD_* helpers used by newer shaders
- * - Retains DREAMDUST_* exports consumed by DreamdustMaterial
+ * Shared Dreamdust GLSL chunks.
+ *
+ * These helpers expose a soft sprite profile, exponential depth fade,
+ * lightweight value-noise/FBM utilities, and ink sampling stubs so the
+ * Dreamdust material can compile before ink features land in later PRs.
  */
 
-// Noise/hash helpers (2D value noise, 3D fbm), and screen helpers
+// Hash + noise -----------------------------------------------------------------
+
 export const DREAMDUST_NOISE_CHUNK = /* glsl */ `
-// 3D hash (iq-style)
 vec3 dd_hash33(vec3 dd_p) {
   vec3 dd_hashScale3 = vec3(0.1031, 0.1030, 0.0973);
   vec3 dd_q = fract(dd_p * dd_hashScale3);
@@ -14,76 +16,107 @@ vec3 dd_hash33(vec3 dd_p) {
   return fract((dd_q.xxy + dd_q.yzz) * dd_q.zyx);
 }
 
-float dd_hash13(vec3 dd_p) { return dd_hash33(dd_p).x; }
-
-// 2D value noise used for reveal thresholding
-float dd_noise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n00 = dd_hash13(vec3(i, 0.0));
-  float n10 = dd_hash13(vec3(i + vec2(1.0, 0.0), 0.0));
-  float n01 = dd_hash13(vec3(i + vec2(0.0, 1.0), 0.0));
-  float n11 = dd_hash13(vec3(i + vec2(1.0), 0.0));
-
-  float nx0 = mix(n00, n10, f.x);
-  float nx1 = mix(n01, n11, f.x);
-  return mix(nx0, nx1, f.y);
+float dd_hash13(vec3 dd_p) {
+  return dd_hash33(dd_p).x;
 }
 
-float dd_noise2(vec3 p) { return dd_noise2(p.xy + vec2(p.z)); }
-
-// 3D fbm used by drift
-float dreamdustHash(vec3 p) { return dd_hash13(p); }
-
-float dreamdustNoise3d(vec3 p) {
-  vec3 i = floor(p);
-  vec3 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n000 = dreamdustHash(i + vec3(0.0, 0.0, 0.0));
-  float n100 = dreamdustHash(i + vec3(1.0, 0.0, 0.0));
-  float n010 = dreamdustHash(i + vec3(0.0, 1.0, 0.0));
-  float n110 = dreamdustHash(i + vec3(1.0, 1.0, 0.0));
-  float n001 = dreamdustHash(i + vec3(0.0, 0.0, 1.0));
-  float n101 = dreamdustHash(i + vec3(1.0, 0.0, 1.0));
-  float n011 = dreamdustHash(i + vec3(0.0, 1.0, 1.0));
-  float n111 = dreamdustHash(i + vec3(1.0, 1.0, 1.0));
-
-  float nx00 = mix(n000, n100, f.x);
-  float nx10 = mix(n010, n110, f.x);
-  float nx01 = mix(n001, n101, f.x);
-  float nx11 = mix(n011, n111, f.x);
-  float nxy0 = mix(nx00, nx10, f.y);
-  float nxy1 = mix(nx01, nx11, f.y);
-  return mix(nxy0, nxy1, f.z);
+vec3 dd_hash33_signed(vec3 dd_p) {
+  return dd_hash33(dd_p) * 2.0 - 1.0;
 }
 
-float dreamdustFbm(vec3 p) {
-  float value = 0.0;
-  float amplitude = 0.5;
-  for (int i = 0; i < 4; i++) {
-    value += dreamdustNoise3d(p) * amplitude;
-    p *= 2.0;
-    amplitude *= 0.5;
+// 2D value noise used for reveal gating
+float dd_noise2(vec2 dd_p) {
+  vec2 dd_i = floor(dd_p);
+  vec2 dd_f = fract(dd_p);
+  vec2 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n00 = dd_hash13(vec3(dd_i, 0.0));
+  float dd_n10 = dd_hash13(vec3(dd_i + vec2(1.0, 0.0), 0.0));
+  float dd_n01 = dd_hash13(vec3(dd_i + vec2(0.0, 1.0), 0.0));
+  float dd_n11 = dd_hash13(vec3(dd_i + vec2(1.0), 0.0));
+
+  float dd_x1 = mix(dd_n00, dd_n10, dd_u.x);
+  float dd_x2 = mix(dd_n01, dd_n11, dd_u.x);
+  return mix(dd_x1, dd_x2, dd_u.y);
+}
+
+float dd_noise2(vec3 dd_p) {
+  return dd_noise2(dd_p.xy + vec2(dd_p.z));
+}
+
+float dreamdustHash(vec3 dd_p) {
+  return dd_hash13(dd_p);
+}
+
+float dreamdustNoise3d(vec3 dd_p) {
+  vec3 dd_i = floor(dd_p);
+  vec3 dd_f = fract(dd_p);
+  vec3 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n000 = dreamdustHash(dd_i + vec3(0.0, 0.0, 0.0));
+  float dd_n100 = dreamdustHash(dd_i + vec3(1.0, 0.0, 0.0));
+  float dd_n010 = dreamdustHash(dd_i + vec3(0.0, 1.0, 0.0));
+  float dd_n110 = dreamdustHash(dd_i + vec3(1.0, 1.0, 0.0));
+  float dd_n001 = dreamdustHash(dd_i + vec3(0.0, 0.0, 1.0));
+  float dd_n101 = dreamdustHash(dd_i + vec3(1.0, 0.0, 1.0));
+  float dd_n011 = dreamdustHash(dd_i + vec3(0.0, 1.0, 1.0));
+  float dd_n111 = dreamdustHash(dd_i + vec3(1.0, 1.0, 1.0));
+
+  float dd_nx00 = mix(dd_n000, dd_n100, dd_u.x);
+  float dd_nx10 = mix(dd_n010, dd_n110, dd_u.x);
+  float dd_nx01 = mix(dd_n001, dd_n101, dd_u.x);
+  float dd_nx11 = mix(dd_n011, dd_n111, dd_u.x);
+  float dd_nxy0 = mix(dd_nx00, dd_nx10, dd_u.y);
+  float dd_nxy1 = mix(dd_nx01, dd_nx11, dd_u.y);
+  return mix(dd_nxy0, dd_nxy1, dd_u.z);
+}
+
+float dreamdustFbm(vec3 dd_p) {
+  float dd_value = 0.0;
+  float dd_amp = 0.5;
+  vec3 dd_pos = dd_p;
+  for (int dd_octave = 0; dd_octave < 4; dd_octave++) {
+    dd_value += dreamdustNoise3d(dd_pos) * dd_amp;
+    dd_pos *= 2.0;
+    dd_amp *= 0.5;
   }
-  return value;
+  return dd_value;
 }
-`
+`;
 
-export const DREAMDUST_DRIFT_CHUNK = /* glsl */ `
-vec3 dreamdustDrift(vec3 pos, float time, float scale, float speed, float amp) {
-  vec3 base = pos * scale + vec3(0.0, 0.0, time * speed);
-  float nx = dreamdustFbm(base + vec3(37.2, 11.8, 5.4));
-  float ny = dreamdustFbm(base + vec3(5.3, 27.1, 19.7));
-  float nz = dreamdustFbm(base + vec3(11.1, 41.3, 7.9));
-  vec3 dir = vec3(nx, ny, nz) * 2.0 - 1.0;
-  float len = max(1e-3, length(dir));
-  dir /= len;
-  return dir * amp;
+// Depth fade -------------------------------------------------------------------
+
+export const DREAMDUST_DEPTH_FADE_CHUNK = /* glsl */ `
+float dd_depthAlpha(float dd_depthNorm, float dd_bias) {
+  if (dd_bias <= 0.0) {
+    return 1.0;
+  }
+  return clamp(exp(-dd_depthNorm * dd_bias), 0.0, 1.0);
 }
-`
+
+float dreamdustDepthFade(float dd_viewDist, float dd_bias) {
+  float dd_norm = clamp(dd_viewDist * uDepthNormScale, 0.0, 10.0);
+  return dd_depthAlpha(dd_norm, dd_bias);
+}
+
+#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
+`;
+
+// Soft sprite ------------------------------------------------------------------
+
+export const DREAMDUST_SOFT_SPRITE_CHUNK = /* glsl */ `
+float dreamdustSoftSprite(vec2 dd_coord) {
+  vec2 dd_delta = dd_coord * 2.0 - 1.0;
+  float dd_r2 = dot(dd_delta, dd_delta);
+  float dd_core = smoothstep(1.0, 0.0, dd_r2);
+  float dd_feather = smoothstep(1.0, 0.55, dd_r2);
+  return dd_core * dd_feather;
+}
+
+#define DD_SOFT_SPRITE(coord) dreamdustSoftSprite(coord)
+`;
+
+// Ink sampling -----------------------------------------------------------------
 
 export const DREAMDUST_INK_SAMPLE_CHUNK = /* glsl */ `
 struct DreamdustInkSample {
@@ -93,57 +126,18 @@ struct DreamdustInkSample {
   vec3 tint;
 };
 
-DreamdustInkSample dreamdustSampleInk(sampler2D tex, vec2 uv) {
-  vec4 ink = texture2D(tex, uv);
-  DreamdustInkSample inkS;
-  inkS.offset = ink.rg * 2.0 - 1.0;
-  inkS.swell = ink.b;
-  inkS.intensity = ink.a;
-  inkS.tint = ink.rgb;
-  return inkS;
+DreamdustInkSample dreamdustSampleInk(sampler2D dd_tex, vec2 dd_uv) {
+  DreamdustInkSample dd_sample;
+  dd_sample.offset = vec2(0.0);
+  dd_sample.swell = 0.0;
+  dd_sample.intensity = 0.0;
+  dd_sample.tint = vec3(0.0);
+  return dd_sample;
 }
-`
+`;
 
-export const DREAMDUST_DEPTH_FADE_CHUNK = /* glsl */ `
-float dreamdustDepthFade(float viewDist, float bias) {
-  if (bias <= 0.0) { return 1.0; }
-  return clamp(exp(-viewDist * bias), 0.0, 1.0);
-}
-
-float dd_depthAlpha(float depthNorm, float bias) {
-  if (bias <= 0.0) { return 1.0; }
-  return clamp(exp(-depthNorm * bias), 0.0, 1.0);
-}
-
-#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
-`
-
-export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `
-float dreamdustPointShape(vec2 coord) {
-  vec2 delta = coord * 2.0 - 1.0;
-  float r2 = dot(delta, delta);
-  float core = smoothstep(1.0, 0.0, r2);
-  float feather = smoothstep(1.0, 0.6, r2);
-  return core * feather;
-}
-`
-
-export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
-vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
-  float mixAmt = clamp(amount, 0.0, 1.0);
-  vec3 tinted = baseColor + tintColor * mixAmt;
-  return mix(baseColor, tinted, mixAmt);
-}
-`
-
-// (registry removed; DREAMDUST_* chunks are imported directly by consumers)
-/**
- * Shared Dreamdust GLSL chunks for shader composition.
- *
- * Each chunk is exported as a raw GLSL string and is intended to be interpolated
- * into shader sources. Helper identifiers follow the `dd_` / `DD_` naming
- * convention to avoid collisions with reserved names.
- */
+// -----------------------------------------------------------------------------
+// Retain DD_* chunk exports consumed by other tooling/tests.
 
 /**
  * Saturation helper that clamps a scalar to the [0, 1] range.


### PR DESCRIPTION
## Summary
- add Dreamdust GLSL chunks for noise, depth fade, soft sprite, and ink sampling stubs to support the base shader
- implement `makeDreamdustMaterial` with reveal/breath uniforms, vertex ink define guard, and fallback uniform defaults
- update `PointCloudStage` to create materials via the new factory and propagate the vertex ink capability flag

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: workspace already reports existing TS errors in unrelated packages)*
- pnpm --filter cryptiq-mindmap-demo run lint *(fails: existing lint warnings/errors unrelated to this change)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: offline environment cannot fetch Google Fonts)*
- pnpm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cc43bb89b8832889ed2847336ee1ba