### PR TITLE
docs: consolidate dreamdust index cross-links

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md
@@ -107,3 +107,9 @@
 - [2025-09-20 — Architecture (Current)](./2025-09-20-architecture-current.md)
 - [2025-09-20 — External Repos Survey](./2025-09-20-external-repos-survey.md)
 - [2025-09-20 — Test Protocol](./2025-09-20-test-protocol.md)
+
+## Related Docs
+
+- [2025-09-20 — Architecture (Target)](./2025-09-20-architecture-target.md)
+- [2025-09-20 — Diagnostic Guards](./2025-09-20-diagnostic-guards.md)
+- [2025-09-20 — Presets](./2025-09-20-presets.md)

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md
@@ -34,3 +34,6 @@
 - [2025-09-20 — Architecture (Current)](./2025-09-20-architecture-current.md)
 - [2025-09-20 — External Repos Survey](./2025-09-20-external-repos-survey.md)
 - [2025-09-20 — Test Protocol](./2025-09-20-test-protocol.md)
+- [2025-09-20 — Architecture (Target)](./2025-09-20-architecture-target.md)
+- [2025-09-20 — Diagnostic Guards](./2025-09-20-diagnostic-guards.md)
+- [2025-09-20 — Presets](./2025-09-20-presets.md)


### PR DESCRIPTION
## Inputs
- Requested README index updates for the 2025-09-20 Dreamdust docs.
- Requested a “Related Docs” appendix for the 2025-09-20 Dreamdust brief.

## Outputs
- Added Architecture (Target), Diagnostic Guards, and Presets links to the Dreamdust docs index.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md†L32-L39】
- Appended a “Related Docs” section to the Dreamdust brief with the same cross-links.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L104-L115】

## Evidence
- README index additions.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/README.md†L32-L39】
- Brief cross-link additions.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-20-dreamdust-ink-mask-brief.md†L104-L115】

## Baseline
- `corepack enable`【c0a23d†L1】
- `pnpm install --frozen-lockfile`【34a3ce†L1】【c14cda†L1-L3】【79d6ad†L1-L4】
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit`【7e0110†L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true` (fails existing lint rules; command allowed to continue).【4749b7†L1】【b3bedf†L1-L3】【8417bd†L1-L64】
- `pnpm --filter cryptiq-mindmap-demo run build` (fails: unable to fetch Google Fonts).【8d94e2†L1】【dea3ca†L1-L3】【a49afb†L1-L3】【7e2007†L1-L84】【340c70†L1-L15】
- `pnpm run smoke`【1ec198†L1】【32a75c†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68cef749f72083288868768a50a02ba4