### PR TITLE
chore(dreamdust): add AK‑DD‑07 ink texture bind one‑shot

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -6,6 +6,7 @@ import type { RootState } from '@react-three/fiber'
 
 import {
   getDreamdustTunables,
+  logOnce,
   subscribeDreamdustTunables,
 } from './metrics'
 
@@ -126,6 +127,99 @@ function safeLog(...args: Parameters<typeof console.log>): void {
   }
 }
 
+type TextureMetrics = {
+  width: number
+  height: number
+  needsUpdate: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  return value
+}
+
+function readTextureDimensions(candidate: unknown):
+  | Pick<TextureMetrics, 'width' | 'height'>
+  | null {
+  if (Array.isArray(candidate)) {
+    for (const entry of candidate) {
+      const dimensions = readTextureDimensions(entry)
+      if (dimensions) {
+        return dimensions
+      }
+    }
+    return null
+  }
+
+  if (!isRecord(candidate)) {
+    return null
+  }
+
+  const potential = candidate as { width?: unknown; height?: unknown }
+  const width = toFiniteNumber(potential.width)
+  const height = toFiniteNumber(potential.height)
+
+  if (width === null || height === null) {
+    return null
+  }
+
+  return { width, height }
+}
+
+function extractInkTextureMetrics(texture: TextureLike): TextureMetrics | null {
+  if (!isRecord(texture)) {
+    return null
+  }
+
+  const record = texture as {
+    needsUpdate?: unknown
+    image?: unknown
+    source?: unknown
+    width?: unknown
+    height?: unknown
+  }
+
+  const needsUpdateValue = record.needsUpdate
+  const needsUpdate =
+    typeof needsUpdateValue === 'boolean'
+      ? needsUpdateValue
+      : Boolean(needsUpdateValue)
+
+  const candidates: unknown[] = []
+
+  if ('image' in record) {
+    candidates.push(record.image)
+  }
+
+  if ('source' in record && isRecord(record.source)) {
+    const source = record.source as { data?: unknown }
+    if ('data' in source) {
+      candidates.push(source.data)
+    }
+  }
+
+  candidates.push(record)
+
+  for (const candidate of candidates) {
+    const dimensions = readTextureDimensions(candidate)
+    if (dimensions) {
+      return {
+        width: dimensions.width,
+        height: dimensions.height,
+        needsUpdate,
+      }
+    }
+  }
+
+  return null
+}
+
 type DreamdustUniformName = keyof DreamdustUniforms
 
 type DreamdustUniformValue<Name extends DreamdustUniformName> =
@@ -219,6 +313,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
   const breathStateRef = React.useRef({
     phase: 0,
   })
+  const lastInkTextureRef = React.useRef<TextureLike | null>(null)
 
   React.useEffect(() => {
     return subscribeDreamdustTunables((next) => {
@@ -457,6 +552,24 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
   const updateInkTexture = React.useCallback(
     (texture: TextureLike | null) => {
       setUniform('uInkTex', texture)
+
+      if (texture === null) {
+        lastInkTextureRef.current = null
+        return
+      }
+
+      if (lastInkTextureRef.current === texture) {
+        return
+      }
+
+      const metrics = extractInkTextureMetrics(texture)
+      if (!metrics) {
+        return
+      }
+
+      lastInkTextureRef.current = texture
+      logOnce('ink-tex bind', metrics)
+      safeLog('[Dreamdust] ink-tex bind', metrics)
     },
     [setUniform],
   )


### PR DESCRIPTION
## Inputs
- Current Architecture
- Diagnostic Guards
- Acceptance Keys
- Test Protocol
- Canonical Brief

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts

## Evidence
- Added helpers to derive ink texture metrics safely before attempting to emit the bind log.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts†L130-L219】
- Track the last ink texture reference so a new bind emits the one-shot payload through `logOnce` and `safeLog` with the required shape.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts†L316-L316】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts†L552-L572】

## Baseline
### corepack enable
```text
root@9d890265a2e1:/workspace/sdk# corepack enable
root@9d890265a2e1:/workspace/sdk#
```

### pnpm install --frozen-lockfile
```text
root@9d890265a2e1:/workspace/sdk# pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 430ms
Done in 4.9s
root@9d890265a2e1:/workspace/sdk#
```

### pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
```text
root@9d890265a2e1:/workspace/sdk# pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
root@9d890265a2e1:/workspace/sdk#
```

### pnpm --filter cryptiq-mindmap-demo run lint || true
```text
root@9d890265a2e1:/workspace/sdk# pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
579:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
580:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
581:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1162:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array. You can also do a functional update 'setUi(u => ...)' if you only need 'ui' in the 'setUi' call.  react-hooks/exhaustive-deps
1167:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
root@9d890265a2e1:/workspace/sdk#
```

### CI=1 pnpm --filter cryptiq-mindmap-demo run build
```text
root@9d890265a2e1:/workspace/sdk# CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

   ▲ Next.js 15.3.5
   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 2/3...
... (truncated for brevity in this summary)
Failed to compile.

app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1
root@9d890265a2e1:/workspace/sdk#
```

### pnpm run smoke
```text
root@9d890265a2e1:/workspace/sdk# pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
root@9d890265a2e1:/workspace/sdk#
```


------
https://chatgpt.com/codex/tasks/task_e_68cf1e036d248328ab5a4c7e06d1d86a