### PR TITLE
feat: upgrade InkField rendering and heatmap overlay

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkField.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkField.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 
-export type InkFieldPoint = { x: number; y: number } | [number, number];
+export type InkFieldPoint =
+  | { x: number; y: number; t?: number; pressure?: number }
+  | [number, number];
 
 export interface InkField {
   readonly size: number;
@@ -19,12 +21,20 @@ type CanvasLike = HTMLCanvasElement | OffscreenCanvas;
 
 type CoordinateMode = 'pixel' | 'zeroToOne' | 'minusOneToOne';
 
-const resolvePoint = (point: InkFieldPoint): { x: number; y: number } => {
+type ResolvedInkPoint = { x: number; y: number; t?: number; pressure?: number };
+
+const resolvePoint = (point: InkFieldPoint): ResolvedInkPoint => {
   if (Array.isArray(point)) {
     const [x, y] = point;
     return { x, y };
   }
-  return point;
+  const { x, y } = point;
+  const t = typeof point.t === 'number' && Number.isFinite(point.t) ? point.t : undefined;
+  const pressure =
+    typeof point.pressure === 'number' && Number.isFinite(point.pressure)
+      ? point.pressure
+      : undefined;
+  return { x, y, t, pressure };
 };
 
 const determineCoordinateMode = (points: Array<{ x: number; y: number }>): CoordinateMode => {
@@ -41,16 +51,16 @@ const determineCoordinateMode = (points: Array<{ x: number; y: number }>): Coord
   return 'pixel';
 };
 
-const mapPoint = (
-  point: { x: number; y: number },
-  mode: CoordinateMode,
-  size: number,
-): { x: number; y: number } => {
+const mapPoint = (point: ResolvedInkPoint, mode: CoordinateMode, size: number): ResolvedInkPoint => {
   switch (mode) {
     case 'zeroToOne':
-      return { x: point.x * size, y: point.y * size };
+      return { ...point, x: point.x * size, y: point.y * size };
     case 'minusOneToOne':
-      return { x: (point.x * 0.5 + 0.5) * size, y: (point.y * 0.5 + 0.5) * size };
+      return {
+        ...point,
+        x: (point.x * 0.5 + 0.5) * size,
+        y: (point.y * 0.5 + 0.5) * size,
+      };
     default:
       return point;
   }
@@ -58,6 +68,91 @@ const mapPoint = (
 
 const DECAY_FLOOR_EPSILON = 1 / 512;
 const BRUSH_IDLE_WINDOW_MS = 240;
+const MIN_FIELD_SIZE = 256;
+const MAX_FIELD_SIZE = 512;
+const DEFAULT_FIELD_SIZE = 384;
+
+const clamp01 = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+};
+
+const resolvePointPressure = (point: ResolvedInkPoint | undefined, fallback: number) => {
+  if (!point) {
+    return fallback;
+  }
+  if (typeof point.pressure === 'number' && Number.isFinite(point.pressure)) {
+    return clamp01(point.pressure);
+  }
+  return fallback;
+};
+
+const resolvePointTime = (point: ResolvedInkPoint | undefined) => {
+  if (!point) return undefined;
+  if (typeof point.t === 'number' && Number.isFinite(point.t)) {
+    return point.t;
+  }
+  return undefined;
+};
+
+const quantizeFieldSize = (size: number) => {
+  if (size >= 480) return 512;
+  if (size >= 352) return 384;
+  return 256;
+};
+
+const chooseFieldSize = (requestedSize: number, dpr: number) => {
+  const clamped = Math.min(Math.max(requestedSize, MIN_FIELD_SIZE), MAX_FIELD_SIZE);
+  let target = quantizeFieldSize(clamped);
+
+  if (typeof navigator !== 'undefined') {
+    const cores = navigator.hardwareConcurrency ?? 4;
+    if (cores <= 2) {
+      target = 256;
+    } else if (cores <= 4) {
+      target = Math.min(target, 384);
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    const width = window.innerWidth || 0;
+    const height = window.innerHeight || 0;
+    const maxDim = Math.max(width, height);
+    if (maxDim > 0 && maxDim < 900) {
+      target = Math.min(target, 384);
+    }
+  }
+
+  if (dpr > 1.6) {
+    target = Math.min(target, 384);
+  }
+
+  return Math.min(Math.max(target, MIN_FIELD_SIZE), MAX_FIELD_SIZE);
+};
+
+const computeVelocityScale = (distance: number, deltaMs: number) => {
+  if (!(Number.isFinite(distance) && Number.isFinite(deltaMs))) {
+    return 1;
+  }
+  const ms = Math.max(4, deltaMs);
+  const pxPerFrame = (distance / ms) * 16;
+  const bonus = Math.min(1.75, Math.max(0, pxPerFrame) * 0.03);
+  return 0.85 + bonus;
+};
+
+const computeRadius = (baseRadius: number, pressure: number, velocityScale: number) => {
+  const pressureScale = 0.55 + pressure * 0.75;
+  const dynamic = baseRadius * pressureScale * velocityScale;
+  return Math.max(1.5, dynamic);
+};
+
+const computeStampIntensity = (pressure: number, velocityScale: number) => {
+  const base = 0.55 + pressure * 0.4;
+  const velocityBonus = Math.min(0.25, Math.max(0, velocityScale - 1) * 0.12);
+  return Math.min(0.95, base + velocityBonus);
+};
 
 const createCanvas = (size: number, dpr: number): { canvas: CanvasLike | null; context: Canvas2DContext | null } => {
   const width = Math.max(1, Math.round(size * dpr));
@@ -90,9 +185,10 @@ const createCanvas = (size: number, dpr: number): { canvas: CanvasLike | null; c
   return { canvas, context };
 };
 
-export const createInkField = (size = 128, dpr = 1): InkField => {
-  const resolvedSize = Math.max(1, size);
+export const createInkField = (size = DEFAULT_FIELD_SIZE, dpr = 1): InkField => {
+  const requestedSize = Math.max(1, size);
   const resolvedDpr = Math.max(0.5, dpr);
+  const resolvedSize = chooseFieldSize(requestedSize, resolvedDpr);
   const { canvas, context } = createCanvas(resolvedSize, resolvedDpr);
 
   let texture: THREE.CanvasTexture | null = null;
@@ -127,26 +223,28 @@ export const createInkField = (size = 128, dpr = 1): InkField => {
 
     const resolvedPoints = points.map(resolvePoint);
     const mode = determineCoordinateMode(resolvedPoints);
-    const baseRadius = Math.max(resolvedSize * 0.10, 1);
-    const radius = Math.max(baseRadius * normalizedPressure, 0.5);
-    const step = Math.max(radius * 0.5, 1);
+    const baseRadius = Math.max(resolvedSize * 0.06, 5);
 
     context.save();
     context.globalCompositeOperation = 'lighter';
     context.globalAlpha = 1;
 
-    const stamp = (sx: number, sy: number) => {
-      const gradient = context.createRadialGradient(sx, sy, 0, sx, sy, radius);
-      gradient.addColorStop(0, 'rgba(255,255,255,0.9)');
+    const stamp = (sx: number, sy: number, stampRadius: number, strength: number) => {
+      const clampedStrength = Math.min(Math.max(strength, 0), 1);
+      const gradient = context.createRadialGradient(sx, sy, 0, sx, sy, stampRadius);
+      gradient.addColorStop(0, `rgba(255,255,255,${clampedStrength.toFixed(3)})`);
       gradient.addColorStop(1, 'rgba(255,255,255,0)');
       context.fillStyle = gradient;
       context.beginPath();
-      context.arc(sx, sy, radius, 0, Math.PI * 2);
+      context.arc(sx, sy, stampRadius, 0, Math.PI * 2);
       context.fill();
     };
 
     let previous = mapPoint(resolvedPoints[0], mode, resolvedSize);
-    stamp(previous.x, previous.y);
+    const initialPressure = resolvePointPressure(previous, normalizedPressure);
+    const initialRadius = computeRadius(baseRadius, initialPressure, 1);
+    const initialIntensity = computeStampIntensity(initialPressure, 1);
+    stamp(previous.x, previous.y, initialRadius, initialIntensity);
 
     for (let i = 1; i < resolvedPoints.length; i += 1) {
       const current = mapPoint(resolvedPoints[i], mode, resolvedSize);
@@ -157,12 +255,24 @@ export const createInkField = (size = 128, dpr = 1): InkField => {
         previous = current;
         continue;
       }
+
+      const currentTime = resolvePointTime(current);
+      const previousTime = resolvePointTime(previous);
+      const deltaMs = currentTime !== undefined && previousTime !== undefined ? currentTime - previousTime : NaN;
+      const velocityScale = computeVelocityScale(distance, Number.isFinite(deltaMs) ? deltaMs : 16);
+      const previousPressure = resolvePointPressure(previous, normalizedPressure);
+      const currentPressure = resolvePointPressure(current, normalizedPressure);
+      const segmentPressure = (previousPressure + currentPressure) * 0.5;
+      const radiusForSegment = computeRadius(baseRadius, segmentPressure, velocityScale);
+      const intensityForSegment = computeStampIntensity(segmentPressure, velocityScale);
+      const step = Math.max(radiusForSegment * 0.35, 0.85);
       const segments = Math.max(1, Math.ceil(distance / step));
       for (let segment = 1; segment <= segments; segment += 1) {
         const t = segment / segments;
         const sx = previous.x + dx * t;
         const sy = previous.y + dy * t;
-        stamp(sx, sy);
+        const falloff = 0.85 + Math.min(0.15, (1 - Math.abs(0.5 - t) * 2) * 0.15);
+        stamp(sx, sy, radiusForSegment * falloff, intensityForSegment);
       }
       previous = current;
     }
@@ -217,8 +327,10 @@ export const createInkField = (size = 128, dpr = 1): InkField => {
 
     const now = getNow();
     const cappedHz = throttleHz > 0 ? Math.min(throttleHz, 60) : 0;
-    const interval = cappedHz > 0 ? 1000 / cappedHz : 0;
     const brushActive = now - lastBrushTime <= BRUSH_IDLE_WINDOW_MS;
+    const idleHz = cappedHz > 0 ? Math.min(24, cappedHz) : 0;
+    const effectiveHz = brushActive ? cappedHz : idleHz;
+    const interval = effectiveHz > 0 ? 1000 / effectiveHz : 0;
     const pendingBrushUpload = lastBrushTime > lastUploadTime;
 
     if (!texture) {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -25,6 +25,41 @@ const DECAY_BASE = 0.98
 const INTENSITY_EPSILON = 0.01
 const INTENSITY_IDLE_ZERO_MS = 2400
 const DEFAULT_PRESSURE = 0.5
+const SHORT_TAP_MS = 120
+const LONG_STROKE_MS = 250
+const SHORT_TRAVEL_PX = 20
+const LONG_TRAVEL_PX = 120
+
+const clamp = (value: number, min: number, max: number) => {
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+const hueToRgb = (hue: number): [number, number, number] => {
+  const normalized = ((hue % 1) + 1) % 1
+  const sector = Math.floor(normalized * 6)
+  const f = normalized * 6 - sector
+  const saturation = 0.85
+  const value = 1
+  const p = value * (1 - saturation)
+  const q = value * (1 - saturation * f)
+  const t = value * (1 - saturation * (1 - f))
+  switch (sector % 6) {
+    case 0:
+      return [value, t, p]
+    case 1:
+      return [q, value, p]
+    case 2:
+      return [p, value, t]
+    case 3:
+      return [p, q, value]
+    case 4:
+      return [t, p, value]
+    default:
+      return [value, p, q]
+  }
+}
 
 function nowMs(): number {
   if (typeof performance !== 'undefined') {
@@ -43,6 +78,7 @@ function decayRateFromDelta(deltaMs: number): number {
 
 export function InkFieldHost(): React.JSX.Element {
   const {
+    startCascade,
     setInkTex,
     setInkIntensity,
     setVertexInkOk,
@@ -64,6 +100,18 @@ export function InkFieldHost(): React.JSX.Element {
     null,
   )
   const loggedInkOnceRef = React.useRef(false)
+  type StrokeStats = {
+    startTime: number
+    lastTime: number
+    totalTravelPx: number
+    sumPressure: number
+    sampleCount: number
+    sumSin: number
+    sumCos: number
+    sumWeight: number
+  }
+  const strokeStatsRef = React.useRef<StrokeStats | null>(null)
+  const strokeCanvasElementRef = React.useRef<HTMLCanvasElement | null>(null)
 
   const lockControls = React.useCallback(() => {
     try {
@@ -94,16 +142,64 @@ export function InkFieldHost(): React.JSX.Element {
     }
   }, [])
 
+  const pushTextureUpdate = React.useCallback(
+    (field: InkField) => {
+      const renderer = rendererRef.current
+      if (!renderer) {
+        return
+      }
+      const texture = field.toCanvasTexture(
+        renderer as Parameters<InkField['toCanvasTexture']>[0],
+        UPLOAD_HZ,
+      )
+      if (textureRef.current !== texture) {
+        textureRef.current = texture
+        setInkTex(texture as InkTexState)
+      }
+    },
+    [setInkTex],
+  )
+
+  const handleCanvasElement = React.useCallback((canvas: HTMLCanvasElement | null) => {
+    strokeCanvasElementRef.current = canvas
+  }, [])
+
   const handleStrokeStart = React.useCallback(
-    (_point: StrokePoint) => {
-      void _point
+    (point: StrokePoint) => {
       lockControls()
       setControlsLocked(true)
       const now = nowMs()
       lastStrokeRef.current = now
-      if (intensityRef.current !== 1) {
-        intensityRef.current = 1
-        setInkIntensity(1)
+      const pressure = clamp(point.pressure > 0 ? point.pressure : DEFAULT_PRESSURE, 0, 1)
+      const baseImpulse = clamp(0.55 + pressure * 0.4, 0, 1)
+      if (Math.abs(baseImpulse - intensityRef.current) > INTENSITY_EPSILON) {
+        intensityRef.current = baseImpulse
+        setInkIntensity(baseImpulse)
+      }
+      strokeStatsRef.current = {
+        startTime: point.t,
+        lastTime: point.t,
+        totalTravelPx: 0,
+        sumPressure: pressure,
+        sampleCount: 1,
+        sumSin: 0,
+        sumCos: 0,
+        sumWeight: 0,
+      }
+      const field = inkFieldRef.current
+      if (field) {
+        field.drawStroke(
+          [
+            {
+              x: point.x,
+              y: point.y,
+              t: point.t,
+              pressure: point.pressure,
+            },
+          ],
+          pressure,
+        )
+        pushTextureUpdate(field)
       }
       // One-time debug of caps/viewport/intensity on first stroke
       if (!loggedInkOnceRef.current) {
@@ -115,7 +211,7 @@ export function InkFieldHost(): React.JSX.Element {
             console.warn('[PC] ink debug (host)', {
               vertexInkOk: !!vertexInkOkRef.current,
               uViewport: [vpW, vpH],
-              inkIntensity: 1,
+              inkIntensity: baseImpulse,
             })
           } catch (error) {
             console.warn('[PC] ink debug (host) failed', error)
@@ -124,7 +220,7 @@ export function InkFieldHost(): React.JSX.Element {
         loggedInkOnceRef.current = true
       }
     },
-    [lockControls, setControlsLocked, setInkIntensity],
+    [lockControls, pushTextureUpdate, setControlsLocked, setInkIntensity],
   )
 
   const handleStrokeSegment = React.useCallback(
@@ -134,41 +230,109 @@ export function InkFieldHost(): React.JSX.Element {
         return
       }
 
-      const pressure = segment.pressure > 0 ? segment.pressure : DEFAULT_PRESSURE
+      const pressure = clamp(segment.pressure > 0 ? segment.pressure : DEFAULT_PRESSURE, 0, 1)
       field.drawStroke(
         [
-          { x: segment.from.x, y: segment.from.y },
-          { x: segment.to.x, y: segment.to.y },
+          { ...segment.from },
+          { ...segment.to },
         ],
         pressure,
       )
 
-      const now = nowMs()
-      lastStrokeRef.current = now
-      if (intensityRef.current !== 1) {
-        intensityRef.current = 1
-        setInkIntensity(1)
+      const stats = strokeStatsRef.current
+      let pxPerFrame = 0
+      if (stats) {
+        const canvas = strokeCanvasElementRef.current
+        const rect = canvas?.getBoundingClientRect()
+        let width = rect?.width ?? 0
+        let height = rect?.height ?? 0
+        if (width <= 0 && canvas?.width) {
+          width = canvas.width
+        }
+        if (height <= 0 && canvas?.height) {
+          height = canvas.height
+        }
+        if ((width <= 0 || height <= 0) && typeof window !== 'undefined') {
+          width = width || window.innerWidth || 0
+          height = height || window.innerHeight || 0
+        }
+        const dxPx = (segment.to.x - segment.from.x) * width
+        const dyPx = (segment.to.y - segment.from.y) * height
+        const distancePx = Math.hypot(dxPx, dyPx)
+        if (Number.isFinite(distancePx) && distancePx > 0) {
+          const previousTime = Number.isFinite(stats.lastTime)
+            ? stats.lastTime
+            : segment.t
+          const deltaMs = Math.max(1, segment.t - previousTime)
+          pxPerFrame = (distancePx / deltaMs) * 16
+          const weight = distancePx
+          const angle = Math.atan2(dyPx, dxPx)
+          stats.totalTravelPx += distancePx
+          stats.sumSin += Math.sin(angle) * weight
+          stats.sumCos += Math.cos(angle) * weight
+          stats.sumWeight += weight
+        }
+        stats.sumPressure += pressure
+        stats.sampleCount += 1
+        stats.lastTime = segment.t
       }
 
-      const renderer = rendererRef.current
-      if (renderer) {
-        const texture = field.toCanvasTexture(
-          renderer as Parameters<InkField['toCanvasTexture']>[0],
-          UPLOAD_HZ,
-        )
-        if (textureRef.current !== texture) {
-          textureRef.current = texture
-          setInkTex(texture as InkTexState)
-        }
+      const now = nowMs()
+      lastStrokeRef.current = now
+      const velocityBoost = Math.min(0.35, Math.max(0, pxPerFrame) * 0.02)
+      const dynamicIntensity = clamp(0.65 + pressure * 0.35 + velocityBoost, 0, 1)
+      if (dynamicIntensity - intensityRef.current > INTENSITY_EPSILON) {
+        intensityRef.current = dynamicIntensity
+        setInkIntensity(dynamicIntensity)
       }
+
+      pushTextureUpdate(field)
     },
-    [setInkIntensity, setInkTex],
+    [pushTextureUpdate, setInkIntensity],
   )
 
   const handleStrokeEnd = React.useCallback(() => {
     unlockControls()
     setControlsLocked(false)
-  }, [setControlsLocked, unlockControls])
+
+    const stats = strokeStatsRef.current
+    strokeStatsRef.current = null
+
+    const now = nowMs()
+    lastStrokeRef.current = now
+
+    if (!stats) {
+      return
+    }
+
+    const endTime = Number.isFinite(stats.lastTime) ? stats.lastTime : stats.startTime
+    const durationMs = Math.max(0, endTime - stats.startTime)
+    const travelPx = Number.isFinite(stats.totalTravelPx) ? stats.totalTravelPx : 0
+    const averagePressure = clamp(stats.sumPressure / Math.max(1, stats.sampleCount), 0, 1)
+
+    if (durationMs < SHORT_TAP_MS || travelPx < SHORT_TRAVEL_PX) {
+      const impulse = clamp(Math.max(intensityRef.current, 0.45 + averagePressure * 0.4), 0, 1)
+      if (Math.abs(impulse - intensityRef.current) > INTENSITY_EPSILON) {
+        intensityRef.current = impulse
+        setInkIntensity(impulse)
+      }
+      return
+    }
+
+    if (durationMs > LONG_STROKE_MS && travelPx > LONG_TRAVEL_PX) {
+      const weight = stats.sumWeight
+      let avgHue = null as number | null
+      if (weight > 0) {
+        const avgSin = stats.sumSin / weight
+        const avgCos = stats.sumCos / weight
+        if (Number.isFinite(avgSin) && Number.isFinite(avgCos) && (avgSin !== 0 || avgCos !== 0)) {
+          avgHue = ((Math.atan2(avgSin, avgCos) / (Math.PI * 2)) % 1 + 1) % 1
+        }
+      }
+      const cascadeColor = hueToRgb(avgHue ?? averagePressure)
+      startCascade(cascadeColor)
+    }
+  }, [setControlsLocked, setInkIntensity, startCascade, unlockControls])
 
   React.useEffect(() => {
     setInkIntensity(0)
@@ -182,6 +346,8 @@ export function InkFieldHost(): React.JSX.Element {
       inkFieldRef.current = null
       rendererRef.current = null
       textureRef.current = null
+      strokeStatsRef.current = null
+      strokeCanvasElementRef.current = null
     }
   }, [setControlsLocked, setInkIntensity, setInkTex, setVertexInkOk, unlockControls])
 
@@ -350,19 +516,32 @@ export function InkFieldHost(): React.JSX.Element {
           const src = tex.image as HTMLCanvasElement | OffscreenCanvas
           const renderer = rendererRef.current
           const glCanvas = renderer?.domElement ?? null
-          const viewportWidth = glCanvas?.width ?? 0
-          const viewportHeight = glCanvas?.height ?? 0
-          if (viewportWidth > 0 && canvas.width !== viewportWidth) {
-            canvas.width = viewportWidth
+          const rect = glCanvas?.getBoundingClientRect()
+          const fallbackWidth = window.innerWidth || 0
+          const fallbackHeight = window.innerHeight || 0
+          const cssWidth = rect?.width ?? glCanvas?.clientWidth ?? fallbackWidth
+          const cssHeight = rect?.height ?? glCanvas?.clientHeight ?? fallbackHeight
+          const pixelWidth = glCanvas?.width ?? Math.max(1, Math.round(cssWidth * (window.devicePixelRatio || 1)))
+          const pixelHeight = glCanvas?.height ?? Math.max(1, Math.round(cssHeight * (window.devicePixelRatio || 1)))
+          if (pixelWidth > 0 && canvas.width !== pixelWidth) {
+            canvas.width = pixelWidth
           }
-          if (viewportHeight > 0 && canvas.height !== viewportHeight) {
-            canvas.height = viewportHeight
+          if (pixelHeight > 0 && canvas.height !== pixelHeight) {
+            canvas.height = pixelHeight
+          }
+          if (cssWidth > 0) {
+            canvas.style.width = `${cssWidth}px`
+          }
+          if (cssHeight > 0) {
+            canvas.style.height = `${cssHeight}px`
           }
           if (canvas.width === 0 || canvas.height === 0) {
-            const fallbackWidth = 256
-            const fallbackHeight = 256
-            canvas.width = fallbackWidth
-            canvas.height = fallbackHeight
+            const fallbackPixelWidth = Math.max(256, Math.round(fallbackWidth || 256))
+            const fallbackPixelHeight = Math.max(256, Math.round(fallbackHeight || 256))
+            canvas.width = fallbackPixelWidth
+            canvas.height = fallbackPixelHeight
+            canvas.style.width = `${fallbackPixelWidth}px`
+            canvas.style.height = `${fallbackPixelHeight}px`
           }
           ctx.imageSmoothingEnabled = false
           ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -403,6 +582,7 @@ export function InkFieldHost(): React.JSX.Element {
         onStrokeStart={handleStrokeStart}
         onStrokeSegment={handleStrokeSegment}
         onStrokeEnd={handleStrokeEnd}
+        onCanvasElement={handleCanvasElement}
       />
       {heatmapVisible && (
         <canvas

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/StrokeCaptureCanvas.tsx
@@ -27,6 +27,7 @@ export type StrokeCaptureCanvasProps = {
   onStrokeStart?(point: StrokePoint): void
   onStrokeSegment?(segment: StrokeSegment): void
   onStrokeEnd?(): void
+  onCanvasElement?(canvas: HTMLCanvasElement | null): void
 }
 
 const MAX_DPR = 1.5
@@ -62,6 +63,7 @@ export function StrokeCaptureCanvas({
   onStrokeStart,
   onStrokeSegment,
   onStrokeEnd,
+  onCanvasElement,
 }: StrokeCaptureCanvasProps): React.JSX.Element {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
   const pointerIdRef = React.useRef<number | null>(null)
@@ -91,6 +93,13 @@ export function StrokeCaptureCanvas({
   React.useEffect(() => {
     endCallbackRef.current = onStrokeEnd
   }, [onStrokeEnd])
+
+  React.useEffect(() => {
+    onCanvasElement?.(canvasRef.current)
+    return () => {
+      onCanvasElement?.(null)
+    }
+  }, [onCanvasElement])
 
   React.useEffect(() => {
     enabledRef.current = enabled


### PR DESCRIPTION
## Summary
- raise the ink field resolution with velocity-aware brush stamping, exponential decay, and throttled texture uploads
- classify captured strokes to emit short-tap impulses or launch cascades and mirror the GL viewport with a heatmap overlay
- surface the capture canvas element so the host can track stroke metrics and align the overlay to the renderer

## Testing
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `NEXT_DISABLE_FONT_DOWNLOADS=1 NEXT_FONT_IGNORE_MISSING_FONT_FILES=1 pnpm --filter cryptiq-mindmap-demo run build` *(fails: offline Google Fonts fetches)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cc53765c80832885b8b477280b7784