### PR TITLE
docs: add generic templates, policy, PR template, labeler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+## Scope
+- Files changed match the task prompt only
+- Minimal, reversible diff; no lockfile or unrelated package changes
+
+## Evidence
+- Inputs (template/refs used): {list}
+- Outputs (files/paths): {list}
+- Citations (code paths/logs): {list with paths or verbatim log lines}
+
+## Baseline outputs (paste)
+Internal Error: EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/local/bin/pnpm'
+    at async Object.symlink (node:internal/fs/promises:1004:10)
+    at async EnableCommand.generatePosixLink (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23156:5)
+    at async Promise.all (index 0)
+    at async EnableCommand.execute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23143:5)
+    at async EnableCommand.validateAndExecute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:20258:22)
+    at async _Cli.run (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21195:18)
+    at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23642:19)
+Scope: all 19 workspace projects
+Lockfile is up to date, resolution step is skipped
+Already up to date
+
+. prepare$ husky install
+. prepare: husky - install command is DEPRECATED
+. prepare: Done
+Done in 2.2s
+
+> cryptiq-mindmap-demo@0.1.0 lint /workspace/apps/cryptiq-mindmap-demo
+> next lint
+
+/workspace/apps/cryptiq-mindmap-demo:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
+Exit status 1
+
+> cryptiq-mindmap-demo@0.1.0 build /workspace/apps/cryptiq-mindmap-demo
+> next build
+
+   ▲ Next.js 15.3.5
+   - Environments: .env.local
+
+   Creating an optimized production build ...
+ ✓ Compiled successfully in 15.0s
+   Skipping validation of types
+   Skipping linting
+   Collecting page data ...
+   Generating static pages (0/7) ...
+   Generating static pages (1/7) 
+   Generating static pages (3/7) 
+   Generating static pages (5/7) 
+ ✓ Generating static pages (7/7)
+   Finalizing page optimization ...
+   Collecting build traces ...
+
+Route (app)                                 Size  First Load JS
+┌ ○ /                                    3.71 kB         106 kB
+├ ○ /_not-found                            143 B         102 kB
+├ ƒ /api/brain-acceptance                  143 B         102 kB
+├ ƒ /api/og                                143 B         102 kB
+├ ○ /brain                                 27 kB         357 kB
+├ ○ /debug/caps                             5 kB         107 kB
+├ ○ /draw3d                              7.83 kB         335 kB
+├ ƒ /quiz/[slug]                         31.5 kB         362 kB
+└ ƒ /result/[id]                         2.04 kB         104 kB
++ First Load JS shared by all             102 kB
+  ├ chunks/226-98d803d27003ca72.js       46.6 kB
+  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
+  └ other shared chunks (total)          2.22 kB
+
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+
+
+> @refinery/monorepo@0.0.0 smoke /workspace
+> node -e "console.log('smoke ok')"
+
+smoke ok

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+docs:
+  - "docs/**"
+templates:
+  - "docs/**/_template.*.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,88 @@ NEXT_PUBLIC_ENABLE_CONTROLS=0
 - PR passes the minimal CI pipeline.
 - Diff is limited to the requested scope; no incidental lockfile churn.
 - A brief verification note is included in the PR body.
