### PR TITLE
docs: add 2025-09-20 Dreamdust acceptance keys registry

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-acceptance-keys.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-acceptance-keys.md
@@ -1,0 +1,33 @@
+# Dreamdust Ink — Acceptance Keys Registry (2025-09-20)
+
+## Canonical log keys (exact strings or regex you will use)
+
+| Key label | Regex anchor | Must appear once? | Sample line |
+| --- | --- | --- | --- |
+| `[dreamdust] caps` | `^\\[dreamdust\\] caps\\s` | Yes — single snapshot per session | `[dreamdust] caps { vertexInkOk: true, floatOk: true, aliasedPointSizeRange: [1, 64], dpr: 2, dprClamp: 1.8 }` |
+| `[PC] instances` | `^\\[PC\\] instances:` | Yes — emit after geometry upload | `[PC] instances: 134162` |
+| `[Dreamdust] reveal start` | `^\\[Dreamdust\\] reveal start\\b` | Yes — one per reveal cycle | `[Dreamdust] reveal start { duration: 2.000 }` |
+| `[Dreamdust] reveal end` | `^\\[Dreamdust\\] reveal end\\b` | Yes — completes each reveal | `[Dreamdust] reveal end { duration: 2.000 }` |
+| `[dreamdust] frame-percentiles` | `^\\[dreamdust\\] frame-percentiles\\s` | Yes — single sample once ≥240 frames collected | `[dreamdust] frame-percentiles { sampleCount: 240, p50Ms: 8.300, p90Ms: 9.100 }` |
+| `[dreamdust] ink-latency` | `^\\[dreamdust\\] ink-latency\\s` | Yes — first successful ink latency capture | `[dreamdust] ink-latency { ms: 16.667, frames: 1.00 }` |
+| `[Dreamdust] compile timeout — falling back to PointsMaterial` | `^\\[Dreamdust\\] compile timeout — falling back to PointsMaterial$` | No — only when shader watchdog triggers fallback | `[Dreamdust] compile timeout — falling back to PointsMaterial` |
+
+## Source of truth objects
+
+- Caps snapshot emits from `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx` via the `logOnce('caps', …)` helper in `metrics.ts` and must fire exactly once when the stage binds Dreamdust uniforms. That payload is the frozen source of truth for `vertexInkOk`, `dprClamp`, and instance guardrails across all consumers.
+
+## Thresholds & single-shot policy
+
+- Desktop DPR clamp must remain ≤ **1.8**; any deviation should flag a regression in the caps payload.
+- Desktop instancing budget stays ≤ **150,000** points; `[PC] instances` should report the actual count and must not exceed this guardrail.
+- Frame percentiles taken after ~240 frames: enforce **p50 ≤ 9 ms** and **p90 ≤ 10 ms** as the acceptance window for 60 FPS parity.
+- Ink latency measurement should land ≤ **20 ms** (≤1.2 frames) to preserve the responsive “ink-in-air” feel.
+- Reveal start/end remain a paired one-shot per cascade: once `[Dreamdust] reveal start` fires, exactly one `[Dreamdust] reveal end` should close the cycle within 1–3 s.
+- Compile timeout log only appears if the shader watchdog trips; absence of this line confirms the main Dreamdust program compiled successfully.
+
+## Validation notes
+
+- Audit log captures to ensure every “Yes” key appears exactly once per smoke session; duplicate caps/percentiles/ink-latency entries indicate a regression in the one-shot guards.
+- When fallback triggers, confirm the compile-timeout log is singular and that the system continues with the PointsMaterial path without repeating the watchdog message.
+- Cross-check caps payload against reveal logs: mismatched `vertexInkOk` or `dprClamp` readings imply the source-of-truth snapshot is drifting.
+- Verify frame-percentile thresholds alongside the instances count to ensure performance guardrails (≤150 k points at ≤10 ms p90) remain intact.


### PR DESCRIPTION
## Inputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.acceptance-keys.md`

## Outputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-acceptance-keys.md`

## Evidence
- Filled out canonical Dreamdust acceptance keys, regex anchors, and sample lines, plus source-of-truth and threshold policies. 【docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-acceptance-keys.md†L5-L33】

## Baseline
- Not re-run (docs-only change).


------
https://chatgpt.com/codex/tasks/task_e_68cee3269f848328b64924c6c12798c2