### PR TITLE
chore(dreamdust): tighten metrics one-shot logging + export key probe

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts
@@ -52,12 +52,20 @@ function isDebugEnabled(): boolean {
  * ```
  */
 export function logOnce<T>(key: string, payload: T): void {
+  if (typeof key !== 'string' || key.trim().length === 0) {
+    return;
+  }
+
   if (!isDebugEnabled() || emittedLogs.has(key)) {
     return;
   }
 
   emittedLogs.add(key);
   console.info(`[dreamdust] ${key}`, payload);
+}
+
+export function logOnceKeyExists(key: string): boolean {
+  return emittedLogs.has(key);
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard dreamdust logOnce against empty keys so the module-level Set only tracks valid identifiers
- export a helper to check whether a logOnce key has fired for tests and internal assertions

## Testing
- pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in packages canvas-r3f and store)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot download Google Fonts in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9811298c8328aa7f07d3594ad11a