### PR TITLE
feat(dreamdust): curl-noise advection with tap-driven impulse

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -241,22 +241,21 @@ void main() {
       inkSampleIntensity = localIntensity;
 
       float tapPhase = clamp(inkSample.swell, 0.0, 1.0);
+      float tapMix = tapPhase;
       if (uTapTau > 1e-3) {
         float baseDecay = exp(-uTapTau);
         float tapDecay = exp(-max(0.0, 1.0 - tapPhase) * uTapTau);
         float denom = max(1.0 - baseDecay, 1e-3);
-        float tapMix = clamp((tapDecay - baseDecay) / denom, 0.0, 1.0);
-        tapImpulse = tapMix * localIntensity * uTapGain;
-      } else {
-        tapImpulse = tapPhase * localIntensity * uTapGain;
+        tapMix = clamp((tapDecay - baseDecay) / denom, 0.0, 1.0);
       }
+      tapImpulse = tapMix * localIntensity * uTapGain;
     }
   }
 #endif
 
   vec3 curlSample = revealPos * uCurlFreq + vec3(uTime * uDriftSpeed);
-  float curlAmp = uCurlAmp * (uDriftAmp + tapImpulse);
-  revealPos += dd_curl3(curlSample) * curlAmp;
+  float curlMix = (uDriftAmp + tapImpulse) * uCurlAmp;
+  revealPos += dd_curl3(curlSample) * curlMix;
 
   vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
   float viewDist = max(1e-3, -viewPos.z);


### PR DESCRIPTION
## Summary
- normalize tap-driven impulse decay to reuse the same mix value regardless of tau thresholds
- inline the curl advection amplitude so drift and tap response scale uniformly via uCurlAmp

## Testing
- ✅ `pnpm install --frozen-lockfile`
- ✅ `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- ⚠️ `pnpm --filter cryptiq-mindmap-demo run lint` *(fails on existing unused variable warnings in unrelated files; command wrapped with `|| true`)*
- ⚠️ `pnpm --filter cryptiq-mindmap-demo run build` *(fails to fetch Google Fonts in this environment)*
- ✅ `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cc6ba81a348328a2546b79d71d6e96