### PR TITLE
docs(dreamdust): add 2025-09-20 deterministic test protocol

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-test-protocol.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-test-protocol.md
@@ -1,0 +1,64 @@
+# Deterministic Test Protocol — 2025-09-20
+
+## Route
+- Launch: `http://localhost:3000/quiz/archetype-v1?pc=scene-02&debug=1`
+- Query params: `pc=scene-02` (prebaked cat layout), `debug=1` to surface logs and overlays
+- Browser prep: open a fresh incognito window, disable extensions, and perform a hard reload (`Cmd+Shift+R` / `Ctrl+Shift+R`) after first paint
+
+## Steps
+1. **Cache reset and dev boot**
+   - Clear the Next build cache: `rm -rf apps/cryptiq-mindmap-demo/.next`
+   - Start the Dreamdust dev server: `pnpm --filter cryptiq-mindmap-demo run dev`
+   - Wait for `ready - started server on http://localhost:3000` before loading the route
+2. **Initial load + countdown observation**
+   - Navigate to the canonical URL above and let the cinematic countdown complete without interaction
+   - Confirm no console errors and note the first burst of Dreamdust one-shot logs
+3. **Ink interaction sweep**
+   - Perform one short tap (press + release) near canvas center; observe local buoyant curls and heatmap alignment
+   - Perform one long stroke covering 40–60% of canvas width; watch the cascade recolor and hold the reveal for at least 5 seconds
+4. **Capture + archive**
+   - Screenshot at the payoff moment: immediately after the long-stroke cascade settles and the centered label appears
+   - Save the DevTools console log (preserve log enabled) and the screenshot into the dated `dreamdust-ink-mask` evidence folder
+
+### Cache clear & dev commands (exact)
+```bash
+rm -rf apps/cryptiq-mindmap-demo/.next
+pnpm --filter cryptiq-mindmap-demo run dev
+```
+
+### Log & screenshot capture points
+- **Server boot**: record the successful Next dev banner and confirm no compilation warnings
+- **First paint**: capture the `[dreamdust] caps …` one-shot payload
+- **Post-short tap**: note `[dreamdust] ink-latency { … }` and the absence of fallback logs
+- **Post-long stroke**: capture `[Dreamdust] reveal end { duration: ~2 }` and take the payoff screenshot
+- **Session end**: export the console log containing all Acceptance Key events and attach the screenshot to the run report
+
+## Expected one-shots mapped to Acceptance Keys
+- **AK-DD-01 — Caps Snapshot**: `[dreamdust] caps { vertexInkOk: true, dprClamp: 1.8, … }` emitted exactly once on canvas creation
+- **AK-DD-02 — Instance Count**: `[PC] instances: 134162` (±500 tolerance) logged once after geometry upload
+- **AK-DD-03 — Reveal Timeline**: `[Dreamdust] reveal start { duration: 2 }` followed by `[Dreamdust] reveal end { duration: 2 }`, each once per session
+- **AK-DD-04 — Frame Percentiles**: `[dreamdust] frame-percentiles { sampleCount: ~240, p50Ms: 8–9, p90Ms: 9–10 }` logged once after the long stroke
+- **AK-DD-05 — Ink Latency**: `[dreamdust] ink-latency { ms: ~16.7, frames: 1 }` logged once immediately after the short tap
+- **AK-DD-06 — Fallback Guard**: **Absence** of `[Dreamdust] compile timeout — falling back to PointsMaterial`; any appearance is an automatic fail
+
+## Pass/Fail Rubric
+- **Pass** when all Acceptance Key one-shots fire exactly once (or remain absent for AK-DD-06), visuals match the brief (ethereal mist, smooth cascade, stable HUD), and no WebGL/program errors appear in the console
+- **Conditional Retry** if visuals match but exactly one Acceptance Key is missing due to suspected logging glitch; rerun once after clearing cache before marking fail
+- **Fail** if any Acceptance Key fires multiple times, any required log is missing after a retry, the fallback log appears, caps/instances exceed thresholds, or the visual experience diverges from the brief (jitter, lag, missing payoff label)
+
+## Failure triage (text flowchart)
+1. Verify cache reset and dev boot commands were executed; if not, rerun Step 1 then repeat the protocol
+2. If Acceptance Key logs are missing, reload with DevTools “Preserve log” enabled and re-run short tap + long stroke
+3. If visuals are off but logs look correct, toggle `debug=1` overlays to confirm ink sampling; if overlays fail, restart dev server
+4. If fallback or WebGL errors persist after restart, capture logs/screenshots immediately and escalate to Dreamdust owner
+
+## Baseline commands (reference)
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit \
+  || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
+pnpm --filter cryptiq-mindmap-demo run lint || true
+pnpm --filter cryptiq-mindmap-demo run build
+pnpm run smoke
+```


### PR DESCRIPTION
## Inputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.test-protocol.md`

## Outputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-test-protocol.md`

## Evidence
- Deterministic protocol filled with route, cache reset commands, capture points, Acceptance Key mapping, rubric, and failure triage flow. 【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-test-protocol.md†L1-L64】

## Baseline command outputs
```
Internal Error: EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/local/bin/pnpm'
    at async Object.symlink (node:internal/fs/promises:1004:10)
    at async EnableCommand.generatePosixLink (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23156:5)
    at async Promise.all (index 0)
    at async EnableCommand.execute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23143:5)
    at async EnableCommand.validateAndExecute (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:20258:22)
    at async _Cli.run (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21195:18)
    at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23642:19)
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

   ╭───────────────────────────────────────────────────────────────────╮
   │                                                                   │
   │                Update available! 9.15.1 → 10.17.0.                │
   │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v10.17.0   │
   │                 Run "pnpm add -g pnpm" to update.                 │
   │                                                                   │
   ╰───────────────────────────────────────────────────────────────────╯


. prepare$ husky install
. prepare: husky - install command is DEPRECATED
. prepare: Done
Done in 4s

> cryptiq-mindmap-demo@0.1.0 lint /workspace/apps/cryptiq-mindmap-demo
> next lint

/workspace/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

> cryptiq-mindmap-demo@0.1.0 build /workspace/apps/cryptiq-mindmap-demo
> next build

   ▲ Next.js 15.3.5
   - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully in 17.0s
   Skipping validation of types
   Skipping linting
   Collecting page data ...
   Generating static pages (0/7) ...
   Generating static pages (1/7)
   Generating static pages (3/7)
   Generating static pages (5/7)
 ✓ Generating static pages (7/7)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                    3.71 kB         106 kB
├ ○ /_not-found                            143 B         102 kB
├ ƒ /api/brain-acceptance                  143 B         102 kB
├ ƒ /api/og                                143 B         102 kB
├ ○ /brain                                 27 kB         357 kB
├ ○ /debug/caps                             5 kB         107 kB
├ ○ /draw3d                              7.83 kB         335 kB
├ ƒ /quiz/[slug]                         31.5 kB         362 kB
└ ƒ /result/[id]                         2.04 kB         104 kB
+ First Load JS shared by all             102 kB
  ├ chunks/226-98d803d27003ca72.js       46.6 kB
  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
  └ other shared chunks (total)          2.22 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand


> @refinery/monorepo@0.0.0 smoke /workspace
> node -e "console.log('smoke ok')"

smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68cee33259648328abd7536b549b68a0