### PR TITLE
docs: add 2025-09-20 dreamdust architecture and survey stubs

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-current.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-current.md
@@ -1,0 +1,61 @@
+# Dreamdust Ink — Current Architecture & Data Flow (Template)
+
+## Scope
+
+- App: `apps/cryptiq-mindmap-demo`
+- Surface(s): {pages/components}
+- Out of scope: {packages/apps not touched}
+
+## High-Level Diagram (describe or paste link)
+
+- {UI} → {Pointer capture} → {Interaction texture (off-screen)} → {R3F Stage} → {ShaderMaterial (vertex/fragment)} → {Post (bloom)} → {HUD/Meta}
+
+## Data Flow (numbered steps)
+
+1. Pointer events captured on `gl.domElement` → normalized UVs
+2. UVs written to off-screen canvas → `THREE.DataTexture` (or FBO)
+3. Stage binds `uInkTex`, caps snapshot, reveal clock to `ShaderMaterial`
+4. Vertex: positions + curl/FBM → offset; Fragment: soft-sprite + rim/tint
+5. Post-processing (if any) blends final frame to Canvas; one-shot logs emit
+
+## Modules & Exact Paths
+
+- Stage & geometry: `app/components/PointCloudStage.tsx`
+- Material/uniforms: `app/components/dreamdust/DreamdustMaterial.ts`
+- GLSL chunks: `app/components/dreamdust/glsl/chunks.ts`
+- Ink capture: `app/components/dreamdust/InkSurface.tsx`
+- Uniform drivers (reveal/time): `app/components/dreamdust/useDreamdustUniforms.ts`
+- Metrics/logging: `app/components/dreamdust/metrics.ts`
+- Route entry: `app/quiz/[slug]/page.tsx`
+
+## SDK/Monorepo Integration
+
+- Package dependencies used by the app: {list package names and roles}
+- Shared utilities consumed: {paths}
+- Build/runtime: Next.js 15 (Turbopack), R3F, Three.js
+
+## Caps & Budgets
+
+- DPR clamp: {value}
+- Point budget: {value}
+- Fallback behavior: {fragment-only/PointsMaterial}
+
+## Tunables & Presets (current)
+
+- revealDuration: {num}
+- curlFactor/evolution: {values}
+- rimGamma/breathAmp: {values}
+- presets: {names with values}
+
+## Observability
+
+- One-shot logs: {caps, instances, reveal, percentiles, ink-latency}
+- Where emitted: {files}
+
+## Risks / Constraints
+
+- {driver support, VTF, perf heads-up}
+
+## Open Questions
+
+- {fill}

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md
@@ -1,0 +1,40 @@
+# Dreamdust Ink — Target Architecture & Experience Map (Template)
+
+## Experience Goals (recap)
+
+- Mist→image (1–3s), breathy hold; tap curls; stroke vapor + color takeover; minimal HUD; payoff label.
+
+## Target Data Flow
+
+- Pointer → Interaction FBO/DataTexture (accumulating) → Shader sampling (vertex+fragment) → Curl+FBM field → Post/Bloom → HUD/Meta.
+
+## Module Responsibilities (target)
+
+- Ink capture: accumulate strokes per-frame; throttle updates to ≤1 per RAF
+- Material: bind `uInkTex`, `uCascade`, `uRimGamma`, reveal/breath uniforms; no attribute declarations in chunks
+- Chunks: pure functions only (FBM, curl, soft-sprite + rim)
+- Stage: caps snapshot once; fallback guard; camera locked; one-shot logs
+- Post: optional bloom with low-cost params; disabled on mobile if needed
+
+## Tunables & Presets (target ranges)
+
+- revealDuration: 1–3s; curlFactor: {0–1}; evolution: {0–1}; inkGain: {0–2}; rimGamma: {1–3}; breathAmp: {0–0.2}
+- Preset A/B: {name → values}
+
+## Acceptance (non-visual)
+
+- Single caps/instances logs; reveal start/end within window; percentiles once
+- Draw start/end logs; ink-latency ≤ 1 frame average; material bound to live `uInkTex`
+
+## Migration Plan
+
+- Step 1: wire FBO/DataTexture path; Step 2: tune reveal/hold; Step 3: tap/ stroke gains; Step 4: bloom; Step 5: presets
+
+## Risks & Mitigations
+
+- Perf spikes → clamp DPR/points; fallback early
+- Driver quirks → avoid undefined GLSL, keep chunks pure
+
+## Open Questions
+
+- {weights map? mobile profile? cascade palette?}

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-external-repos-survey.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-external-repos-survey.md
@@ -1,0 +1,34 @@
+# External Repos Survey — Adaptation Plan (Template)
+
+## Candidates (one section per repo)
+
+### {Repo Name}
+
+- Link: {URL}
+- What it demonstrates: {1 line}
+- Relevant techniques to adapt: {bullets}
+- Files of interest: {paths or modules in the repo}
+- License/attribution: {MIT/etc}
+- Adaptation plan: {what to copy/port and where in our app}
+- Risks/unknowns: {perf, API, license}
+
+### {Next Repo}
+
+- Link: {URL}
+- What it demonstrates: {1 line}
+- Relevant techniques to adapt: {bullets}
+- Files of interest: {paths}
+- License/attribution: {type}
+- Adaptation plan: {mapping to our files}
+- Risks/unknowns: {notes}
+
+## Mapping to Our Codebase
+
+- Interaction texture: from {repo} → `app/components/dreamdust/InkSurface.tsx` / `uInkTex`
+- Curl/FBM: from {repo} → `glsl/chunks.ts`
+- Bloom/post: from {repo} → stage post stack
+- Morph/reveal bias: from {repo} → reveal timeline / weights map
+
+## Next Steps
+
+- Pick 1–2 high‑impact techniques; open tiny PR plan with collision matrix and checks.


### PR DESCRIPTION
## Summary
- add 2025-09-20 Dreamdust Ink current architecture stub from template
- add 2025-09-20 Dreamdust Ink target architecture stub from template
- add 2025-09-20 Dreamdust Ink external repos survey stub from template

## Verification
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint || true
- CI=1 pnpm --filter cryptiq-mindmap-demo run build
- pnpm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cdf6d57ac08328b6301629d0e7e0f8