### PR TITLE
feat: dreamdust cascade diffusion and color takeover

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -57,6 +57,8 @@ const DEFAULT_UNIFORM_VALUES = {
   uInkTex: null,
   uCascade: 0,
   uCascadeColor: [1, 1, 1] as [number, number, number],
+  uCascadeSizeBoost: 0,
+  uVaporGain: 0,
   uVertexInkOk: 0,
   uViewport: [1, 1] as [number, number],
 } as const
@@ -161,6 +163,9 @@ uniform float uDepthMax;
 uniform float uGamma;
 uniform float uDepthNormScale;
 uniform float uVertexInkOk;
+uniform float uCascade;
+uniform float uCascadeSizeBoost;
+uniform float uVaporGain;
 
 uniform float uHasCapture;
 uniform float uZNearNdc;
@@ -254,14 +259,28 @@ void main() {
 #endif
 
   vec3 curlSample = revealPos * uCurlFreq + vec3(uTime * uDriftSpeed);
+  float cascadeMix = clamp(uCascade, 0.0, 1.0);
+  float vaporGain = max(uVaporGain, 0.0);
   float curlMix = (uDriftAmp + tapImpulse) * uCurlAmp;
-  revealPos += dd_curl3(curlSample) * curlMix;
+  float curlBoost = mix(1.0, 4.0, cascadeMix);
+  float vaporBoost = 1.0 + vaporGain * cascadeMix;
+  curlMix *= curlBoost * vaporBoost;
+  vec3 curlOffset = dd_curl3(curlSample) * curlMix;
+  revealPos += curlOffset;
+
+  if (cascadeMix > 1e-5) {
+    vec3 vaporSample = curlSample * 0.75 + vec3(uTime * 0.21, uTime * 0.13, uTime * 0.07);
+    vec3 vaporFlow = dd_fbm3Vec(vaporSample) - vec3(0.5);
+    float vaporStrength = cascadeMix * (0.35 + vaporGain * 0.85);
+    revealPos += vaporFlow * vaporStrength;
+  }
 
   vec4 viewPos = viewMatrix * vec4(revealPos, 1.0);
   float viewDist = max(1e-3, -viewPos.z);
   float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
   float breathScale = 1.0 + breathPhase * 0.12;
-  float pointSize = uPointBaseSize * attenuation * breathScale;
+  float cascadeSize = mix(0.0, max(uCascadeSizeBoost, 0.0), cascadeMix);
+  float pointSize = uPointBaseSize * attenuation * breathScale * (1.0 + cascadeSize);
 
   vec3 inkTint = vec3(0.0);
   float inkMix = 0.0;
@@ -366,8 +385,11 @@ void main() {
   }
 #endif
 
+  vec3 baseRgb = color;
   if (uCascade > 0.0) {
-    color = mix(color, uCascadeColor, clamp(uCascade, 0.0, 1.0));
+    float cascadeMix = clamp(uCascade, 0.0, 1.0);
+    float cascadeStrength = smoothstep(0.0, 1.0, pow(cascadeMix, 0.7));
+    color = mix(baseRgb, uCascadeColor, cascadeStrength);
   }
 
   float pointShape = clamp(1.0 - sprite, 0.0, 1.0);

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx
@@ -352,8 +352,8 @@ export function InkFieldHost(): React.JSX.Element {
           avgHue = ((Math.atan2(avgSin, avgCos) / (Math.PI * 2)) % 1 + 1) % 1
         }
       }
-      const cascadeColor = hueToRgb(avgHue ?? averagePressure)
-      startCascade(cascadeColor)
+      const avgHueColor = hueToRgb(avgHue ?? averagePressure)
+      startCascade(avgHueColor)
     }
   }, [setControlsLocked, setInkIntensity, startCascade, unlockControls])
 

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -21,6 +21,8 @@ type DreamdustUniformValueMap = {
   uBreath: number
   uCascade: number
   uCascadeColor: Vec3
+  uCascadeSizeBoost: number
+  uVaporGain: number
   uNoiseScale: number
   uNoiseSpeed: number
   uNoiseThreshold: number
@@ -55,6 +57,8 @@ const DEFAULT_UNIFORM_VALUES: DreamdustUniformValueMap = {
   uBreath: 0.5,
   uCascade: 0,
   uCascadeColor: [1, 1, 1],
+  uCascadeSizeBoost: 0,
+  uVaporGain: 0,
   uNoiseScale: 1,
   uNoiseSpeed: 1,
   uNoiseThreshold: 1,
@@ -95,6 +99,9 @@ const DEFAULT_REVEAL_MS = 2000
 const MIN_REVEAL_SECONDS = 0.2
 const BREATH_PERIOD_SECONDS = 7.5
 const BREATH_SPEED = (Math.PI * 2) / BREATH_PERIOD_SECONDS
+const CASCADE_DURATION_SECONDS = 1.6
+const CASCADE_SIZE_BOOST = 2.4
+const CASCADE_VAPOR_GAIN = 1.35
 
 function clamp01(value: number): number {
   if (value < 0) return 0
@@ -144,6 +151,16 @@ type RevealTimelineState = {
   didLogEnd: boolean
 }
 
+type CascadeTimelineState = {
+  active: boolean
+  elapsed: number
+  duration: number
+  sizeBoost: number
+  vaporGain: number
+  didLogStart: boolean
+  didLogEnd: boolean
+}
+
 export function useDreamdustUniforms(): UseDreamdustUniformsResult {
   const uniformsRef = React.useRef<DreamdustUniforms | null>(null)
 
@@ -157,6 +174,8 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
       uBreath: { value: DEFAULT_UNIFORM_VALUES.uBreath },
       uCascade: { value: DEFAULT_UNIFORM_VALUES.uCascade },
       uCascadeColor: { value: [...DEFAULT_UNIFORM_VALUES.uCascadeColor] as Vec3 },
+      uCascadeSizeBoost: { value: DEFAULT_UNIFORM_VALUES.uCascadeSizeBoost },
+      uVaporGain: { value: DEFAULT_UNIFORM_VALUES.uVaporGain },
       uNoiseScale: { value: DEFAULT_UNIFORM_VALUES.uNoiseScale },
       uNoiseSpeed: { value: DEFAULT_UNIFORM_VALUES.uNoiseSpeed },
       uNoiseThreshold: { value: DEFAULT_UNIFORM_VALUES.uNoiseThreshold },
@@ -186,6 +205,15 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
       MIN_REVEAL_SECONDS,
       (tunablesRef.current.revealMs ?? DEFAULT_REVEAL_MS) / 1000,
     ),
+    didLogEnd: false,
+  })
+  const cascadeTimelineRef = React.useRef<CascadeTimelineState>({
+    active: false,
+    elapsed: 0,
+    duration: CASCADE_DURATION_SECONDS,
+    sizeBoost: CASCADE_SIZE_BOOST,
+    vaporGain: CASCADE_VAPOR_GAIN,
+    didLogStart: false,
     didLogEnd: false,
   })
   const breathStateRef = React.useRef({
@@ -257,6 +285,39 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
             })
           }
         }
