### PR TITLE
docs: standardize Dreamdust mask brief and add assets dir

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
@@ -2,6 +2,8 @@
 
 - Scope: End-to-end smoke of “Dreamdust Ink” in `apps/cryptiq-mindmap-demo` only; no cross‑workspace edits.
 
+> Dated snapshot of [`dreamdust-ink-mask-single-source-brief.md`](./dreamdust-ink-mask-single-source-brief.md) captured on **2025-09-20**.
+
 ### END EXPERIENCE
 
 **NOTE:** This is, by far, the _most_ important thing; I **do not** care about anything but the beauty of the end experience.

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/dreamdust-ink-mask-single-source-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/dreamdust-ink-mask-single-source-brief.md
@@ -2,6 +2,8 @@
 
 - Scope: End-to-end smoke of “Dreamdust Ink” in `apps/cryptiq-mindmap-demo` only; no cross‑workspace edits.
 
+> Canonical dated snapshot: [`2025-09-20-dreamdust-ink-mask-brief.md`](./2025-09-20-dreamdust-ink-mask-brief.md)
+
 ### END EXPERIENCE
 
 **NOTE:** This is, by far, the _most_ important thing; I **do not** care about anything but the beauty of the end experience.


### PR DESCRIPTION
## Summary
- add reciprocal cross-links between the Dreamdust Ink single-source and dated briefs to clarify canonical ownership
- create an `assets/` directory (tracked via `.gitkeep`) for forthcoming Dreamdust Ink mask resources

## Testing
- corepack enable
- pnpm install --frozen-lockfile
- pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
- pnpm --filter cryptiq-mindmap-demo run lint (fails with existing lint warnings/errors; allowed per instructions)
- CI=1 pnpm --filter cryptiq-mindmap-demo run build
- pnpm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cdf6cd583c8328915823cda9ab1a73