### PR TITLE
fix(dreamdust): unblock GLSL compile (dd_fbm3Vec alias, drop duplicate position attribute)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -174,7 +174,6 @@ uniform mat4 uPVInvCapture;
 
 uniform sampler2D uInkTex;
 
-attribute vec3 position;
 attribute vec2 aUv;
 attribute float aDepth;
 attribute vec3 color;

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -320,6 +320,9 @@ vec3 dd_fbm3Field(vec3 dd_p) {
   );
 }
 
+/* glsl */
+vec3 dd_fbm3Vec(vec3 dd_p) { return dd_fbm3Field(dd_p); }
+
 vec3 dd_curl3(vec3 dd_p) {
   const float dd_eps = 0.1;
   vec3 dd_dx = vec3(dd_eps, 0.0, 0.0);


### PR DESCRIPTION
## Summary
- add a dd_fbm3Vec helper aliasing dd_fbm3Field so curl noise consumers share the same naming contract
- remove the redundant `position` attribute declaration from the Dreamdust vertex shader template to avoid double injection

## Testing
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit *(fails: path resolved relative to package root; reran with package-relative config)*
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in unrelated packages)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd75e525c88328b7f1b71ac391d911