### PR TITLE
feat(dreamdust): soft-sprite rim gamma helper + uniform wiring

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -344,7 +344,7 @@ ${DREAMDUST_INK_SAMPLE_CHUNK}
 ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
-  float sprite = dreamdustSoftSprite(gl_PointCoord);
+  float sprite = dreamdustSoftSpriteRim(gl_PointCoord, uRimGamma);
   if (sprite <= 0.0) {
     discard;
   }
@@ -391,10 +391,9 @@ void main() {
     color = mix(baseRgb, uCascadeColor, cascadeStrength);
   }
 
-  float pointShape = clamp(1.0 - sprite, 0.0, 1.0);
-  float rim = pow(pointShape, max(uRimGamma, 1e-3));
-  color = mix(color, vec3(1.0), rim * 0.2);
-  alpha *= mix(1.0, 0.9, rim);
+  float rim = dreamdustRimStrength(sprite);
+  color = dreamdustApplyRimLight(color, rim);
+  alpha = dreamdustApplyRimAlpha(alpha, rim);
 
   color = dreamdustApplyGamma(color, uGamma);
 

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts
@@ -140,6 +140,14 @@ float dreamdustSoftSprite(vec2 uv) {
   float falloff = 1.0 - smoothstep(0.8, 1.0, radius);
   return clamp(falloff * falloff, 0.0, 1.0);
 }
+
+float dreamdustSoftSpriteRim(vec2 uv, float rimGamma) {
+  vec2 centered = uv * 2.0 - 1.0;
+  float radius = length(centered);
+  float falloff = 1.0 - smoothstep(0.8, 1.0, radius);
+  float base = clamp(falloff * falloff, 0.0, 1.0);
+  return pow(base, max(0.1, rimGamma));
+}
 `
 
 export const DREAMDUST_COLOR_CHUNK = /* glsl */ `
@@ -153,6 +161,19 @@ vec3 dreamdustApplyGamma(vec3 color, float gamma) {
   float g = max(gamma, 1e-3);
   vec3 safe = max(color, vec3(0.0));
   return pow(safe, vec3(1.0 / g));
+}
+
+float dreamdustRimStrength(float sprite) {
+  float pointShape = clamp(1.0 - sprite, 0.0, 1.0);
+  return pow(pointShape, max(uRimGamma, 1e-3));
+}
+
+vec3 dreamdustApplyRimLight(vec3 color, float rimStrength) {
+  return mix(color, vec3(1.0), rimStrength * 0.2);
+}
+
+float dreamdustApplyRimAlpha(float alpha, float rimStrength) {
+  return alpha * mix(1.0, 0.9, rimStrength);
 }
 `
 


### PR DESCRIPTION
## Summary
- add a gamma-shaped rim helper to the Dreamdust soft sprite GLSL chunk and expose rim mix utilities alongside existing color helpers
- wire the fragment shader to use the new rim helper and chunk functions while keeping the default uRimGamma of 2

## Testing
- pnpm exec tsc -p tsconfig.typecheck.json --noEmit *(fails: existing type errors in shared packages)*
- pnpm --filter cryptiq-mindmap-demo run lint *(fails: existing lint errors and warnings in unrelated files)*
- pnpm --filter cryptiq-mindmap-demo run build *(fails: Next.js cannot fetch Google Fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda0cb5ed48328826b5e5d49482003