### PR TITLE
feat(dreamdust): minimal ink heatmap + orbit gating

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -26,6 +26,7 @@ import {
   subscribeDreamdustTunables,
   type DreamdustTunables,
 } from './dreamdust/metrics'
+import InkSurface from './dreamdust/InkSurface'
 import { useDreamdustUniforms } from './dreamdust/useDreamdustUniforms'
 import { capInstances, clampDPR, decimateInterleaved, pointCap } from './pointcloud/budget'
 
@@ -544,7 +545,13 @@ function DreamdustTicker({
   return null
 }
 
-function SceneControls({ radius }: { radius?: number }) {
+function SceneControls({
+  radius,
+  drawing = false,
+}: {
+  radius?: number
+  drawing?: boolean
+}) {
   const controlsRef = React.useRef(null)
   const { gl } = useThree()
   React.useEffect(() => {
@@ -554,9 +561,9 @@ function SceneControls({ radius }: { radius?: number }) {
     <OrbitControls
       ref={controlsRef}
       makeDefault
-      enableRotate
-      enableZoom
-      enablePan={true}
+      enableRotate={!drawing}
+      enableZoom={!drawing}
+      enablePan={!drawing}
       enableDamping
       dampingFactor={0.1}
       minDistance={Math.max(0.1, radius ? radius * 0.02 : 100)}
@@ -613,6 +620,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     // omit perspective in baseline
   } = props
   const [bloomEnabled, setBloomEnabled] = React.useState(false)
+  const [drawing, setDrawing] = React.useState(false)
+  const inkUpdateLoggedRef = React.useRef(false)
   const base = sceneId ? `/assets/pointclouds/${sceneId}` : null
   const colorUrl = colorUrlProp ?? (base ? `${base}/color.png` : null)
   const depthUrl = depthUrlProp ?? (base ? `${base}/depth16.png` : null)
@@ -746,6 +755,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   }, [uniforms])
 
   const dreamdustCtx = useOptionalDreamdustCtx()
+  const startCascade = dreamdustCtx?.startCascade
   const inkTex = dreamdustCtx?.inkTex ?? null
   const inkIntensity = dreamdustCtx?.inkIntensity ?? 1
   const vertexInkOk = dreamdustCtx?.vertexInkOk ?? runtimeCaps?.vertexInkOk ?? false
@@ -1432,6 +1442,34 @@ export default function PointCloudStage(props: PointCloudStageProps) {
         }}
       >
         {/* no FitOrtho in perspective baseline */}
+        <InkSurface
+          onStart={() => {
+            inkUpdateLoggedRef.current = false
+            setDrawing(true)
+          }}
+          onTexture={(tex) => {
+            try {
+              updateInkTexture(tex)
+              if (drawing && !inkUpdateLoggedRef.current) {
+                console.log('[PC] ink tex updated')
+                inkUpdateLoggedRef.current = true
+              }
+            } catch {
+              // Ignore uniform update failures to keep drawing resilient
+            }
+          }}
+          onEnd={(info) => {
+            setDrawing(false)
+            inkUpdateLoggedRef.current = false
+            if (info.type === 'stroke') {
+              try {
+                startCascade?.([1, 1, 1])
+              } catch {
+                // Ignore cascade trigger failures
+              }
+            }
+          }}
+        />
         <CameraSync
           fovDeg={ui.fovDeg}
           distance={prebakedTransform ? 2 * prebakedTransform.radius : undefined}
@@ -1513,7 +1551,10 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             />
           )
         ) : null}
