### PR TITLE
docs: add dreamdust 2025-09-20 presets

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-presets.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-presets.md
@@ -1,0 +1,64 @@
+# Dreamdust Ink Presets — 2025-09-20
+
+## Target Parameter Ranges
+
+| Parameter | Min | Max | Notes |
+| --- | --- | --- | --- |
+| revealDuration | 1 s | 3 s | Target reveal window for mist-to-image pacing (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| curlFactor | 0 | 1 | Normalized curl strength span for shader noise mixing (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| evolution | 0 | 1 | Normalized temporal FBM evolution budget (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| inkGain | 0 | 2 | Scalar range for ink intensity amplification (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| rimGamma | 1 | 3 | Rim-light gamma shaping bounds for sprite falloff (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| breathAmp | 0 | 0.2 | Breath oscillation ceiling to preserve subtle holds (per [_template.architecture-target.md](./_template.architecture-target.md)). |
+| cascadeRate | 0 | 1 | Cascade mix is clamped in shader, so timelines must stay normalized (see [`DreamdustMaterial.ts`](../../../../apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts)). |
+
+## Smoke-Test Acceptance Keys (non-visual)
+
+Ensure every preset run maintains the one-shot log discipline captured in the dated acceptance registry ([`2025-09-20-test-protocol.md`](./2025-09-20-test-protocol.md)):
+
+- **AK-DD-03 — Reveal Timeline**: Single `[Dreamdust] reveal start`/`[Dreamdust] reveal end` pair with durations matching the preset’s reveal window.
+- **AK-DD-04 — Frame Percentiles**: `[dreamdust] frame-percentiles` sample once after the long-stroke check to confirm performance holds.
+- **AK-DD-05 — Ink Latency**: `[dreamdust] ink-latency` stays within the ≤1-frame response window after a tap, confirming the preset does not hinder input latency.
+- **AK-DD-06 — Fallback Guard**: Absence of the shader fallback log continues to be the success criteria across presets.
+
+## Preset A — “Breathy Hold”
+
+| Parameter | Value |
+| --- | --- |
+| revealDuration | 2.0 s |
+| breathAmp | 0.06 |
+| curlFactor | 0.20 |
+| evolution | 0.20 |
+| inkGain | 0.40 |
+| rimGamma | 2.0 |
+| cascadeRate | 0.00 |
+
+**When to use:** Default playback for calm countdowns where the audience needs a lingering reveal without cascade motion; pair with AK-DD-03/05/06 smoke checks to confirm the relaxed pacing still respects one-shot logs (see [`2025-09-20-test-protocol.md`](./2025-09-20-test-protocol.md)).
+
+## Preset B — “Tap Twirl”
+
+| Parameter | Value |
+| --- | --- |
+| revealDuration | 1.6 s |
+| breathAmp | 0.08 |
+| curlFactor | 0.45 |
+| evolution | 0.35 |
+| inkGain | 0.90 |
+| rimGamma | 1.8 |
+| cascadeRate | 0.10 |
+
+**When to use:** Choose for interaction-focused demos that highlight tight tap curls and moderate cascade onset; verify AK-DD-03/04/05 remain single-shot during smoke validation to ensure the increased energy does not destabilize telemetry (see [`2025-09-20-test-protocol.md`](./2025-09-20-test-protocol.md)).
+
+## Preset C — “Vapor Takeover”
+
+| Parameter | Value |
+| --- | --- |
+| revealDuration | 1.8 s |
+| breathAmp | 0.05 |
+| curlFactor | 0.35 |
+| evolution | 0.50 |
+| inkGain | 1.40 |
+| rimGamma | 1.6 |
+| cascadeRate | 0.85 |
+
+**When to use:** Deploy for showcase moments where a rapid vapor cascade should overtake the canvas; audit AK-DD-03/04/05/06 after smoke runs to confirm the aggressive cascade still honors reveal timing, performance, and fallback guards (see [`2025-09-20-test-protocol.md`](./2025-09-20-test-protocol.md)).


### PR DESCRIPTION
## Inputs
- Referenced `_template.architecture-target.md` for target tunable ranges.
- Referenced `2025-09-20-test-protocol.md` acceptance keys and `DreamdustMaterial.ts` shader clamp details.

## Outputs
- Added `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-presets.md`.

## Evidence
- Documented target parameter ranges, acceptance key guardrails, and three preset payloads with usage notes for Breathy Hold, Tap Twirl, and Vapor Takeover.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-presets.md†L3-L64】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L260-L274】

## Baseline command outputs
- `corepack enable`【5eb166†L1-L2】
- `pnpm install --frozen-lockfile`【a5563a†L1-L2】【b0aba6†L1-L6】
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`【22b6c3†L1-L2】【7155a7†L1-L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true` (fails on existing lint issues)【5f5d90†L1-L5】【d157ee†L1-L55】
- `pnpm --filter cryptiq-mindmap-demo run build` (blocked by Google Fonts fetch failures)【739b74†L1-L5】【8dacd7†L1-L3】【0ff367†L1-L77】【0c91c3†L1-L14】
- `pnpm run smoke`【ea166a†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68ceee10ef008328ace1bb2de56994a8