### PR TITLE
feat: curl-noise advection for dreamdust

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -2,9 +2,10 @@ import { Matrix4, ShaderMaterial } from 'three'
 import type { IUniform, ShaderMaterialParameters } from 'three'
 
 import {
+  DD_CURL3,
+  DD_FBM3,
   DREAMDUST_COLOR_CHUNK,
   DREAMDUST_DEPTH_FADE_CHUNK,
-  DREAMDUST_DRIFT_CHUNK,
   DREAMDUST_INK_SAMPLE_CHUNK,
   DREAMDUST_NOISE_CHUNK,
   DREAMDUST_SOFT_SPRITE_CHUNK,
@@ -30,6 +31,11 @@ const DEFAULT_UNIFORM_VALUES = {
   uNoiseSpeed: 1,
   uNoiseThreshold: 1,
   uDriftAmp: 0,
+  uCurlFreq: 1,
+  uCurlAmp: 1,
+  uDriftSpeed: 1,
+  uTapGain: 0.5,
+  uTapTau: 2,
   uPointBaseSize: 1,
   uFocal: 1,
   uMinSize: 1,
@@ -41,6 +47,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uDepthMin: 0,
   uDepthMax: 1,
   uGamma: 1,
+  uRimGamma: 2,
   uDepthBias: 1.8,
   uDepthNormScale: 0.001,
   uHasCapture: 0,
@@ -136,6 +143,11 @@ uniform float uBreath;
 uniform float uNoiseScale;
 uniform float uNoiseSpeed;
 uniform float uDriftAmp;
+uniform float uCurlFreq;
+uniform float uCurlAmp;
+uniform float uDriftSpeed;
+uniform float uTapGain;
+uniform float uTapTau;
 uniform float uPointBaseSize;
 uniform float uFocal;
 uniform float uMinSize;
@@ -171,8 +183,9 @@ varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 
 ${DREAMDUST_NOISE_CHUNK}
-${DREAMDUST_DRIFT_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
+${DD_FBM3}
+${DD_CURL3}
 
 vec4 dreamdustUnproject(vec3 localPos, vec2 captureUv, float depth01) {
 #ifdef USE_UNPROJECT
@@ -210,7 +223,40 @@ void main() {
   mistPos += mistDir * (breathPhase * 0.08);
 
   vec3 revealPos = mix(mistPos, basePos, revealGate);
-  revealPos += dreamdustDrift(revealPos, uTime, uNoiseScale, uNoiseSpeed, uDriftAmp);
+
+  float tapImpulse = 0.0;
+  vec2 inkSampleOffset = vec2(0.0);
+  float inkSampleSwell = 0.0;
+  vec3 inkSampleTint = vec3(0.0);
+  float inkSampleIntensity = 0.0;
+
+#ifdef USE_VERTEX_INK
+  if (uInkIntensity > 1e-5 && uVertexInkOk > 0.5) {
+    DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
+    float localIntensity = inkSample.intensity * uInkIntensity;
+    if (localIntensity > 1e-5) {
+      inkSampleOffset = inkSample.offset;
+      inkSampleSwell = inkSample.swell;
+      inkSampleTint = inkSample.tint;
+      inkSampleIntensity = localIntensity;
+
+      float tapPhase = clamp(inkSample.swell, 0.0, 1.0);
+      if (uTapTau > 1e-3) {
+        float baseDecay = exp(-uTapTau);
+        float tapDecay = exp(-max(0.0, 1.0 - tapPhase) * uTapTau);
+        float denom = max(1.0 - baseDecay, 1e-3);
+        float tapMix = clamp((tapDecay - baseDecay) / denom, 0.0, 1.0);
+        tapImpulse = tapMix * localIntensity * uTapGain;
+      } else {
+        tapImpulse = tapPhase * localIntensity * uTapGain;
+      }
+    }
+  }
+#endif
+
+  vec3 curlSample = revealPos * uCurlFreq + vec3(uTime * uDriftSpeed);
+  float curlAmp = uCurlAmp * (uDriftAmp + tapImpulse);
+  revealPos += dd_curl3(curlSample) * curlAmp;
 
   vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
   float viewDist = max(1e-3, -viewPos.z);
@@ -222,17 +268,13 @@ void main() {
   float inkMix = 0.0;
 
 #ifdef USE_VERTEX_INK
-  if (uInkIntensity > 1e-5 && uVertexInkOk > 0.5) {
-    DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
-    float localIntensity = inkSample.intensity * uInkIntensity;
-    if (localIntensity > 1e-5) {
-      float pxScale = viewDist / max(1e-3, uFocal);
-      vec2 inkOffset = inkSample.offset * (localIntensity * uOffsetGain * pxScale);
-      viewPos.xy += inkOffset;
-      pointSize += inkSample.swell * localIntensity * uSizeGain;
-      inkTint = inkSample.tint;
-      inkMix = localIntensity * uTintGain;
-    }
+  if (inkSampleIntensity > 1e-5) {
+    float pxScale = viewDist / max(1e-3, uFocal);
+    vec2 inkOffset = inkSampleOffset * (inkSampleIntensity * uOffsetGain * pxScale);
+    viewPos.xy += inkOffset;
+    pointSize += inkSampleSwell * inkSampleIntensity * uSizeGain;
+    inkTint = inkSampleTint;
+    inkMix = inkSampleIntensity * uTintGain;
   }
 #endif
 
@@ -264,6 +306,7 @@ uniform float uTintGain;
 uniform float uDepthBias;
 uniform float uDepthNormScale;
 uniform float uGamma;
+uniform float uRimGamma;
 uniform float uCascade;
 uniform vec3 uCascadeColor;
 
@@ -327,6 +370,11 @@ void main() {
   if (uCascade > 0.0) {
     color = mix(color, uCascadeColor, clamp(uCascade, 0.0, 1.0));
   }
+
+  float pointShape = clamp(1.0 - sprite, 0.0, 1.0);
+  float rim = pow(pointShape, max(uRimGamma, 1e-3));
+  color = mix(color, vec3(1.0), rim * 0.2);
+  alpha *= mix(1.0, 0.9, rim);
 
   color = dreamdustApplyGamma(color, uGamma);
 

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -261,6 +261,89 @@ float dd_noise2Fbm(vec2 dd_p, float dd_lacunarity, float dd_gain, int dd_octaves
 `;
 
 /**
+ * 3D value noise and fractal brownian motion helpers built on {@link DD_HASH3}.
+ *
+ * @glslUniforms None
+ */
+export const DD_FBM3 = /* glsl */ `
+float dd_noise3Value(vec3 dd_p) {
+  vec3 dd_i = floor(dd_p);
+  vec3 dd_f = fract(dd_p);
+  vec3 dd_u = dd_f * dd_f * (3.0 - 2.0 * dd_f);
+
+  float dd_n000 = dd_hash13(dd_i);
+  float dd_n100 = dd_hash13(dd_i + vec3(1.0, 0.0, 0.0));
+  float dd_n010 = dd_hash13(dd_i + vec3(0.0, 1.0, 0.0));
+  float dd_n110 = dd_hash13(dd_i + vec3(1.0, 1.0, 0.0));
+  float dd_n001 = dd_hash13(dd_i + vec3(0.0, 0.0, 1.0));
+  float dd_n101 = dd_hash13(dd_i + vec3(1.0, 0.0, 1.0));
+  float dd_n011 = dd_hash13(dd_i + vec3(0.0, 1.0, 1.0));
+  float dd_n111 = dd_hash13(dd_i + vec3(1.0, 1.0, 1.0));
+
+  float dd_nx00 = mix(dd_n000, dd_n100, dd_u.x);
+  float dd_nx10 = mix(dd_n010, dd_n110, dd_u.x);
+  float dd_nx01 = mix(dd_n001, dd_n101, dd_u.x);
+  float dd_nx11 = mix(dd_n011, dd_n111, dd_u.x);
+  float dd_nxy0 = mix(dd_nx00, dd_nx10, dd_u.y);
+  float dd_nxy1 = mix(dd_nx01, dd_nx11, dd_u.y);
+  return mix(dd_nxy0, dd_nxy1, dd_u.z);
+}
+
+float dd_fbm3(vec3 dd_p) {
+  float dd_value = 0.0;
+  float dd_amplitude = 0.5;
+  const int dd_octaves = 4;
+  for (int dd_index = 0; dd_index < dd_octaves; ++dd_index) {
+    dd_value += dd_noise3Value(dd_p) * dd_amplitude;
+    dd_p *= 2.0;
+    dd_amplitude *= 0.5;
+  }
+  return dd_value;
+}
+
+#define DD_FBM3(p) dd_fbm3(p)
+`;
+
+/**
+ * Curl noise derived from {@link DD_FBM3} for divergence-free flow fields.
+ *
+ * @glslUniforms None
+ */
+export const DD_CURL3 = /* glsl */ `
+vec3 dd_fbm3Vec(vec3 dd_p) {
+  return vec3(
+    dd_fbm3(dd_p + vec3(37.2, 11.8, 5.4)),
+    dd_fbm3(dd_p + vec3(5.3, 27.1, 19.7)),
+    dd_fbm3(dd_p + vec3(11.1, 41.3, 7.9))
+  );
+}
+
+vec3 dd_curl3(vec3 dd_p) {
+  const float dd_eps = 0.35;
+  vec3 dd_dx = vec3(dd_eps, 0.0, 0.0);
+  vec3 dd_dy = vec3(0.0, dd_eps, 0.0);
+  vec3 dd_dz = vec3(0.0, 0.0, dd_eps);
+
+  vec3 dd_ny1 = dd_fbm3Vec(dd_p + dd_dy);
+  vec3 dd_ny2 = dd_fbm3Vec(dd_p - dd_dy);
+  vec3 dd_nz1 = dd_fbm3Vec(dd_p + dd_dz);
+  vec3 dd_nz2 = dd_fbm3Vec(dd_p - dd_dz);
+  vec3 dd_nx1 = dd_fbm3Vec(dd_p + dd_dx);
+  vec3 dd_nx2 = dd_fbm3Vec(dd_p - dd_dx);
+
+  vec3 dd_curl;
+  dd_curl.x = dd_nz1.y - dd_nz2.y - dd_ny1.z + dd_ny2.z;
+  dd_curl.y = dd_nx1.z - dd_nx2.z - dd_nz1.x + dd_nz2.x;
+  dd_curl.z = dd_ny1.x - dd_ny2.x - dd_nx1.y + dd_nx2.y;
+
+  float dd_len = max(length(dd_curl), 1e-4);
+  return dd_curl / dd_len;
+}
+
+#define DD_CURL3(p) dd_curl3(p)
+`;
+
+/**
  * Converts absolute screen-space pixels into clip-space coordinates.
  *
  * @glslUniforms uViewport (vec2) viewport resolution in pixels
@@ -298,6 +381,8 @@ export const glslChunks = {
   remap: DD_REMAP,
   hash3: DD_HASH3,
   fbm2: DD_NOISE2_FBM,
+  fbm3: DD_FBM3,
+  curl3: DD_CURL3,
   screenPxToClip: DD_SCREEN_PX_TO_CLIP,
   depthAlpha: DD_DEPTH_ALPHA,
 } as const;


### PR DESCRIPTION
## Summary
- add reusable dd_fbm3 and dd_curl3 GLSL chunks for divergence-free curl noise
- drive Dreamdust vertex advection with curl noise, tap-driven impulses, and new uniforms
- apply an airy rim response in the fragment shader for softer edges

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Google Fonts blocked in container)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cc60b5817c8328b877b70d2ddd6915