### PR TITLE
feat: curl-noise advection with tap impulse for dreamdust

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -4,10 +4,11 @@ import type { IUniform, ShaderMaterialParameters } from 'three'
 import {
   DREAMDUST_COLOR_CHUNK,
   DREAMDUST_DEPTH_FADE_CHUNK,
-  DREAMDUST_DRIFT_CHUNK,
   DREAMDUST_INK_SAMPLE_CHUNK,
   DREAMDUST_NOISE_CHUNK,
   DREAMDUST_SOFT_SPRITE_CHUNK,
+  DD_CURL3,
+  DD_FBM3,
 } from './glsl/chunks'
 
 type UniformRecord = Record<string, IUniform>
@@ -30,6 +31,11 @@ const DEFAULT_UNIFORM_VALUES = {
   uNoiseSpeed: 1,
   uNoiseThreshold: 1,
   uDriftAmp: 0,
+  uCurlFreq: 0.35,
+  uCurlAmp: 1,
+  uDriftSpeed: 0.5,
+  uTapGain: 1,
+  uTapTau: 1.8,
   uPointBaseSize: 1,
   uFocal: 1,
   uMinSize: 1,
@@ -38,6 +44,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uOffsetGain: 0,
   uInkIntensity: 1,
   uTintGain: 1,
+  uRimGamma: 1.6,
   uDepthMin: 0,
   uDepthMax: 1,
   uGamma: 1,
@@ -136,6 +143,11 @@ uniform float uBreath;
 uniform float uNoiseScale;
 uniform float uNoiseSpeed;
 uniform float uDriftAmp;
+uniform float uCurlFreq;
+uniform float uCurlAmp;
+uniform float uDriftSpeed;
+uniform float uTapGain;
+uniform float uTapTau;
 uniform float uPointBaseSize;
 uniform float uFocal;
 uniform float uMinSize;
@@ -147,6 +159,7 @@ uniform float uTintGain;
 uniform float uDepthMin;
 uniform float uDepthMax;
 uniform float uGamma;
+uniform float uRimGamma;
 uniform float uDepthNormScale;
 uniform float uVertexInkOk;
 
@@ -171,7 +184,8 @@ varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
-${DREAMDUST_DRIFT_CHUNK}
+${DD_FBM3}
+${DD_CURL3}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
 
 vec4 dreamdustUnproject(vec3 localPos, vec2 captureUv, float depth01) {
@@ -210,14 +224,9 @@ void main() {
   mistPos += mistDir * (breathPhase * 0.08);
 
   vec3 revealPos = mix(mistPos, basePos, revealGate);
-  revealPos += dreamdustDrift(revealPos, uTime, uNoiseScale, uNoiseSpeed, uDriftAmp);
-
-  vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
-  float viewDist = max(1e-3, -viewPos.z);
-  float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
-  float breathScale = 1.0 + breathPhase * 0.12;
-  float pointSize = uPointBaseSize * attenuation * breathScale;
-
+  float tapImpulse = 0.0;
+  vec2 inkOffsetAccum = vec2(0.0);
+  float inkSizeBoost = 0.0;
   vec3 inkTint = vec3(0.0);
   float inkMix = 0.0;
 
@@ -226,13 +235,45 @@ void main() {
     DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
     float localIntensity = inkSample.intensity * uInkIntensity;
     if (localIntensity > 1e-5) {
-      float pxScale = viewDist / max(1e-3, uFocal);
-      vec2 inkOffset = inkSample.offset * (localIntensity * uOffsetGain * pxScale);
-      viewPos.xy += inkOffset;
-      pointSize += inkSample.swell * localIntensity * uSizeGain;
       inkTint = inkSample.tint;
       inkMix = localIntensity * uTintGain;
+      inkOffsetAccum = inkSample.offset * (localIntensity * uOffsetGain);
+      inkSizeBoost = inkSample.swell * localIntensity * uSizeGain;
+
+      if (uTapGain > 1e-5) {
+        float swell = clamp(inkSample.swell, 0.0, 1.0);
+        float tapSignal = localIntensity * swell;
+        if (tapSignal > 1e-5) {
+          float tau = max(uTapTau, 1e-3);
+          float tapDecay = exp(-tau * (1.0 - swell));
+          tapImpulse = tapSignal * tapDecay * uTapGain;
+        }
+      }
     }
+  }
+#endif
+
+  float curlFreq = max(uCurlFreq, 1e-4);
+  float curlAmp = max(uCurlAmp, 0.0);
+  float curlSpeed = uDriftSpeed;
+  vec3 curlSample = revealPos * curlFreq + uTime * curlSpeed;
+  vec3 curlDir = dd_curl3(curlSample);
+  float driftStrength = max(uDriftAmp + tapImpulse, 0.0);
+  revealPos += curlDir * (driftStrength * curlAmp);
+
+  vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
+  float viewDist = max(1e-3, -viewPos.z);
+  float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
+  float breathScale = 1.0 + breathPhase * 0.12;
+  float pointSize = uPointBaseSize * attenuation * breathScale;
+
+#ifdef USE_VERTEX_INK
+  if (inkSizeBoost != 0.0) {
+    pointSize += inkSizeBoost;
+  }
+  if (inkOffsetAccum.x != 0.0 || inkOffsetAccum.y != 0.0) {
+    float pxScale = viewDist / max(1e-3, uFocal);
+    viewPos.xy += inkOffsetAccum * pxScale;
   }
 #endif
 
@@ -284,8 +325,8 @@ ${DREAMDUST_INK_SAMPLE_CHUNK}
 ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
-  float sprite = dreamdustSoftSprite(gl_PointCoord);
-  if (sprite <= 0.0) {
+  float pointShape = dreamdustSoftSprite(gl_PointCoord);
+  if (pointShape <= 0.0) {
     discard;
   }
 
@@ -297,7 +338,11 @@ void main() {
   float baseReveal = smoothstep(threshold - 0.2, 1.0, flow);
   float revealAlpha = max(baseReveal, revealStrength * 0.35);
 
-  float alpha = sprite * revealAlpha * revealStrength;
+  float rimGamma = max(uRimGamma, 1e-3);
+  float airyShape = pow(pointShape, rimGamma);
+  float rim = clamp(pointShape - airyShape, 0.0, 1.0);
+
+  float alpha = airyShape * revealAlpha * revealStrength;
   float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);
   alpha *= dreamdustDepthAlpha(depthNorm, uDepthBias);
   if (alpha <= 0.001) {
@@ -326,6 +371,10 @@ void main() {
 
   if (uCascade > 0.0) {
     color = mix(color, uCascadeColor, clamp(uCascade, 0.0, 1.0));
+  }
+
+  if (rim > 1e-5) {
+    color = mix(color, vec3(1.0), rim * 0.25);
   }
 
   color = dreamdustApplyGamma(color, uGamma);

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -261,6 +261,109 @@ float dd_noise2Fbm(vec2 dd_p, float dd_lacunarity, float dd_gain, int dd_octaves
 `;
 
 /**
+ * 3D fractal brownian motion helper built on top of {@link dd_hash33}.
+ *
+ * @glslUniforms None
+ */
+export const DD_FBM3 = /* glsl */ `
+float dd_noise3Value(vec3 dd_p) {
+  vec3 dd_i = floor(dd_p);
+  vec3 dd_f = fract(dd_p);
+  vec3 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n000 = dd_hash13(dd_i);
+  float dd_n100 = dd_hash13(dd_i + vec3(1.0, 0.0, 0.0));
+  float dd_n010 = dd_hash13(dd_i + vec3(0.0, 1.0, 0.0));
+  float dd_n110 = dd_hash13(dd_i + vec3(1.0, 1.0, 0.0));
+  float dd_n001 = dd_hash13(dd_i + vec3(0.0, 0.0, 1.0));
+  float dd_n101 = dd_hash13(dd_i + vec3(1.0, 0.0, 1.0));
+  float dd_n011 = dd_hash13(dd_i + vec3(0.0, 1.0, 1.0));
+  float dd_n111 = dd_hash13(dd_i + vec3(1.0, 1.0, 1.0));
+
+  float dd_nx00 = mix(dd_n000, dd_n100, dd_u.x);
+  float dd_nx10 = mix(dd_n010, dd_n110, dd_u.x);
+  float dd_nx01 = mix(dd_n001, dd_n101, dd_u.x);
+  float dd_nx11 = mix(dd_n011, dd_n111, dd_u.x);
+  float dd_nxy0 = mix(dd_nx00, dd_nx10, dd_u.y);
+  float dd_nxy1 = mix(dd_nx01, dd_nx11, dd_u.y);
+  return mix(dd_nxy0, dd_nxy1, dd_u.z);
+}
+
+float dd_fbm3(vec3 dd_p, float dd_lacunarity, float dd_gain, int dd_octaves) {
+  const int dd_maxOctaves = 8;
+  int dd_capped = min(dd_octaves, dd_maxOctaves);
+  float dd_amplitude = 0.5;
+  float dd_frequency = 1.0;
+  float dd_sum = 0.0;
+
+  for (int dd_index = 0; dd_index < dd_maxOctaves; ++dd_index) {
+    if (dd_index >= dd_capped) {
+      break;
+    }
+
+    dd_sum += dd_amplitude * dd_noise3Value(dd_p * dd_frequency);
+    dd_frequency *= dd_lacunarity;
+    dd_amplitude *= dd_gain;
+  }
+
+  return dd_sum;
+}
+
+#define DD_FBM3(p, lacunarity, gain, octaves) dd_fbm3(p, lacunarity, gain, octaves)
+`;
+
+/**
+ * Curl noise derived from {@link dd_fbm3} for divergence-free advection.
+ *
+ * @glslUniforms None
+ */
+export const DD_CURL3 = /* glsl */ `
+vec3 dd_fbm3Vec(vec3 dd_p) {
+  return vec3(
+    dd_fbm3(dd_p + vec3(37.1, 17.3, 91.7), 2.0, 0.5, 5) - 0.5,
+    dd_fbm3(dd_p + vec3(11.7, 41.3, 27.9), 2.0, 0.5, 5) - 0.5,
+    dd_fbm3(dd_p + vec3(23.9, 7.1, 61.3), 2.0, 0.5, 5) - 0.5
+  );
+}
+
+vec3 dd_curl3(vec3 dd_p) {
+  const float dd_eps = 0.1;
+  const float dd_inv2eps = 0.5 / dd_eps;
+  vec3 dd_dx = vec3(dd_eps, 0.0, 0.0);
+  vec3 dd_dy = vec3(0.0, dd_eps, 0.0);
+  vec3 dd_dz = vec3(0.0, 0.0, dd_eps);
+
+  vec3 dd_flowXPos = dd_fbm3Vec(dd_p + dd_dx);
+  vec3 dd_flowXNeg = dd_fbm3Vec(dd_p - dd_dx);
+  vec3 dd_flowYPos = dd_fbm3Vec(dd_p + dd_dy);
+  vec3 dd_flowYNeg = dd_fbm3Vec(dd_p - dd_dy);
+  vec3 dd_flowZPos = dd_fbm3Vec(dd_p + dd_dz);
+  vec3 dd_flowZNeg = dd_fbm3Vec(dd_p - dd_dz);
+
+  float dd_dFz_dy = (dd_flowYPos.z - dd_flowYNeg.z) * dd_inv2eps;
+  float dd_dFy_dz = (dd_flowZPos.y - dd_flowZNeg.y) * dd_inv2eps;
+  float dd_dFx_dz = (dd_flowZPos.x - dd_flowZNeg.x) * dd_inv2eps;
+  float dd_dFz_dx = (dd_flowXPos.z - dd_flowXNeg.z) * dd_inv2eps;
+  float dd_dFy_dx = (dd_flowXPos.y - dd_flowXNeg.y) * dd_inv2eps;
+  float dd_dFx_dy = (dd_flowYPos.x - dd_flowYNeg.x) * dd_inv2eps;
+
+  vec3 dd_curl = vec3(
+    dd_dFz_dy - dd_dFy_dz,
+    dd_dFx_dz - dd_dFz_dx,
+    dd_dFy_dx - dd_dFx_dy
+  );
+
+  float dd_len = length(dd_curl);
+  if (dd_len < 1e-5) {
+    return vec3(0.0);
+  }
+  return dd_curl / dd_len;
+}
+
+#define DD_CURL3(p) dd_curl3(p)
+`;
+
+/**
  * Converts absolute screen-space pixels into clip-space coordinates.
  *
  * @glslUniforms uViewport (vec2) viewport resolution in pixels
@@ -298,6 +401,8 @@ export const glslChunks = {
   remap: DD_REMAP,
   hash3: DD_HASH3,
   fbm2: DD_NOISE2_FBM,
+  fbm3: DD_FBM3,
+  curl3: DD_CURL3,
   screenPxToClip: DD_SCREEN_PX_TO_CLIP,
   depthAlpha: DD_DEPTH_ALPHA,
 } as const;


### PR DESCRIPTION
## Summary
- add reusable dd_fbm3 and dd_curl3 GLSL chunks for curl-noise flow fields
- drive Dreamdust vertex advection with curl noise plus tap-driven impulses and expose new curl/tap/rim uniforms
- soften fragment edges with rim gamma shaping for an airier sprite profile

## Testing
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint (fails with existing lint errors)
- pnpm --filter cryptiq-mindmap-demo run build (fails: offline font downloads)
- pnpm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cc60142aac8328aac8ed18267017eb