### PR TITLE
docs: add Dreamdust index and cross-links (2025-09-20)

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
@@ -100,3 +100,10 @@
 ## Open Questions
 
 <!-- reserved; decisions tracked here in future updates -->
+
+## Cross-links
+
+- [2025-09-20 — Acceptance Keys](./2025-09-20-acceptance-keys.md)
+- [2025-09-20 — Architecture (Current)](./2025-09-20-architecture-current.md)
+- [2025-09-20 — External Repos Survey](./2025-09-20-external-repos-survey.md)
+- [2025-09-20 — Test Protocol](./2025-09-20-test-protocol.md)

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
@@ -28,3 +28,9 @@
 2. Draft “External Repos Survey” with concrete adaptation notes.
 3. Define “Target Architecture” and presets.
 4. Publish a dated “Brief” with acceptance criteria and test protocol.
+
+## Index
+- [2025-09-20 — Acceptance Keys](./2025-09-20-acceptance-keys.md)
+- [2025-09-20 — Architecture (Current)](./2025-09-20-architecture-current.md)
+- [2025-09-20 — External Repos Survey](./2025-09-20-external-repos-survey.md)
+- [2025-09-20 — Test Protocol](./2025-09-20-test-protocol.md)


### PR DESCRIPTION
## Inputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md`
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md`

## Outputs
- Appended index links in the Dreamdust documentation README for dated references.
- Added a cross-links section to the 2025-09-20 Dreamdust brief.

## Evidence
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md` lines 32-36.
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md` lines 104-109.

## Baseline command outputs
- Not run (docs-only change).


------
https://chatgpt.com/codex/tasks/task_e_68cee8e7bf9c8328b08366e3d68334b8