-        <SceneControls radius={prebakedTransform ? prebakedTransform.radius : undefined} />
+        <SceneControls
+          radius={prebakedTransform ? prebakedTransform.radius : undefined}
+          drawing={drawing}
+        />
         {bloomEnabled && <BloomPass strength={0.12} radius={0.1} threshold={0.7} />}
       </Canvas>
       {debugVisible && (

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import { useThree } from '@react-three/fiber'
+import * as React from 'react'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import * as THREE from 'three'
+
+type AnyDataTexture = {
+  needsUpdate: boolean
+  wrapS: unknown
+  wrapT: unknown
+  minFilter: unknown
+  magFilter: unknown
+  dispose?: () => void
+}
+
+type ThreeNamespace = {
+  DataTexture: new (
+    data: Uint8Array,
+    width: number,
+    height: number,
+    format: unknown,
+  ) => AnyDataTexture
+  ClampToEdgeWrapping: unknown
+  LinearFilter: unknown
+  RGBAFormat: unknown
+}
+
+const THREE_NS = THREE as unknown as ThreeNamespace
+
+export type InkSurfaceProps = {
+  onStart?: () => void
+  onEnd?: (info: {
+    type: 'tap' | 'stroke'
+    durationMs: number
+    distancePx: number
+  }) => void
+  onTexture?: (texture: AnyDataTexture) => void
+}
+
+const TEXTURE_SIZE = 256
+const BRUSH_RADIUS_PX = 8
+const BRUSH_STEP = BRUSH_RADIUS_PX * 0.5
+
+const clamp01 = (value: number) => {
+  if (!Number.isFinite(value)) return 0
+  if (value <= 0) return 0
+  if (value >= 1) return 1
+  return value
+}
+
+type Vec2 = { x: number; y: number }
+
+type PointerState = {
+  pointerId: number
+  startTime: number
+  startClient: Vec2
+}
+
+export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
+  const { gl } = useThree()
+  const pointerStateRef = React.useRef<PointerState | null>(null)
+  const drawingRef = React.useRef(false)
+  const lastClientRef = React.useRef<Vec2 | null>(null)
+  const lastCanvasRef = React.useRef<Vec2 | null>(null)
+  const distanceRef = React.useRef(0)
+  const ctxRef = React.useRef<CanvasRenderingContext2D | null>(null)
+  const dataRef = React.useRef<Uint8Array | null>(null)
+  const textureRef = React.useRef<AnyDataTexture | null>(null)
+  const rafRef = React.useRef<number | null>(null)
+  const onStartRef = React.useRef(onStart)
+  const onEndRef = React.useRef(onEnd)
+  const onTextureRef = React.useRef(onTexture)
+
+  React.useEffect(() => {
+    onStartRef.current = onStart
+  }, [onStart])
+
+  React.useEffect(() => {
+    onEndRef.current = onEnd
+  }, [onEnd])
+
+  React.useEffect(() => {
+    onTextureRef.current = onTexture
+  }, [onTexture])
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const canvas = document.createElement('canvas')
+    canvas.width = TEXTURE_SIZE
+    canvas.height = TEXTURE_SIZE
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return undefined
+    }
+    ctx.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE)
+    ctx.globalCompositeOperation = 'lighter'
+
+    const data = new Uint8Array(TEXTURE_SIZE * TEXTURE_SIZE * 4)
+    const texture = new THREE_NS.DataTexture(
+      data,
+      TEXTURE_SIZE,
+      TEXTURE_SIZE,
+      THREE_NS.RGBAFormat,
+    )
+    texture.wrapS = THREE_NS.ClampToEdgeWrapping
+    texture.wrapT = THREE_NS.ClampToEdgeWrapping
+    texture.minFilter = THREE_NS.LinearFilter
+    texture.magFilter = THREE_NS.LinearFilter
+    texture.needsUpdate = true
+
+    ctxRef.current = ctx
+    dataRef.current = data
+    textureRef.current = texture
+
+    const flushTexture = () => {
+      const context = ctxRef.current
+      const arr = dataRef.current
+      const tex = textureRef.current
+      if (!context || !arr || !tex) {
+        return
+      }
+      const imageData = context.getImageData(0, 0, TEXTURE_SIZE, TEXTURE_SIZE)
+      arr.set(imageData.data)
+      tex.needsUpdate = true
+      const cb = onTextureRef.current
+      if (typeof cb === 'function') {
+        try {
+          cb(tex)
+        } catch {
+          // Ignore downstream texture update errors
+        }
+      }
+    }
+
+    const scheduleFlush = () => {
+      if (rafRef.current !== null) {
+        return
+      }
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null
+        flushTexture()
+      })
+    }
+
+    const resetDrawingState = () => {
+      drawingRef.current = false
+      pointerStateRef.current = null
+      lastClientRef.current = null
+      lastCanvasRef.current = null
+      distanceRef.current = 0
+    }
+
+    const paintDisc = (point: Vec2) => {
+      const context = ctxRef.current
+      if (!context) {
+        return
+      }
+      const { x, y } = point
+      const gradient = context.createRadialGradient(x, y, 0, x, y, BRUSH_RADIUS_PX)
+      gradient.addColorStop(0, 'rgba(255,255,255,0.9)')
+      gradient.addColorStop(1, 'rgba(255,255,255,0)')
+      context.fillStyle = gradient
+      context.beginPath()
+      context.arc(x, y, BRUSH_RADIUS_PX, 0, Math.PI * 2)
+      context.fill()
+    }
+
+    const drawBetween = (from: Vec2, to: Vec2) => {
+      const dx = to.x - from.x
+      const dy = to.y - from.y
+      const dist = Math.hypot(dx, dy)
+      if (!Number.isFinite(dist) || dist === 0) {
+        paintDisc(to)
+        return
+      }
+      const steps = Math.max(1, Math.ceil(dist / BRUSH_STEP))
+      for (let i = 1; i <= steps; i++) {
+        const t = i / steps
+        paintDisc({ x: from.x + dx * t, y: from.y + dy * t })
+      }
+    }
+
+    const drawAtClient = (client: Vec2) => {
+      const context = ctxRef.current
+      const domElement = gl?.domElement
+      if (!context || !domElement) {
+        return
+      }
+      const rect = domElement.getBoundingClientRect()
+      const width = rect.width || 0
+      const height = rect.height || 0
+      if (width <= 0 || height <= 0) {
+        return
+      }
+      const u = clamp01((client.x - rect.left) / width)
+      const v = clamp01((client.y - rect.top) / height)
+      const canvasX = u * TEXTURE_SIZE
+      const canvasY = v * TEXTURE_SIZE
+      const lastClient = lastClientRef.current
+      if (lastClient) {
+        distanceRef.current += Math.hypot(client.x - lastClient.x, client.y - lastClient.y) || 0
+      }
+      lastClientRef.current = { x: client.x, y: client.y }
+      const lastCanvas = lastCanvasRef.current
+      const currentPoint = { x: canvasX, y: canvasY }
+      if (lastCanvas) {
+        drawBetween(lastCanvas, currentPoint)
+      } else {
+        paintDisc(currentPoint)
+      }
+      lastCanvasRef.current = currentPoint
+      scheduleFlush()
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!event.isPrimary || drawingRef.current) {
+        return
+      }
+      const domElement = gl?.domElement
+      if (!domElement) {
+        return
+      }
+      if (!ctxRef.current) {
+        return
+      }
+      pointerStateRef.current = {
+        pointerId: event.pointerId,
+        startTime: typeof performance !== 'undefined' ? performance.now() : event.timeStamp,
+        startClient: { x: event.clientX, y: event.clientY },
+      }
+      drawingRef.current = true
+      lastClientRef.current = null
+      lastCanvasRef.current = null
+      distanceRef.current = 0
+      ctxRef.current.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE)
+      drawAtClient({ x: event.clientX, y: event.clientY })
+      scheduleFlush()
+      try {
+        console.log('[PC] draw start')
+      } catch {
+        // noop
+      }
+      const cb = onStartRef.current
+      if (typeof cb === 'function') {
+        try {
+          cb()
+        } catch {
+          // Ignore downstream handler failures
+        }
+      }
+    }
+
+    const finishDrawing = (event?: PointerEvent) => {
+      if (!drawingRef.current) {
+        return
+      }
+      const state = pointerStateRef.current
+      if (event && state && event.pointerId !== state.pointerId) {
+        return
+      }
+      if (event) {
+        drawAtClient({ x: event.clientX, y: event.clientY })
+      }
+      drawingRef.current = false
+      const startTime = state?.startTime ?? (typeof performance !== 'undefined' ? performance.now() : 0)
+      const durationMs =
+        (typeof performance !== 'undefined' ? performance.now() : event?.timeStamp ?? startTime) - startTime
+      const distancePx = distanceRef.current
+      const type: 'tap' | 'stroke' = durationMs < 160 && distancePx < 12 ? 'tap' : 'stroke'
+      try {
+        console.log(
+          `[PC] draw end { type: '${type}', durationMs: ${durationMs.toFixed(1)}, distancePx: ${distancePx.toFixed(
+            1,
+          )} }`,
+        )
+      } catch {
+        // noop
+      }
+      const cb = onEndRef.current
+      if (typeof cb === 'function') {
+        try {
+          cb({ type, durationMs, distancePx })
+        } catch {
+          // Ignore downstream handler failures
+        }
+      }
+      scheduleFlush()
+      resetDrawingState()
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const state = pointerStateRef.current
+      if (!drawingRef.current || !state || event.pointerId !== state.pointerId) {
+        return
+      }
+      drawAtClient({ x: event.clientX, y: event.clientY })
+    }
+
+    const handlePointerUp = (event: PointerEvent) => {
+      finishDrawing(event)
+    }
+
+    const handlePointerCancel = (event: PointerEvent) => {
+      finishDrawing(event)
+    }
+
+    const domElement = gl?.domElement
+    domElement?.addEventListener('pointerdown', handlePointerDown, { passive: true })
+    domElement?.addEventListener('pointermove', handlePointerMove, { passive: true })
+    domElement?.addEventListener('pointerup', handlePointerUp, { passive: true })
+    domElement?.addEventListener('pointercancel', handlePointerCancel, { passive: true })
+    domElement?.addEventListener('pointerleave', handlePointerCancel, { passive: true })
+
+    flushTexture()
+
+    return () => {
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+      domElement?.removeEventListener('pointerdown', handlePointerDown)
+      domElement?.removeEventListener('pointermove', handlePointerMove)
+      domElement?.removeEventListener('pointerup', handlePointerUp)
+      domElement?.removeEventListener('pointercancel', handlePointerCancel)
+      domElement?.removeEventListener('pointerleave', handlePointerCancel)
+      texture?.dispose?.()
+      ctxRef.current = null
+      dataRef.current = null
+      textureRef.current = null
+      resetDrawingState()
+    }
+  }, [gl])
+
+  return null
+}
+
+export default InkSurface


### PR DESCRIPTION
## Summary
- add an InkSurface helper that captures pointer strokes into an offscreen heatmap texture and emits stroke metrics
- mount the InkSurface inside PointCloudStage so ink updates feed dreamdust uniforms, orbit controls pause while drawing, and stroke finishes trigger the cascade hook

## Testing
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: existing workspace type errors)*
- `pnpm --filter cryptiq-mindmap-demo run lint` *(fails: existing lint violations in untouched files)*
- `pnpm --filter cryptiq-mindmap-demo run build` *(fails: Next.js font downloads blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd97ed3dc483288b1e0d60040fb407