### PR TITLE
chore(dreamdust): AK‑DD‑09 caps fan‑out + compile watchdog hardening

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -21,6 +21,7 @@ import { createDreamdustMaterial } from './dreamdust/DreamdustMaterial'
 import { getDreamdustCaps, type DreamdustRuntimeCaps } from './dreamdust/capabilities'
 import { useDreamdustCtx } from './dreamdust/context'
 import {
+  ackDreamdustCapsFanout,
   getDreamdustTunables,
   logOnce,
   subscribeDreamdustTunables,
@@ -310,6 +311,7 @@ function PointsMesh({
   const materialRef = React.useRef<THREE.ShaderMaterial | null>(material)
   const materialValidRef = React.useRef(false)
   const programWaitLoggedRef = React.useRef(false)
+  const compileWatchdogLoggedRef = React.useRef(false)
   const fallbackPoints = React.useMemo(
     () =>
       new THREE.PointsMaterial({
@@ -360,6 +362,7 @@ function PointsMesh({
     materialRef.current = material
     materialValidRef.current = false
     programWaitLoggedRef.current = false
+    compileWatchdogLoggedRef.current = false
     setUseFallback(false)
     return () => {
       materialValidRef.current = false
@@ -415,31 +418,61 @@ function PointsMesh({
   }, [onMaterialValid, useFallback])
 
   React.useEffect(() => {
+    if (useFallback) {
+      return
+    }
+
     let raf = 0
     let frames = 0
+    let active = true
     const MAX_FRAMES = 180
+
+    const stop = () => {
+      if (!active) return
+      active = false
+      if (raf) {
+        cancelAnimationFrame(raf)
+        raf = 0
+      }
+    }
+
     const step = () => {
+      if (!active) {
+        return
+      }
+
       const m = materialRef.current as unknown as { program?: { glProgram?: unknown } }
       if (m && m.program && m.program.glProgram) {
+        stop()
         return
       }
+
       frames += 1
       if (frames >= MAX_FRAMES) {
-        try {
-          console.log('[Dreamdust] compile timeout — falling back to PointsMaterial')
-        } catch {
-          /* noop */
+        if (!compileWatchdogLoggedRef.current) {
+          compileWatchdogLoggedRef.current = true
+          try {
+            console.log('[Dreamdust] compile timeout — falling back to PointsMaterial')
+          } catch {
+            /* noop */
+          }
         }
         setUseFallback(true)
+        stop()
         return
       }
+
       raf = requestAnimationFrame(step)
     }
-    if (!useFallback) {
-      raf = requestAnimationFrame(step)
-    }
+
+    raf = requestAnimationFrame(step)
+
     return () => {
-      if (raf) cancelAnimationFrame(raf)
+      active = false
+      if (raf) {
+        cancelAnimationFrame(raf)
+        raf = 0
+      }
     }
   }, [useFallback])
 
@@ -698,7 +731,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     packed.height > 0
   const readyFallback = fallbackGate && colorReady && !!depth16From8
   const pointBudget = React.useMemo(() => pointCap(), [])
-  const [runtimeCaps, setRuntimeCaps] = React.useState<DreamdustRuntimeCaps | null>(null)
+  const [runtimeCaps, setRuntimeCaps] = React.useState<Readonly<DreamdustRuntimeCaps> | null>(null)
 
   const dreamdustUniformApi = useDreamdustUniforms()
   const { uniforms: baseUniforms, setUniform, updateInkTexture } = dreamdustUniformApi
@@ -1380,6 +1413,11 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     return [ui.mirrorLR ? -1 : 1, ui.mirrorUD ? -1 : 1, 1] as [number, number, number]
   }, [ui.mirrorLR, ui.mirrorUD])
 
+  React.useEffect(() => {
+    if (!dreamdustCtx) return
+    dreamdustCtx.setMirrorFlags(!!ui.mirrorLR, !!ui.mirrorUD)
+  }, [dreamdustCtx, ui.mirrorLR, ui.mirrorUD])
+
   const cameraFitTarget = React.useMemo(() => [0, 0, 0] as [number, number, number], [])
   const cameraFitRadius = React.useMemo(() => {
     if (prebakedTransform) return prebakedTransform.radius
@@ -1415,16 +1453,24 @@ export default function PointCloudStage(props: PointCloudStageProps) {
         onCreated={({ gl }) => {
           const dprClamp = clampDPR(gl, 2)
           const caps = getDreamdustCaps(gl.domElement)
-          setRuntimeCaps(caps)
-          setUniform('uVertexInkOk', caps.vertexInkOk ? 1 : 0)
+          if (caps.aliasedPointSizeRange && !Object.isFrozen(caps.aliasedPointSizeRange)) {
+            Object.freeze(caps.aliasedPointSizeRange)
+          }
+          const frozenCaps = Object.freeze(caps) as Readonly<DreamdustRuntimeCaps>
+          setRuntimeCaps(frozenCaps)
           if (dreamdustCtx) {
-            dreamdustCtx.setVertexInkOk(caps.vertexInkOk)
+            dreamdustCtx.setCaps(frozenCaps)
+          }
+          ackDreamdustCapsFanout('stage')
+          setUniform('uVertexInkOk', frozenCaps.vertexInkOk ? 1 : 0)
+          if (dreamdustCtx) {
+            dreamdustCtx.setVertexInkOk(frozenCaps.vertexInkOk)
           }
           logOnce('caps', {
-            vertexInkOk: caps.vertexInkOk,
-            floatOk: caps.floatOk,
-            aliasedPointSizeRange: Array.from(caps.aliasedPointSizeRange),
-            dpr: caps.dpr,
+            vertexInkOk: frozenCaps.vertexInkOk,
+            floatOk: frozenCaps.floatOk,
+            aliasedPointSizeRange: Array.from(frozenCaps.aliasedPointSizeRange),
+            dpr: frozenCaps.dpr,
             dprClamp,
           })
           // ACES tone mapping for nicer highlights

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
@@ -2,11 +2,18 @@
 
 import * as React from 'react'
 
+import { type DreamdustRuntimeCaps } from './capabilities'
+import { ackDreamdustCapsFanout } from './metrics'
+
 type InkTexture = import('three').Texture | null
 
 type CascadeColor = [number, number, number]
 
 type StartCascade = (color: CascadeColor) => void
+
+type FrozenDreamdustCaps = Readonly<DreamdustRuntimeCaps>
+
+type MirrorState = Readonly<{ lr: boolean; ud: boolean }>
 
 type DreamdustContextValue = {
   startCascade: StartCascade
@@ -20,7 +27,16 @@ type DreamdustContextValue = {
   setControlsLocked: React.Dispatch<React.SetStateAction<boolean>>
   heatmapVisible: boolean
   setHeatmapVisible: React.Dispatch<React.SetStateAction<boolean>>
+  caps: FrozenDreamdustCaps | null
+  setCaps: (caps: FrozenDreamdustCaps | null) => void
+  mirror: MirrorState
+  setMirrorFlags: (mirrorLR: boolean, mirrorUD: boolean) => void
 }
+
+type CapsReadyCallback = (caps: FrozenDreamdustCaps) => void
+
+const capsReadyListeners = new Set<CapsReadyCallback>()
+let latestCaps: FrozenDreamdustCaps | null = null
 
 const DreamdustContext = React.createContext<DreamdustContextValue | undefined>(
   undefined,
@@ -30,9 +46,56 @@ export function DreamdustProvider({ children }: React.PropsWithChildren) {
   const cascadeStarterRef = React.useRef<StartCascade>(() => {})
   const [inkTex, setInkTex] = React.useState<InkTexture>()
   const [inkIntensity, setInkIntensity] = React.useState<number>(1)
-  const [vertexInkOk, setVertexInkOk] = React.useState<boolean>(false)
+  const capsRef = React.useRef<FrozenDreamdustCaps | null>(null)
+  const [caps, setCapsState] = React.useState<FrozenDreamdustCaps | null>(null)
+  const setCaps = React.useCallback((nextCaps: FrozenDreamdustCaps | null) => {
+    if (capsRef.current === nextCaps) {
+      return
+    }
+    capsRef.current = nextCaps
+    setCapsState(nextCaps)
+    if (nextCaps) {
+      latestCaps = nextCaps
+      ackDreamdustCapsFanout('context')
+      const listeners = Array.from(capsReadyListeners)
+      for (const listener of listeners) {
+        try {
+          listener(nextCaps)
+        } catch {
+          // Ignore listener errors to keep fan-out resilient.
+        }
+      }
+    } else if (latestCaps) {
+      latestCaps = null
+    }
+  }, [])
+  const [vertexInkOkState, setVertexInkOkState] = React.useState<boolean>(false)
+  const setVertexInkOk = React.useCallback<React.Dispatch<React.SetStateAction<boolean>>>(
+    (update) => {
+      setVertexInkOkState((prev) => {
+        const next = typeof update === 'function' ? (update as (value: boolean) => boolean)(prev) : update
+        if (capsRef.current) {
+          ackDreamdustCapsFanout('host')
+        }
+        return next === prev ? prev : next
+      })
+    },
+    [],
+  )
+  const vertexInkOk = vertexInkOkState
   const [controlsLocked, setControlsLocked] = React.useState(false)
   const [heatmapVisible, setHeatmapVisible] = React.useState(false)
+  const [mirror, setMirror] = React.useState<MirrorState>(() => Object.freeze({ lr: false, ud: true }))
+  const setMirrorFlags = React.useCallback((mirrorLR: boolean, mirrorUD: boolean) => {
+    setMirror((prev) => {
+      const nextLR = !!mirrorLR
+      const nextUD = !!mirrorUD
+      if (prev.lr === nextLR && prev.ud === nextUD) {
+        return prev
+      }
+      return Object.freeze({ lr: nextLR, ud: nextUD }) as MirrorState
+    })
+  }, [])
 
   const startCascade = React.useCallback<StartCascade>((color) => {
     cascadeStarterRef.current(color)
@@ -51,6 +114,10 @@ export function DreamdustProvider({ children }: React.PropsWithChildren) {
       setControlsLocked,
       heatmapVisible,
       setHeatmapVisible,
+      caps,
+      setCaps,
+      mirror,
+      setMirrorFlags,
     }),
     [
       startCascade,
@@ -59,6 +126,11 @@ export function DreamdustProvider({ children }: React.PropsWithChildren) {
       vertexInkOk,
       controlsLocked,
       heatmapVisible,
+      caps,
+      mirror,
+      setCaps,
+      setMirrorFlags,
+      setVertexInkOk,
     ],
   )
 
@@ -75,4 +147,29 @@ export function useDreamdustCtx() {
     throw new Error('useDreamdustCtx must be used within a DreamdustProvider')
   }
   return context
+}
+
+export function useDreamdustCaps(): FrozenDreamdustCaps | null {
+  const context = React.useContext(DreamdustContext)
+  return context?.caps ?? null
+}
+
+export function onCapsReady(callback?: CapsReadyCallback | null): () => void {
+  if (typeof callback !== 'function') {
+    return () => {}
+  }
+
+  capsReadyListeners.add(callback)
+
+  if (latestCaps) {
+    try {
+      callback(latestCaps)
+    } catch {
+      // Listener errors should not disrupt registration.
+    }
+  }
+
+  return () => {
+    capsReadyListeners.delete(callback)
+  }
 }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts
@@ -4,6 +4,72 @@
  */
 const emittedLogs = new Set<string>();
 
+export type DreamdustCapsFanoutSource = 'stage' | 'context' | 'host' | 'metrics';
+
+type CapsFanoutState = Record<DreamdustCapsFanoutSource, boolean>;
+
+const capsFanoutState: CapsFanoutState = {
+  stage: false,
+  context: false,
+  host: false,
+  metrics: false,
+};
+
+let capsFanoutLogged = false;
+let capsFanoutTimer: number | null = null;
+
+const CAPS_FANOUT_TIMEOUT_MS = 2000;
+
+function logCapsFanout(): void {
+  if (capsFanoutLogged) {
+    return;
+  }
+
+  capsFanoutLogged = true;
+
+  if (capsFanoutTimer !== null && typeof window !== 'undefined') {
+    window.clearTimeout(capsFanoutTimer);
+    capsFanoutTimer = null;
+  }
+
+  try {
+    console.info(
+      `[dreamdust] caps-fanout { stage: ${capsFanoutState.stage}, context: ${capsFanoutState.context}, host: ${capsFanoutState.host}, metrics: ${capsFanoutState.metrics} }`,
+    );
+  } catch {
+    // Swallow logging failures to avoid interrupting runtime flow.
+  }
+}
+
+function scheduleCapsFanoutTimeout(): void {
+  if (capsFanoutLogged || capsFanoutTimer !== null || typeof window === 'undefined') {
+    return;
+  }
+
+  capsFanoutTimer = window.setTimeout(() => {
+    capsFanoutTimer = null;
+    logCapsFanout();
+  }, CAPS_FANOUT_TIMEOUT_MS);
+}
+
+export function ackDreamdustCapsFanout(source: DreamdustCapsFanoutSource): void {
+  if (capsFanoutLogged) {
+    return;
+  }
+
+  if (!capsFanoutState[source]) {
+    capsFanoutState[source] = true;
+  }
+
+  if (capsFanoutState.stage) {
+    scheduleCapsFanoutTimeout();
+  }
+
+  if (capsFanoutState.stage && capsFanoutState.context && capsFanoutState.host && capsFanoutState.metrics) {
+    logCapsFanout();
+  }
+}
+
 /**
  * Cached query string that was last evaluated for debug logging.
  */
@@ -62,6 +128,10 @@ export function logOnce<T>(key: string, payload: T): void {
 
   emittedLogs.add(key);
   console.info(`[dreamdust] ${key}`, payload);
+}
+
+if (typeof window !== 'undefined') {
+  ackDreamdustCapsFanout('metrics');
 }
 
 export function logOnceKeyExists(key: string): boolean {


### PR DESCRIPTION
## Inputs
- AK‑DD‑09 caps fan‑out hardening task for PointCloudStage, Dreamdust context, and metrics surfaces.

## Outputs
- apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
- apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx
- apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts

## Evidence
- PointCloudStage freezes the runtime caps, distributes them through context with stage acknowledgements, propagates mirror flags, and hardens the compile watchdog to a one-shot fallback.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L420-L477】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1411-L1475】
- DreamdustProvider now tracks the frozen caps and mirror state, exposes `useDreamdustCaps`/`onCapsReady`, and records host/context acknowledgements without cloning.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/context.tsx†L5-L175】
- Metrics module manages caps fan-out acknowledgements, emits the consolidated log, and self-acknowledges the metrics participant on the client.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/metrics.ts†L1-L135】

## Baseline command outputs
- `corepack enable`【ae813f†L1-L1】
- `pnpm install --frozen-lockfile`【cb9ac3†L1-L5】
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`【4c1cb2†L1-L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true`【1fd9e7†L1-L35】
- `CI=1 pnpm --filter cryptiq-mindmap-demo run build` (fails to fetch Google Fonts)【de7d78†L1-L13】
- `pnpm run smoke`【797fee†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68d01aa664648328b676353c20a37b8d