+
+## Codex Cloud Policy (Generic)
+
+- One‑PR‑per‑task: Each Codex task must produce exactly one PR; do not coordinate multiple PRs within a single task.
+- Branch names: ; target base branch as specified in the task.
+- Scope: Modify only files explicitly listed in the task prompt and those allowed by this policy; avoid lockfile churn and cross‑package edits unless the prompt explicitly requires them.
+- Evidence: Every claim must cite exact file paths or paste verbatim logs/snippets. No speculative assertions.
+- Required baseline (paste outputs in PR body):
+  Internal Error: EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/local/bin/pnpm'
+    at async Object.symlink (node:internal/fs/promises:1004:10)
+    at async EnableCommand.generatePosixLink (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23156:5)
+    at async Promise.all (index 0)
+    at async EnableCommand.execute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23143:5)
+    at async EnableCommand.validateAndExecute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:20258:22)
+    at async _Cli.run (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21195:18)
+    at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23642:19)
+Scope: all 19 workspace projects
+Lockfile is up to date, resolution step is skipped
+Already up to date
+
+   ╭───────────────────────────────────────────────────────────────────╮
+   │                                                                   │
+   │                Update available! 9.15.1 → 10.17.0.                │
+   │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v10.17.0   │
+   │                 Run "pnpm add -g pnpm" to update.                 │
+   │                                                                   │
+   ╰───────────────────────────────────────────────────────────────────╯
+
+
+. prepare$ husky install
+. prepare: husky - install command is DEPRECATED
+. prepare: Done
+Done in 4s
+
+> cryptiq-mindmap-demo@0.1.0 lint /workspace/apps/cryptiq-mindmap-demo
+> next lint
+
+/workspace/apps/cryptiq-mindmap-demo:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
+Exit status 1
+
+> cryptiq-mindmap-demo@0.1.0 build /workspace/apps/cryptiq-mindmap-demo
+> next build
+
+   ▲ Next.js 15.3.5
+   - Environments: .env.local
+
+   Creating an optimized production build ...
+ ✓ Compiled successfully in 17.0s
+   Skipping validation of types
+   Skipping linting
+   Collecting page data ...
+   Generating static pages (0/7) ...
+   Generating static pages (1/7) 
+   Generating static pages (3/7) 
+   Generating static pages (5/7) 
+ ✓ Generating static pages (7/7)
+   Finalizing page optimization ...
+   Collecting build traces ...
+
+Route (app)                                 Size  First Load JS
+┌ ○ /                                    3.71 kB         106 kB
+├ ○ /_not-found                            143 B         102 kB
+├ ƒ /api/brain-acceptance                  143 B         102 kB
+├ ƒ /api/og                                143 B         102 kB
+├ ○ /brain                                 27 kB         357 kB
+├ ○ /debug/caps                             5 kB         107 kB
+├ ○ /draw3d                              7.83 kB         335 kB
+├ ƒ /quiz/[slug]                         31.5 kB         362 kB
+└ ƒ /result/[id]                         2.04 kB         104 kB
++ First Load JS shared by all             102 kB
+  ├ chunks/226-98d803d27003ca72.js       46.6 kB
+  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
+  └ other shared chunks (total)          2.22 kB
+
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+
+
+> @refinery/monorepo@0.0.0 smoke /workspace
+> node -e "console.log('smoke ok')"
+
+smoke ok
+- File discipline: Prefer one new/edited artifact per PR when possible; keep diffs minimal and reversible; templates are read‑only unless the prompt says otherwise.

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
@@ -4,6 +4,8 @@
 - Use the templates below to standardize documentation and planning.
 
 ## Templates
+- Acceptance Keys Registry: `_template.acceptance-keys.md`
+- Deterministic Test Protocol: `_template.test-protocol.md`
 
 - Brief: `_template.dreamdust-ink-mask-brief.md`
 - Current Architecture: `_template.architecture-current.md`

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.acceptance-keys.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.acceptance-keys.md
@@ -1,0 +1,21 @@
+# Acceptance Keys Registry (Template)
+
+## Canonical log keys (exact strings or regex you will use)
+- key1: 
+- key2: 
+- key3: 
+
+## Source of truth objects
+- Example: “caps snapshot” emitted once at canvas/material creation
+- Policy: emit once; freeze; consume consistently across modules
+
+## Thresholds & single-shot policy
+- Example thresholds (edit per project):
+  - points ≤ {CAP}
+  - DPR ≤ {MAX_DPR}
+  - one caps log/session; one instances log/session
+  - frame-percentiles: one snapshot after ~{N} frames; p50 ≤ {MS} desktop
+
+## Validation notes
+- Define which logs MUST appear once and which MUST NOT repeat
+- Define acceptable ranges for performance proxies

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.test-protocol.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.test-protocol.md
@@ -1,0 +1,14 @@
+# Deterministic Test Protocol (Template)
+
+## Route
+- 
+
+## Steps
+1. Clear build cache:  then start dev: 
+2. Hard reload the route; wait for required one-shot logs
+3. Capture screenshot at key moment(s); perform interaction(s) 
+4. Save logs and screenshots under 
+
+## Expected one-shots (edit for your project)
+- {key1}, {key2}, {key3}
+- No shader/compile/program errors (if applicable)


### PR DESCRIPTION
Docs-only PR adding two generic templates (_template.acceptance-keys.md, _template.test-protocol.md), tracking assets/.gitkeep, updating README templates section, appending generic Codex Cloud Policy to AGENTS.md, and adding PR template + labeler.\n\nDiff is docs + .github only. Baseline unchanged.