### PR TITLE
docs(dreamdust): add 2025-09-20 target architecture

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md
@@ -1,0 +1,67 @@
+# Dreamdust Ink — Target Architecture & Experience Map (2025-09-20)
+
+## Experience Goals (recap)
+
+- Mist should ease into the prebaked image within 1–3 seconds, then settle into a calm, “breathy” silhouette with stable brightness.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L11-L20】
+- Short taps trigger localized curls and soft point-size/tint pulses that resolve within ~2 seconds while respecting the held shape.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L13-L15】
+- Long strokes vaporize into a smoke-like cascade that recolors the full canvas with the active concept hue, delivering a single payoff label moment.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L15-L20】
+- HUD remains minimal (Clear/Undo/Auto/FPS) while Dreamdust emits a single caps snapshot as the source of truth for vertex ink and DPR clamp.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L17-L20】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1429】
+
+## Why these targets
+
+- The latest smoke run hit all one-shot logs (`caps`, `[PC] instances`, reveal start/end, frame percentiles, ink latency) but the cloud still read as a “vibrating haze” with no visible ink response despite heatmap activity, so the targets focus on clarity, curl staging, and ink gains to close that gap.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L64-L69】
+
+## Target Data Flow
+
+1. Pointer events feed the off-screen Dreamdust ink canvas, painting gradients into a `THREE.DataTexture` and throttling flushes to a single RAF per frame.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx†L93-L149】
+2. The interaction texture streams into the stage uniforms through `PointCloudStage` so Dreamdust uniforms always reference the live `uInkTex` and caps-derived toggles.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L703-L798】
+3. Vertex processing unprojects mist positions, applies curl+FBM forces, breath modulation, and ink-driven offsets to drive the reveal path.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L208-L299】
+4. Fragment shading samples soft-sprite and rim helpers, blending cascade color and ink tint fallbacks when vertex ink is unavailable.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L315-L400】
+5. Optional bloom renders through an `EffectComposer` pass after the Dreamdust draw to reinforce the luminous payoff.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L496-L528】
+6. HUD overlays (`InkFieldHost`) lock controls, push ink stats, and emit latency metrics while the telemetry layer logs percentiles once per session.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx†L177-L307】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L300-L409】
+7. The quiz route mounts Dreamdust inside `DreamdustProvider`, ensuring the stage and HUD remain the single interactive surface for the mask round.【F:apps/cryptiq-mindmap-demo/app/quiz/[slug]/page.tsx†L119-L228】
+
+## Module Responsibilities (target)
+
+- **Ink capture (`InkSurface.tsx`)** — Maintain RAF-throttled texture flushes, pointer distance logging, and gradient painting while preparing for pressure-aware tap vs stroke thresholds.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx†L120-L218】
+- **Dreamdust stage (`PointCloudStage.tsx`)** — Bind live ink textures, propagate caps to uniforms, enforce the single `logOnce('caps', …)` snapshot, and keep bloom optional for devices under budget.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L703-L817】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1446】
+- **Material & uniforms (`DreamdustMaterial.ts`)** — Keep vertex/fragment GLSL aligned with curl, vapor, tap impulses, rim lighting, and ink tint fallbacks without leaking attribute declarations into shared chunks.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L208-L400】
+- **GLSL chunks (`glsl/chunks.ts`)** — Preserve pure helper functions for FBM, curl, rim falloff, and depth fades so material assembly can inline without side effects.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts†L327-L416】
+- **Metrics (`metrics.ts`)** — Continue one-shot ink latency and frame percentile logging, tighten tunable clamps, and expose preset-safe ranges to the HUD.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L144-L209】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L341-L409】
+- **Route (`app/quiz/[slug]/page.tsx`)** — Ensure Dreamdust remains the default scene when `pc` is present, with the HUD layered once over the full-viewport stage container.【F:apps/cryptiq-mindmap-demo/app/quiz/[slug]/page.tsx†L119-L228】
+
+## Tunables & Presets (target ranges)
+
+- `revealDuration`: 1–3 s to keep mist→image pacing tight while staying within the stored `revealMs` clamp range.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L144-L209】
+- `breathAmp`: 0–0.15 so the `uBreath` modulation stays calm and avoids haze jitter in the mist hold.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L226-L283】
+- `curlFactor`: 0–0.6 (maps to `uDriftAmp * uCurlAmp`) to stage localized twirls without overwhelming the silhouette.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L260-L268】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L731-L743】
+- `evolution`: 0–1 to gate reveal noise speed and vapor FBM blend, keeping the countdown smooth before cascade onset.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L352-L375】
+- `inkGain`: 0–2 across offset/size/tint channels so ink reactions read instantly without clipping point size or tint.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L738-L743】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L287-L295】
+- `rimGamma`: 1–3 to balance soft sprite falloff vs rim accent for both mist hold and cascade payoff.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L326-L397】
+- `cascadeRate`: 0–1, mapping to `uCascade` and vapor gain so the long-stroke recolor remains deterministic and single-shot.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L260-L275】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L387-L395】
+- Presets: maintain a calm default (mid revealDuration, low curlFactor, low inkGain) and a vapor takeover preset (short revealDuration, higher cascadeRate, elevated inkGain) built from these ranges.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L144-L209】
+
+## Acceptance (non-visual)
+
+- `[dreamdust] caps` and `[PC] instances` log exactly once, with the instances count ≤150 k and DPR clamp ≤1.8.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1429】
+- Reveal start/end pair within 1–3 s alongside single-shot frame percentiles and ink latency output.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L64-L69】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L341-L409】
+- Pointer logs (`[PC] draw start/end`) bracket each interaction while `uInkTex` stays bound and reactive in Dreamdust uniforms.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx†L177-L340】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L287-L299】
+
+## Migration Plan
+
+1. Finalize the RAF-gated ink pipeline and expose reveal/evolution tunables in the HUD for live range testing.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx†L140-L218】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L144-L209】
+2. Tighten Dreamdust uniform defaults (breath, curl, ink gains) to land mist clarity and tap curls, then validate with smoke logs.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L731-L743】
+3. Author cascade presets (calm hold vs vapor takeover) and ensure `[Dreamdust] reveal start/end` timings align with the 1–3 s window.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L260-L395】
+4. Re-enable bloom selectively with guardrails for mobile/low-power caps, keeping luminous payoff without perf spikes.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L496-L528】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1429】
+5. Lock presets and tunable storage once visuals read correctly, then capture baseline smoke evidence for sign-off.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L214-L409】
+
+## Risks & Mitigations
+
+- **Perf spikes** — Excess curl or bloom can drop frame percentiles; clamp DPR and point budgets via caps and disable bloom when caps fail.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1446】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L400-L409】
+- **Driver quirks** — Strictly pure GLSL chunks and compile watchdog fallback keep undefined behavior from crashing the reveal path.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/glsl/chunks.ts†L327-L371】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L420-L434】
+- **Ink desync** — If the HUD and stage diverge on caps, enforce the single caps snapshot through `DreamdustProvider` before updating uniforms.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1415-L1429】【F:apps/cryptiq-mindmap-demo/app/quiz/[slug]/page.tsx†L119-L228】
+
+## Open Questions
+
+- Should cascade presets also adjust bloom strength to maintain rim readability across calm vs vapor modes?【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L496-L528】
+- Do we need additional HUD affordances to surface preset state without cluttering the minimal controls?【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkFieldHost.tsx†L177-L307】


### PR DESCRIPTION
## Inputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/_template.architecture-target.md`

## Outputs
- `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md`

## Evidence
- Captured the end-state data flow from ink capture through Dreamdust shaders, bloom, and HUD routing, tying each stage to its source file.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md†L16-L32】
- Documented module responsibilities, tunable ranges, acceptance signals, and migration checkpoints aligned with the latest smoke observations.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-architecture-target.md†L26-L66】

## Baseline
```text
$ corepack enable
```
```text
$ pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 186ms
Done in 2.5s
```
```text
$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
```
```text
$ pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
579:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
580:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
581:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1162:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array. You can also do a functional update 'setUi(u => ...)' if you only need 'ui' in the 'setUi' call.  react-hooks/exhaustive-deps
1167:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks-exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
```
```text
$ CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

▲ Next.js 15.3.5

Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
...
Failed to compile.

app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1
```
```text
$ pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68ceedf800dc8328a86a95ef14d64d29