### PR TITLE
chore(dreamdust): AK‑DD‑08 UV guard at InkSurface (+ mirror flags)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -1447,6 +1447,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
       >
         {/* no FitOrtho in perspective baseline */}
         <InkSurface
+          mirrorLR={!!ui.mirrorLR}
+          mirrorUD={!!ui.mirrorUD}
           onStart={() => {
             inkUpdateLoggedRef.current = false
             setDrawing(true)

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx
@@ -37,6 +37,8 @@ export type InkSurfaceProps = {
     distancePx: number
   }) => void
   onTexture?: (texture: AnyDataTexture) => void
+  mirrorLR?: boolean
+  mirrorUD?: boolean
 }
 
 const TEXTURE_SIZE = 256
@@ -58,7 +60,13 @@ type PointerState = {
   startClient: Vec2
 }
 
-export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
+export function InkSurface({
+  onStart,
+  onEnd,
+  onTexture,
+  mirrorLR = false,
+  mirrorUD = false,
+}: InkSurfaceProps) {
   const { gl } = useThree()
   const pointerStateRef = React.useRef<PointerState | null>(null)
   const drawingRef = React.useRef(false)
@@ -72,6 +80,10 @@ export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
   const onStartRef = React.useRef(onStart)
   const onEndRef = React.useRef(onEnd)
   const onTextureRef = React.useRef(onTexture)
+  const mirrorRef = React.useRef({ lr: !!mirrorLR, ud: !!mirrorUD })
+  const guardLoggedRef = React.useRef(true)
+  const guardWatchdogRef = React.useRef<number | null>(null)
+  const guardDeadlineRef = React.useRef(0)
 
   React.useEffect(() => {
     onStartRef.current = onStart
@@ -84,6 +96,10 @@ export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
   React.useEffect(() => {
     onTextureRef.current = onTexture
   }, [onTexture])
+
+  React.useEffect(() => {
+    mirrorRef.current = { lr: !!mirrorLR, ud: !!mirrorUD }
+  }, [mirrorLR, mirrorUD])
 
   React.useEffect(() => {
     if (typeof window === 'undefined') {
@@ -147,12 +163,66 @@ export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
       })
     }
 
+    const stopGuardWatchdog = () => {
+      if (guardWatchdogRef.current !== null) {
+        window.cancelAnimationFrame(guardWatchdogRef.current)
+        guardWatchdogRef.current = null
+      }
+      guardDeadlineRef.current = 0
+    }
+
+    const startGuardWatchdog = () => {
+      stopGuardWatchdog()
+      guardLoggedRef.current = false
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now()
+      guardDeadlineRef.current = now + 3000
+      const tick = () => {
+        if (guardLoggedRef.current) {
+          stopGuardWatchdog()
+          return
+        }
+        const current = typeof performance !== 'undefined' ? performance.now() : Date.now()
+        if (current >= guardDeadlineRef.current) {
+          stopGuardWatchdog()
+          return
+        }
+        guardWatchdogRef.current = window.requestAnimationFrame(tick)
+      }
+      guardWatchdogRef.current = window.requestAnimationFrame(tick)
+    }
+
+    const logInkGuard = (rawU: number, rawV: number, clampedU: number, clampedV: number) => {
+      if (guardLoggedRef.current) {
+        return
+      }
+      guardLoggedRef.current = true
+      stopGuardWatchdog()
+      const within =
+        Number.isFinite(rawU) &&
+        Number.isFinite(rawV) &&
+        rawU >= 0 &&
+        rawU <= 1 &&
+        rawV >= 0 &&
+        rawV <= 1
+      const formatValue = (value: number) => (Number.isFinite(value) ? value.toFixed(3) : 'NaN')
+      const mirror = mirrorRef.current
+      try {
+        console.log(
+          `[PC] ink-uv guard ${within ? 'ok' : 'violation'} { raw: [${formatValue(rawU)}, ${formatValue(rawV)}], clamped: [${formatValue(clampedU)}, ${formatValue(clampedV)}], mirror: { lr: ${mirror.lr}, ud: ${mirror.ud} } }`,
+        )
+      } catch {
+        // noop
+      }
+    }
+
     const resetDrawingState = () => {
       drawingRef.current = false
       pointerStateRef.current = null
       lastClientRef.current = null
       lastCanvasRef.current = null
       distanceRef.current = 0
+      guardLoggedRef.current = true
+      stopGuardWatchdog()
     }
 
     const paintDisc = (point: Vec2) => {
@@ -194,11 +264,16 @@ export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
       const rect = domElement.getBoundingClientRect()
       const width = rect.width || 0
       const height = rect.height || 0
+      const offsetX = client.x - rect.left
+      const offsetY = client.y - rect.top
+      const rawU = width > 0 ? offsetX / width : Number.NaN
+      const rawV = height > 0 ? offsetY / height : Number.NaN
+      const u = clamp01(rawU)
+      const v = clamp01(rawV)
+      logInkGuard(rawU, rawV, u, v)
       if (width <= 0 || height <= 0) {
         return
       }
-      const u = clamp01((client.x - rect.left) / width)
-      const v = clamp01((client.y - rect.top) / height)
       const canvasX = u * TEXTURE_SIZE
       const canvasY = v * TEXTURE_SIZE
       const lastClient = lastClientRef.current
@@ -243,6 +318,7 @@ export function InkSurface({ onStart, onEnd, onTexture }: InkSurfaceProps) {
       lastCanvasRef.current = null
       distanceRef.current = 0
       ctxRef.current.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE) // single-stroke heatmap
+      startGuardWatchdog()
       drawAtClient({ x: event.clientX, y: event.clientY })
       scheduleFlush()
       try {


### PR DESCRIPTION
## Inputs
- AK-DD-08 UV guard task instructions for InkSurface.

## Outputs
- Updated `apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx`
- Updated `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`

## Evidence
- Added optional mirror flags, guard logging, and a RAF watchdog in InkSurface to record raw/clamped UV coordinates with mirror metadata.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/InkSurface.tsx†L32-L383】
- Propagated mirror orientation props from PointCloudStage into InkSurface for guard reporting.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1449-L1455】

## Test Protocol
- Not run (interactive pointer session required to emit AK guard lines in the browser).

## Baseline command outputs
```
root@5f541a1bab63:/workspace/sdk# corepack enable
root@5f541a1bab63:/workspace/sdk#

root@5f541a1bab63:/workspace/sdk# pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped

Already up to date
. prepare$
│
└─ Done in 162ms
Done in 2.2s
root@5f541a1bab63:/workspace/sdk#

root@5f541a1bab63:/workspace/sdk# pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
root@5f541a1bab63:/workspace/sdk#

root@5f541a1bab63:/workspace/sdk# pnpm --filter cryptiq-mindmap-demo run lint || true

> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint



This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
579:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
580:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
581:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1162:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array. You can also do a functional update 'setUi(u => ...)' if you only need 'ui' in the 'setUi' call.  react-hooks/exhaustive-deps
1167:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
root@5f541a1bab63:/workspace/sdk#

root@5f541a1bab63:/workspace/sdk# pnpm --filter cryptiq-mindmap-demo run build

> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build


   ▲ Next.js 15.3.5

   Creating an optimized production build ...

Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 3/3...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.]

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1
root@5f541a1bab63:/workspace/sdk#

root@5f541a1bab63:/workspace/sdk# pnpm run smoke

> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok

root@5f541a1bab63:/workspace/sdk#
```


------
https://chatgpt.com/codex/tasks/task_e_68cf1e1337388328a839b11b0a9c7816