+      }
+
+      const cascade = cascadeTimelineRef.current
+      if (cascade.active) {
+        if (!cascade.didLogStart) {
+          cascade.didLogStart = true
+          safeLog('[Dreamdust] cascade start', {
+            duration: Number(cascade.duration.toFixed(3)),
+          })
+        }
+        cascade.elapsed = Math.min(cascade.elapsed + safeDelta, cascade.duration)
+        const progress = cascade.duration > 0 ? cascade.elapsed / cascade.duration : 1
+        const eased = cubicEaseInOut(progress)
+        const mix = clamp01(eased)
+        uniforms.uCascade.value = mix
+        uniforms.uCascadeSizeBoost.value = cascade.sizeBoost
+        uniforms.uVaporGain.value = cascade.vaporGain * mix
+        if (cascade.elapsed >= cascade.duration) {
+          cascade.active = false
+          uniforms.uCascade.value = 1
+          uniforms.uVaporGain.value = 0
+          if (!cascade.didLogEnd) {
+            cascade.didLogEnd = true
+            safeLog('[Dreamdust] cascade end', {
+              duration: Number(cascade.duration.toFixed(3)),
+            })
+          }
+        }
+      } else if (uniforms.uVaporGain.value > 1e-4) {
+        uniforms.uVaporGain.value = Math.max(
+          0,
+          uniforms.uVaporGain.value - safeDelta * cascade.vaporGain,
+        )
       }
     },
     [],
@@ -357,8 +418,18 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
 
   const startCascade = React.useCallback((color: Vec3) => {
     const uniforms = uniformsRef.current
+    const cascade = cascadeTimelineRef.current
+    cascade.active = true
+    cascade.elapsed = 0
+    cascade.duration = CASCADE_DURATION_SECONDS
+    cascade.sizeBoost = CASCADE_SIZE_BOOST
+    cascade.vaporGain = CASCADE_VAPOR_GAIN
+    cascade.didLogStart = false
+    cascade.didLogEnd = false
     if (!uniforms) return
-    uniforms.uCascade.value = 1
+    uniforms.uCascade.value = 0
+    uniforms.uCascadeSizeBoost.value = cascade.sizeBoost
+    uniforms.uVaporGain.value = 0
     const target = uniforms.uCascadeColor.value
     for (let i = 0; i < target.length && i < color.length; i += 1) {
       target[i] = color[i]
@@ -367,8 +438,15 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
 
   const stopCascade = React.useCallback(() => {
     const uniforms = uniformsRef.current
+    const cascade = cascadeTimelineRef.current
+    cascade.active = false
+    cascade.elapsed = 0
+    cascade.didLogStart = false
+    cascade.didLogEnd = false
     if (!uniforms) return
     uniforms.uCascade.value = 0
+    uniforms.uCascadeSizeBoost.value = DEFAULT_UNIFORM_VALUES.uCascadeSizeBoost
+    uniforms.uVaporGain.value = DEFAULT_UNIFORM_VALUES.uVaporGain
     const target = uniforms.uCascadeColor.value
     const defaults = DEFAULT_UNIFORM_VALUES.uCascadeColor
     for (let i = 0; i < target.length && i < defaults.length; i += 1) {


### PR DESCRIPTION
## Summary
- add cascade diffusion controls to the Dreamdust material including vapor-driven curl boost and point growth
- extend the Dreamdust uniform manager with a cascade timeline that animates vapor gain, size boost, and takeover color
- trigger the cascade when long strokes are detected so the cloud dissolves into the averaged hue

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter cryptiq-mindmap-demo run lint || true`
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Google Fonts unavailable in the sandbox)*
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cc6ff20b088328b5e57ab9fe3d8552