### PR TITLE
feat: add dreamdust shader base with reveal and soft sprite

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -717,21 +717,37 @@ export default function PointCloudStage(props: PointCloudStageProps) {
 
   const fallbackMaterial = React.useMemo(() => {
     if (!runtimeCaps) return null
-    const material = createDreamdustMaterial(uniforms, { unproject: true })
-    material.defines = {
-      ...(material.defines ?? {}),
-      VERTEX_INK_OK: runtimeCaps.vertexInkOk ? 1 : 0,
+    const material = createDreamdustMaterial(uniforms, {
+      unproject: true,
+      vertexInkOk: runtimeCaps.vertexInkOk ?? false,
+    })
+    const defines = material.defines ?? {}
+    const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
+    defines.VERTEX_INK_OK = vertexInkDefine
+    if (vertexInkDefine) {
+      defines.USE_VERTEX_INK = 1
+    } else {
+      delete defines.USE_VERTEX_INK
     }
+    material.defines = defines
     material.needsUpdate = true
     return material
   }, [runtimeCaps, uniforms])
   const prebakedMaterial = React.useMemo(() => {
     if (!runtimeCaps) return null
-    const material = createDreamdustMaterial(uniforms, { unproject: false })
-    material.defines = {
-      ...(material.defines ?? {}),
-      VERTEX_INK_OK: runtimeCaps.vertexInkOk ? 1 : 0,
+    const material = createDreamdustMaterial(uniforms, {
+      unproject: false,
+      vertexInkOk: runtimeCaps.vertexInkOk ?? false,
+    })
+    const defines = material.defines ?? {}
+    const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
+    defines.VERTEX_INK_OK = vertexInkDefine
+    if (vertexInkDefine) {
+      defines.USE_VERTEX_INK = 1
+    } else {
+      delete defines.USE_VERTEX_INK
     }
+    material.defines = defines
     material.needsUpdate = true
     return material
   }, [runtimeCaps, uniforms])

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -1,41 +1,101 @@
-import { ShaderMaterial } from 'three'
+import { Matrix4, ShaderMaterial } from 'three'
 import type { IUniform, ShaderMaterialParameters } from 'three'
 
 import {
   DREAMDUST_COLOR_CHUNK,
+  DREAMDUST_DEPTH_FADE_CHUNK,
   DREAMDUST_DRIFT_CHUNK,
   DREAMDUST_INK_SAMPLE_CHUNK,
   DREAMDUST_NOISE_CHUNK,
-  DREAMDUST_POINT_SHAPE_CHUNK,
-  DREAMDUST_DEPTH_FADE_CHUNK,
+  DREAMDUST_SOFT_SPRITE_CHUNK,
 } from './glsl/chunks'
 
 type UniformRecord = Record<string, IUniform>
 
 type DreamdustMaterialOptions = {
   unproject: boolean
+  vertexInkOk: boolean
+}
+
+type DreamdustMaterialOptionsInput = {
+  unproject: boolean
+  vertexInkOk?: boolean
+}
+
+const DEFAULT_UNIFORM_VALUES = {
+  uTime: 0,
+  uReveal: 1,
+  uBreath: 0.5,
+  uNoiseScale: 1,
+  uNoiseSpeed: 1,
+  uNoiseThreshold: 1,
+  uDriftAmp: 0,
+  uPointBaseSize: 1,
+  uFocal: 1,
+  uMinSize: 1,
+  uMaxSize: 1,
+  uSizeGain: 1,
+  uOffsetGain: 0,
+  uInkIntensity: 1,
+  uTintGain: 1,
+  uDepthMin: 0,
+  uDepthMax: 1,
+  uGamma: 1,
+  uDepthBias: 1.8,
+  uDepthNormScale: 0.001,
+  uHasCapture: 0,
+  uZNearNdc: -0.85,
+  uZFarNdc: 0.85,
+  uPVInvCapture: new Matrix4(),
+  uInkTex: null,
+  uCascade: 0,
+  uCascadeColor: [1, 1, 1] as [number, number, number],
+  uVertexInkOk: 0,
+  uViewport: [1, 1] as [number, number],
+} as const
+
+type DefaultUniformKey = keyof typeof DEFAULT_UNIFORM_VALUES
+
+function cloneUniformValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return [...value]
+  }
+  if (value instanceof Matrix4) {
+    return value.clone()
+  }
+  return value
+}
+
+function ensureUniform(uniforms: UniformRecord, name: DefaultUniformKey) {
+  if (uniforms[name] === undefined) {
+    const defaultValue = DEFAULT_UNIFORM_VALUES[name]
+    uniforms[name] = { value: cloneUniformValue(defaultValue) } as IUniform
+  }
 }
 
 const VERTEX_SHADER = /* glsl */ `
 precision highp float;
 
-uniform float uBaseSize;
-uniform float uFocal;
-uniform float uMinSize;
-uniform float uMaxSize;
-uniform float uDepthMin;
-uniform float uDepthMax;
-uniform float uGamma;
-uniform float uInvertDepth;
 uniform float uTime;
+uniform float uReveal;
+uniform float uBreath;
 uniform float uNoiseScale;
 uniform float uNoiseSpeed;
 uniform float uDriftAmp;
+uniform float uPointBaseSize;
+uniform float uFocal;
+uniform float uMinSize;
+uniform float uMaxSize;
+uniform float uSizeGain;
+uniform float uOffsetGain;
 uniform float uInkIntensity;
-uniform float uInkOffsetGain;
-uniform float uInkSizeGain;
-uniform float uInkTintGain;
+uniform float uTintGain;
+uniform float uDepthMin;
+uniform float uDepthMax;
+uniform float uGamma;
+uniform float uDepthNormScale;
 uniform float uVertexInkOk;
+
 uniform float uHasCapture;
 uniform float uZNearNdc;
 uniform float uZFarNdc;
@@ -43,88 +103,101 @@ uniform mat4 uPVInvCapture;
 
 uniform sampler2D uInkTex;
 
+attribute vec3 position;
 attribute vec2 aUv;
 attribute float aDepth;
 attribute vec3 color;
 
 varying vec3 vColor;
-varying vec3 vNoiseCoord;
 varying vec3 vInkTint;
 varying float vInkMix;
 varying vec2 vInkUv;
+varying float vRevealMix;
+varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_DRIFT_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
 
-vec4 dreamdustUnproject(vec2 captureUv, float depth01) {
+vec4 dreamdustUnproject(vec3 localPos, vec2 captureUv, float depth01) {
 #ifdef USE_UNPROJECT
   if (uHasCapture > 0.5) {
     vec2 ndc = captureUv * 2.0 - 1.0;
     vec4 wNear = uPVInvCapture * vec4(ndc.x, ndc.y, uZNearNdc, 1.0);
     vec4 wFar = uPVInvCapture * vec4(ndc.x, ndc.y, uZFarNdc, 1.0);
-    wNear.xyz /= max(1e-6, wNear.w);
-    wFar.xyz /= max(1e-6, wFar.w);
-    wNear.w = 1.0;
-    wFar.w = 1.0;
-    return mix(wNear, wFar, depth01);
+    vec3 nearPos = wNear.xyz / max(1e-6, wNear.w);
+    vec3 farPos = wFar.xyz / max(1e-6, wFar.w);
+    return vec4(mix(nearPos, farPos, depth01), 1.0);
   }
 #endif
-  return modelMatrix * vec4(position, 1.0);
+  return modelMatrix * vec4(localPos, 1.0);
 }
 
 void main() {
-  float depthNorm = clamp((aDepth - uDepthMin) / max(1e-5, (uDepthMax - uDepthMin)), 0.0, 1.0);
-  depthNorm = pow(depthNorm, uGamma);
-  if (uInvertDepth > 0.5) {
-    depthNorm = 1.0 - depthNorm;
-  }
+  float depthSpan = max(1e-5, uDepthMax - uDepthMin);
+  float depth01 = clamp((aDepth - uDepthMin) / depthSpan, 0.0, 1.0);
+  depth01 = pow(depth01, max(uGamma, 1e-5));
 
-  vec4 worldPos = dreamdustUnproject(aUv, depthNorm);
+  vec4 worldPos = dreamdustUnproject(position, aUv, depth01);
+  vec3 basePos = worldPos.xyz;
 
-  // Ink sampling comes first to modulate drift near strokes
+  float revealProgress = clamp(uReveal, 0.0, 1.0);
+  float revealSeed = dd_hash13(vec3(aUv * 37.0, aDepth * 19.0));
+  float revealGate = smoothstep(revealSeed * 0.7, 1.0, revealProgress);
+
+  vec3 jitterSeed = dd_hash33(vec3(aUv * 173.0, aDepth * 59.0));
+  vec3 mistDir = jitterSeed * 2.0 - 1.0;
+  mistDir = normalize(mistDir + vec3(1e-4));
+  float mistAmount = (1.0 - revealGate) * 1.8 + 0.35;
+  vec3 mistPos = basePos + mistDir * mistAmount;
+
+  float breathPhase = (uBreath - 0.5) * 2.0;
+  mistPos += mistDir * (breathPhase * 0.08);
+
+  vec3 revealPos = mix(mistPos, basePos, revealGate);
+  revealPos += dreamdustDrift(revealPos, uTime, uNoiseScale, uNoiseSpeed, uDriftAmp);
+
+  vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
+  float viewDist = max(1e-3, -viewPos.z);
+  float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
+  float breathScale = 1.0 + breathPhase * 0.12;
+  float pointSize = uPointBaseSize * attenuation * breathScale;
+
   vec3 inkTint = vec3(0.0);
   float inkMix = 0.0;
-  float inkSizeBoost = 0.0;
-  float localIntensity = 0.0;
-  bool vertexInkSupported = uVertexInkOk > 0.5;
-  bool applyVertexInk = vertexInkSupported && uInkIntensity > 0.0;
-  DreamdustInkSample inkS;
-  if (applyVertexInk) {
-    inkS = dreamdustSampleInk(uInkTex, aUv);
-    localIntensity = inkS.intensity * uInkIntensity;
+
+#ifdef USE_VERTEX_INK
+  if (uInkIntensity > 1e-5 && uVertexInkOk > 0.5) {
+    DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
+    float localIntensity = inkSample.intensity * uInkIntensity;
+    if (localIntensity > 1e-5) {
+      float pxScale = viewDist / max(1e-3, uFocal);
+      vec2 inkOffset = inkSample.offset * (localIntensity * uOffsetGain * pxScale);
+      viewPos.xy += inkOffset;
+      pointSize += inkSample.swell * localIntensity * uSizeGain;
+      inkTint = inkSample.tint;
+      inkMix = localIntensity * uTintGain;
+    }
   }
+#endif
 
-  // Modulate drift amplitude by local ink intensity for a smokey swirl
-  float driftAmp = uDriftAmp * (1.0 + localIntensity * 0.4);
-  worldPos.xyz += dreamdustDrift(worldPos.xyz, uTime, uNoiseScale, uNoiseSpeed, driftAmp);
+  gl_PointSize = max(0.0, pointSize);
 
-  vec4 viewPos = viewMatrix * worldPos;
-  float viewDist = max(1e-3, -viewPos.z);
-
-  if (applyVertexInk && localIntensity > 1e-5) {
-    float pxScale = viewDist / max(1e-3, uFocal);
-    vec2 offsetView = inkS.offset * (uInkOffsetGain * localIntensity * pxScale);
-    viewPos.xy += offsetView;
-    inkSizeBoost = inkS.swell * localIntensity * uInkSizeGain;
-    inkTint = inkS.tint;
-    inkMix = localIntensity * uInkTintGain;
-  }
-
-  float atten = clamp(uFocal / viewDist, uMinSize, uMaxSize);
-  gl_PointSize = max(0.0, uBaseSize * atten + inkSizeBoost);
+  float mistLift = mix(0.35, 1.0, revealGate);
+  mistLift = clamp(max(mistLift, revealProgress * 0.9), 0.0, 1.0);
 
   vColor = color;
-  vNoiseCoord = worldPos.xyz * uNoiseScale;
   vInkTint = inkTint;
   vInkMix = inkMix;
   vInkUv = aUv;
+  vRevealMix = mistLift;
+  vRevealCoord = aUv * (3.0 + uNoiseScale) + jitterSeed.xy;
   vPosMV = viewPos.xyz;
 
   gl_Position = projectionMatrix * viewPos;
 }
-`;
+`
 
 const FRAGMENT_SHADER = /* glsl */ `
 precision highp float;
@@ -133,80 +206,101 @@ uniform float uTime;
 uniform float uNoiseSpeed;
 uniform float uNoiseThreshold;
 uniform float uInkIntensity;
-uniform float uInkTintGain;
-uniform float uVertexInkOk;
+uniform float uTintGain;
 uniform float uDepthBias;
 uniform float uDepthNormScale;
+uniform float uGamma;
+uniform float uCascade;
+uniform vec3 uCascadeColor;
 
 uniform sampler2D uInkTex;
 
 varying vec3 vColor;
-varying vec3 vNoiseCoord;
 varying vec3 vInkTint;
 varying float vInkMix;
 varying vec2 vInkUv;
+varying float vRevealMix;
+varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
-${DREAMDUST_POINT_SHAPE_CHUNK}
+${DREAMDUST_SOFT_SPRITE_CHUNK}
 ${DREAMDUST_COLOR_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
 ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
-  float shape = dreamdustPointShape(gl_PointCoord);
-  if (shape <= 0.0) {
+  float sprite = dreamdustSoftSprite(gl_PointCoord);
+  if (sprite <= 0.0) {
     discard;
   }
 
-  vec3 posMV = vPosMV;
-  float distNorm = clamp(-posMV.z * uDepthNormScale, 0.0, 10.0);
+  float threshold = clamp(uNoiseThreshold, 0.0, 1.0);
+  vec2 revealSample = vRevealCoord + vec2(uTime * 0.18 * uNoiseSpeed, uTime * 0.05);
+  float revealNoise = dd_noise2(revealSample);
+  float revealStrength = clamp(vRevealMix, 0.0, 1.0);
+  float flow = revealNoise + revealStrength * (1.0 - threshold * 0.5);
+  float baseReveal = smoothstep(threshold - 0.2, 1.0, flow);
+  float revealAlpha = max(baseReveal, revealStrength * 0.35);
 
-  vec2 revealCoord = vec2(vNoiseCoord.x + uTime * uNoiseSpeed, vNoiseCoord.y);
-  if (dd_noise2(revealCoord) < uNoiseThreshold) {
-    discard;
-  }
-
-  float alpha = shape;
-  alpha *= DD_DEPTH_ALPHA(distNorm, uDepthBias);
-  if (alpha <= 0.0) {
+  float alpha = sprite * revealAlpha * revealStrength;
+  float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);
+  alpha *= dreamdustDepthAlpha(depthNorm, uDepthBias);
+  if (alpha <= 0.001) {
     discard;
   }
 
   vec3 color = vColor;
+
+#ifdef USE_VERTEX_INK
   if (vInkMix > 1e-5) {
     color = dreamdustApplyInkTint(color, vInkTint, vInkMix);
   }
-
-  bool vertexInkSupported = uVertexInkOk > 0.5;
-  bool applyFragmentInk = !vertexInkSupported && uInkIntensity > 0.0;
-  if (applyFragmentInk) {
+#else
+  if (uInkIntensity > 1e-5) {
     DreamdustInkSample fragInk = dreamdustSampleInk(uInkTex, vInkUv);
     float localIntensity = fragInk.intensity * uInkIntensity;
     if (localIntensity > 1e-5) {
-      float tintMix = localIntensity * uInkTintGain;
+      float tintMix = localIntensity * uTintGain;
       if (tintMix > 1e-5) {
         color = dreamdustApplyInkTint(color, fragInk.tint, tintMix);
       }
       alpha *= clamp(localIntensity, 0.0, 1.0);
     }
   }
+#endif
+
+  if (uCascade > 0.0) {
+    color = mix(color, uCascadeColor, clamp(uCascade, 0.0, 1.0));
+  }
+
+  color = dreamdustApplyGamma(color, uGamma);
 
   gl_FragColor = vec4(color, alpha);
 }
-`;
+`
 
-export function createDreamdustMaterial(
+export function makeDreamdustMaterial(
   uniforms: UniformRecord,
-  opts: DreamdustMaterialOptions
+  opts: DreamdustMaterialOptions | DreamdustMaterialOptionsInput,
 ) {
-  if (uniforms.uDepthNormScale === undefined) {
-    uniforms.uDepthNormScale = { value: 1 } as IUniform
+  const uniformNames = Object.keys(DEFAULT_UNIFORM_VALUES) as DefaultUniformKey[]
+  for (const name of uniformNames) {
+    ensureUniform(uniforms, name)
   }
 
-  const defines: ShaderMaterialParameters['defines'] = opts.unproject
-    ? { USE_UNPROJECT: 1 }
-    : {}
+  const resolved: DreamdustMaterialOptions = {
+    unproject: opts.unproject,
+    vertexInkOk: opts.vertexInkOk ?? false,
+  }
+
+  const defines: ShaderMaterialParameters['defines'] = {}
+  if (resolved.unproject) {
+    defines.USE_UNPROJECT = 1
+  }
+  if (resolved.vertexInkOk) {
+    defines.USE_VERTEX_INK = 1
+  }
 
   const params: ShaderMaterialParameters = {
     uniforms,
@@ -222,12 +316,27 @@ export function createDreamdustMaterial(
   const material = new ShaderMaterial(params)
   material.uniforms = uniforms
   material.defines = material.defines ?? {}
-  if (opts.unproject) {
+  if (resolved.unproject) {
     material.defines.USE_UNPROJECT = 1
   } else {
     delete material.defines.USE_UNPROJECT
   }
+  if (resolved.vertexInkOk) {
+    material.defines.USE_VERTEX_INK = 1
+  } else {
+    delete material.defines.USE_VERTEX_INK
+  }
+
+  if (uniforms.uVertexInkOk) {
+    uniforms.uVertexInkOk.value = resolved.vertexInkOk ? 1 : 0
+  }
+
   return material
 }
+
+/**
+ * @deprecated use {@link makeDreamdustMaterial} instead.
+ */
+export const createDreamdustMaterial = makeDreamdustMaterial
 
 export type { DreamdustMaterialOptions }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -73,6 +73,60 @@ function ensureUniform(uniforms: UniformRecord, name: DefaultUniformKey) {
   }
 }
 
+function aliasUniform(
+  uniforms: UniformRecord,
+  legacyName: string,
+  canonicalName: DefaultUniformKey,
+) {
+  const canonicalUniform = uniforms[canonicalName] as IUniform | undefined
+  const legacyUniform = uniforms[legacyName] as IUniform | undefined
+
+  if (legacyUniform && !canonicalUniform) {
+    uniforms[canonicalName] = legacyUniform
+    return
+  }
+
+  if (!legacyUniform && canonicalUniform) {
+    uniforms[legacyName] = canonicalUniform
+    return
+  }
+
+  if (legacyUniform && canonicalUniform && legacyUniform !== canonicalUniform) {
+    uniforms[legacyName] = canonicalUniform
+  }
+}
+
+function isTruthyDefine(value: unknown): boolean {
+  if (typeof value === 'number') {
+    return value !== 0
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toLowerCase()
+    if (trimmed === '' || trimmed === '0' || trimmed === 'false') {
+      return false
+    }
+    return true
+  }
+  return !!value
+}
+
+function syncLegacyVertexInkDefine(
+  defines: ShaderMaterialParameters['defines'] | undefined,
+) {
+  if (!defines) {
+    return
+  }
+  const record = defines as Record<string, unknown>
+  if (!Object.prototype.hasOwnProperty.call(record, 'VERTEX_INK_OK')) {
+    return
+  }
+  if (isTruthyDefine(record.VERTEX_INK_OK)) {
+    record.USE_VERTEX_INK = 1
+  } else {
+    delete record.USE_VERTEX_INK
+  }
+}
+
 const VERTEX_SHADER = /* glsl */ `
 precision highp float;
 
@@ -284,10 +338,12 @@ export function makeDreamdustMaterial(
   uniforms: UniformRecord,
   opts: DreamdustMaterialOptions | DreamdustMaterialOptionsInput,
 ) {
+  aliasUniform(uniforms, 'uBaseSize', 'uPointBaseSize')
   const uniformNames = Object.keys(DEFAULT_UNIFORM_VALUES) as DefaultUniformKey[]
   for (const name of uniformNames) {
     ensureUniform(uniforms, name)
   }
+  aliasUniform(uniforms, 'uBaseSize', 'uPointBaseSize')
 
   const resolved: DreamdustMaterialOptions = {
     unproject: opts.unproject,
@@ -300,7 +356,9 @@ export function makeDreamdustMaterial(
   }
   if (resolved.vertexInkOk) {
     defines.USE_VERTEX_INK = 1
+    defines.VERTEX_INK_OK = 1
   }
+  syncLegacyVertexInkDefine(defines)
 
   const params: ShaderMaterialParameters = {
     uniforms,
@@ -316,6 +374,7 @@ export function makeDreamdustMaterial(
   const material = new ShaderMaterial(params)
   material.uniforms = uniforms
   material.defines = material.defines ?? {}
+  syncLegacyVertexInkDefine(material.defines)
   if (resolved.unproject) {
     material.defines.USE_UNPROJECT = 1
   } else {
@@ -323,12 +382,22 @@ export function makeDreamdustMaterial(
   }
   if (resolved.vertexInkOk) {
     material.defines.USE_VERTEX_INK = 1
+    material.defines.VERTEX_INK_OK = 1
   } else {
     delete material.defines.USE_VERTEX_INK
+    delete material.defines.VERTEX_INK_OK
   }
 
   if (uniforms.uVertexInkOk) {
     uniforms.uVertexInkOk.value = resolved.vertexInkOk ? 1 : 0
+  }
+
+  const originalOnBeforeCompile = material.onBeforeCompile?.bind(material)
+  material.onBeforeCompile = function onBeforeCompile(shader, renderer) {
+    syncLegacyVertexInkDefine(material.defines)
+    if (originalOnBeforeCompile) {
+      originalOnBeforeCompile(shader, renderer)
+    }
   }
 
   return material

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -6,7 +6,7 @@
 
 // Noise/hash helpers (2D value noise, 3D fbm), and screen helpers
 export const DREAMDUST_NOISE_CHUNK = /* glsl */ `
-// 3D hash (iq-style)
+// Branchless IQ-style hashes
 vec3 dd_hash33(vec3 dd_p) {
   vec3 dd_hashScale3 = vec3(0.1031, 0.1030, 0.0973);
   vec3 dd_q = fract(dd_p * dd_hashScale3);
@@ -14,61 +14,68 @@ vec3 dd_hash33(vec3 dd_p) {
   return fract((dd_q.xxy + dd_q.yzz) * dd_q.zyx);
 }
 
-float dd_hash13(vec3 dd_p) { return dd_hash33(dd_p).x; }
-
-// 2D value noise used for reveal thresholding
-float dd_noise2(vec2 p) {
-  vec2 i = floor(p);
-  vec2 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n00 = dd_hash13(vec3(i, 0.0));
-  float n10 = dd_hash13(vec3(i + vec2(1.0, 0.0), 0.0));
-  float n01 = dd_hash13(vec3(i + vec2(0.0, 1.0), 0.0));
-  float n11 = dd_hash13(vec3(i + vec2(1.0), 0.0));
-
-  float nx0 = mix(n00, n10, f.x);
-  float nx1 = mix(n01, n11, f.x);
-  return mix(nx0, nx1, f.y);
+float dd_hash13(vec3 dd_p) {
+  return dd_hash33(dd_p).x;
 }
 
-float dd_noise2(vec3 p) { return dd_noise2(p.xy + vec2(p.z)); }
-
-// 3D fbm used by drift
-float dreamdustHash(vec3 p) { return dd_hash13(p); }
-
-float dreamdustNoise3d(vec3 p) {
-  vec3 i = floor(p);
-  vec3 f = fract(p);
-  f = f * f * (3.0 - 2.0 * f);
-
-  float n000 = dreamdustHash(i + vec3(0.0, 0.0, 0.0));
-  float n100 = dreamdustHash(i + vec3(1.0, 0.0, 0.0));
-  float n010 = dreamdustHash(i + vec3(0.0, 1.0, 0.0));
-  float n110 = dreamdustHash(i + vec3(1.0, 1.0, 0.0));
-  float n001 = dreamdustHash(i + vec3(0.0, 0.0, 1.0));
-  float n101 = dreamdustHash(i + vec3(1.0, 0.0, 1.0));
-  float n011 = dreamdustHash(i + vec3(0.0, 1.0, 1.0));
-  float n111 = dreamdustHash(i + vec3(1.0, 1.0, 1.0));
-
-  float nx00 = mix(n000, n100, f.x);
-  float nx10 = mix(n010, n110, f.x);
-  float nx01 = mix(n001, n101, f.x);
-  float nx11 = mix(n011, n111, f.x);
-  float nxy0 = mix(nx00, nx10, f.y);
-  float nxy1 = mix(nx01, nx11, f.y);
-  return mix(nxy0, nxy1, f.z);
+float dd_hash12(vec2 dd_p) {
+  return dd_hash13(vec3(dd_p, 0.0));
 }
 
-float dreamdustFbm(vec3 p) {
-  float value = 0.0;
-  float amplitude = 0.5;
-  for (int i = 0; i < 4; i++) {
-    value += dreamdustNoise3d(p) * amplitude;
-    p *= 2.0;
-    amplitude *= 0.5;
+// 2D value noise used by reveal flow
+float dd_noise2(vec2 dd_p) {
+  vec2 dd_i = floor(dd_p);
+  vec2 dd_f = fract(dd_p);
+  vec2 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n00 = dd_hash12(dd_i);
+  float dd_n10 = dd_hash12(dd_i + vec2(1.0, 0.0));
+  float dd_n01 = dd_hash12(dd_i + vec2(0.0, 1.0));
+  float dd_n11 = dd_hash12(dd_i + vec2(1.0, 1.0));
+
+  float dd_x0 = mix(dd_n00, dd_n10, dd_u.x);
+  float dd_x1 = mix(dd_n01, dd_n11, dd_u.x);
+  return mix(dd_x0, dd_x1, dd_u.y);
+}
+
+float dd_noise2(vec3 dd_p) {
+  return dd_noise2(dd_p.xy + vec2(dd_p.z));
+}
+
+// Smoothed value noise for drift fields
+float dreamdustNoise3d(vec3 dd_p) {
+  vec3 dd_i = floor(dd_p);
+  vec3 dd_f = fract(dd_p);
+  vec3 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n000 = dd_hash13(dd_i);
+  float dd_n100 = dd_hash13(dd_i + vec3(1.0, 0.0, 0.0));
+  float dd_n010 = dd_hash13(dd_i + vec3(0.0, 1.0, 0.0));
+  float dd_n110 = dd_hash13(dd_i + vec3(1.0, 1.0, 0.0));
+  float dd_n001 = dd_hash13(dd_i + vec3(0.0, 0.0, 1.0));
+  float dd_n101 = dd_hash13(dd_i + vec3(1.0, 0.0, 1.0));
+  float dd_n011 = dd_hash13(dd_i + vec3(0.0, 1.0, 1.0));
+  float dd_n111 = dd_hash13(dd_i + vec3(1.0, 1.0, 1.0));
+
+  float dd_nx00 = mix(dd_n000, dd_n100, dd_u.x);
+  float dd_nx10 = mix(dd_n010, dd_n110, dd_u.x);
+  float dd_nx01 = mix(dd_n001, dd_n101, dd_u.x);
+  float dd_nx11 = mix(dd_n011, dd_n111, dd_u.x);
+  float dd_nxy0 = mix(dd_nx00, dd_nx10, dd_u.y);
+  float dd_nxy1 = mix(dd_nx01, dd_nx11, dd_u.y);
+  return mix(dd_nxy0, dd_nxy1, dd_u.z);
+}
+
+float dreamdustFbm(vec3 dd_p) {
+  float dd_value = 0.0;
+  float dd_amplitude = 0.5;
+  const int dd_octaves = 4;
+  for (int dd_i = 0; dd_i < dd_octaves; ++dd_i) {
+    dd_value += dreamdustNoise3d(dd_p) * dd_amplitude;
+    dd_p *= 2.0;
+    dd_amplitude *= 0.5;
   }
-  return value;
+  return dd_value;
 }
 `
 
@@ -106,33 +113,47 @@ DreamdustInkSample dreamdustSampleInk(sampler2D tex, vec2 uv) {
 
 export const DREAMDUST_DEPTH_FADE_CHUNK = /* glsl */ `
 float dreamdustDepthFade(float viewDist, float bias) {
-  if (bias <= 0.0) { return 1.0; }
+  if (bias <= 0.0) {
+    return 1.0;
+  }
   return clamp(exp(-viewDist * bias), 0.0, 1.0);
 }
 
-float dd_depthAlpha(float depthNorm, float bias) {
-  if (bias <= 0.0) { return 1.0; }
+float dreamdustViewDepthNorm(vec3 posMV, float scale) {
+  return clamp(-posMV.z * scale, 0.0, 10.0);
+}
+
+float dreamdustDepthAlpha(float depthNorm, float bias) {
+  if (bias <= 0.0) {
+    return 1.0;
+  }
   return clamp(exp(-depthNorm * bias), 0.0, 1.0);
 }
 
-#define DD_DEPTH_ALPHA(depthNorm, bias) dd_depthAlpha(depthNorm, bias)
+#define DD_DEPTH_ALPHA(depthNorm, bias) dreamdustDepthAlpha(depthNorm, bias)
 `
 
-export const DREAMDUST_POINT_SHAPE_CHUNK = /* glsl */ `
-float dreamdustPointShape(vec2 coord) {
+export const DREAMDUST_SOFT_SPRITE_CHUNK = /* glsl */ `
+float dreamdustSoftSprite(vec2 coord) {
   vec2 delta = coord * 2.0 - 1.0;
   float r2 = dot(delta, delta);
-  float core = smoothstep(1.0, 0.0, r2);
-  float feather = smoothstep(1.0, 0.6, r2);
-  return core * feather;
+  float inner = smoothstep(0.95, 0.0, r2);
+  float fringe = smoothstep(1.3, 0.3, r2);
+  return clamp(inner * fringe, 0.0, 1.0);
 }
 `
 
 export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
 vec3 dreamdustApplyInkTint(vec3 baseColor, vec3 tintColor, float amount) {
   float mixAmt = clamp(amount, 0.0, 1.0);
-  vec3 tinted = baseColor + tintColor * mixAmt;
+  vec3 tinted = mix(baseColor, tintColor, mixAmt);
   return mix(baseColor, tinted, mixAmt);
+}
+
+vec3 dreamdustApplyGamma(vec3 color, float gamma) {
+  float g = max(gamma, 1e-3);
+  vec3 safe = max(color, vec3(0.0));
+  return pow(safe, vec3(1.0 / g));
 }
 `
 


### PR DESCRIPTION
## Summary
- add safe default uniform provisioning and a `makeDreamdustMaterial` factory with reveal/breath modulation and guarded vertex-ink support
- refresh Dreamdust GLSL chunks with value-noise/FBM helpers, soft sprite, depth falloff, and tint/gamma utilities

## Testing
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint *(warn-only; existing lint errors remain in app/page.tsx)*
- NEXT_DISABLE_FONT_DOWNLOADS=1 pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot fetch Google Fonts in this environment)*
- pnpm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cc4c5f95388328ad0b7d8c7a12ad07