### PR TITLE
tweak(dreamdust): re-enable Bloom with guardrails

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -29,7 +29,13 @@ import {
 } from './dreamdust/metrics'
 import InkSurface from './dreamdust/InkSurface'
 import { useDreamdustUniforms } from './dreamdust/useDreamdustUniforms'
-import { capInstances, clampDPR, decimateInterleaved, pointCap } from './pointcloud/budget'
+import {
+  capInstances,
+  clampDPR,
+  decimateInterleaved,
+  detectMobile,
+  pointCap,
+} from './pointcloud/budget'
 
 type PointCloudStageProps = {
   sceneId?: string
@@ -59,6 +65,71 @@ type DreamdustStageUniforms = ReturnType<typeof useDreamdustUniforms>['uniforms'
 
 type DreamdustStageUniformsWithReveal = DreamdustStageUniforms & {
   uReveal?: { value: number }
+}
+
+const BLOOM_SETTINGS = {
+  strength: 0.12,
+  radius: 0.1,
+  threshold: 0.7,
+} as const
+
+type NavigatorWithPowerHints = Navigator & {
+  deviceMemory?: number
+  connection?: {
+    saveData?: boolean
+    effectiveType?: string
+  }
+}
+
+function isLowPowerDevice(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const nav = navigator as NavigatorWithPowerHints
+
+  try {
+    const connection = nav.connection
+    if (connection) {
+      if (connection.saveData) {
+        return true
+      }
+      const effectiveType = connection.effectiveType
+      if (typeof effectiveType === 'string' && /(slow-2g|2g|3g)/i.test(effectiveType)) {
+        return true
+      }
+    }
+  } catch {
+    // Ignore connection feature detection errors.
+  }
+
+  if (
+    typeof nav.hardwareConcurrency === 'number' &&
+    Number.isFinite(nav.hardwareConcurrency) &&
+    nav.hardwareConcurrency > 0 &&
+    nav.hardwareConcurrency <= 4
+  ) {
+    return true
+  }
+
+  const deviceMemory = nav.deviceMemory
+  if (typeof deviceMemory === 'number' && Number.isFinite(deviceMemory) && deviceMemory > 0 && deviceMemory <= 4) {
+    return true
+  }
+
+  return detectMobile()
+}
+
+function readNoBloomOverride(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const params = new URLSearchParams(window.location.search)
+    return params.get('noBloom') === '1'
+  } catch {
+    return false
+  }
 }
 
 function useOptionalDreamdustCtx() {
@@ -657,6 +728,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     // omit perspective in baseline
   } = props
   const [bloomEnabled, setBloomEnabled] = React.useState(false)
+  const [noBloomOverride] = React.useState(readNoBloomOverride)
+  const [bloomEligible, setBloomEligible] = React.useState(false)
+  const [bloomGuardReady, setBloomGuardReady] = React.useState(false)
   const [drawing, setDrawing] = React.useState(false)
   const inkUpdateLoggedRef = React.useRef(false)
   const base = sceneId ? `/assets/pointclouds/${sceneId}` : null
@@ -1165,11 +1239,11 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     mirrorLR?: boolean
     mirrorUD?: boolean
     roll180?: boolean
-  }>({
+  }>(() => ({
     thickness: 0.4,
     pointSizeScale: 1.1,
     keepRatio: 1,
-    bloom: false,
+    bloom: !noBloomOverride,
     fovDeg: 20,
     reveal: 1,
     flipUp: false,
@@ -1177,7 +1251,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     mirrorLR: false,
     mirrorUD: true,
     roll180: false,
-  })
+  }))
   const [fitRequest, setFitRequest] = React.useState(0)
   const { bloom, pointSizeScale, reveal, thickness } = ui
   const thicknessScale = React.useMemo(
@@ -1189,10 +1263,20 @@ export default function PointCloudStage(props: PointCloudStageProps) {
       const p = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null
       if (p && p.get('debug') === '1') setDebugVisible(true)
       const saved = typeof window !== 'undefined' ? window.localStorage.getItem('pcDebug') : null
-      if (saved) setUi({ ...ui, ...JSON.parse(saved) })
+      if (saved) {
+        const parsed = JSON.parse(saved) as Partial<typeof ui>
+        setUi((prev) => {
+          const next = { ...prev, ...parsed }
+          if (noBloomOverride) {
+            next.bloom = false
+          }
+          return next
+        })
+      } else if (noBloomOverride) {
+        setUi((prev) => ({ ...prev, bloom: false }))
+      }
     } catch { /* noop */ }
-     
-  }, [])
+  }, [noBloomOverride])
   React.useEffect(() => {
     try {
       if (typeof window !== 'undefined') window.localStorage.setItem('pcDebug', JSON.stringify(ui))
@@ -1213,8 +1297,20 @@ export default function PointCloudStage(props: PointCloudStageProps) {
 
   // Apply bloom flag from debug panel (pure React)
   React.useEffect(() => {
-    setBloomEnabled(bloom)
-  }, [bloom])
+    setBloomEnabled(bloom && bloomEligible && !noBloomOverride)
+  }, [bloom, bloomEligible, noBloomOverride])
+
+  const bloomLogRef = React.useRef(false)
+  React.useEffect(() => {
+    if (!bloomGuardReady || bloomLogRef.current) return
+    const enabled = bloom && bloomEligible && !noBloomOverride
+    try {
+      console.info(
+        `[dreamdust] bloom { enabled: ${enabled}, strength: ${BLOOM_SETTINGS.strength}, radius: ${BLOOM_SETTINGS.radius}, threshold: ${BLOOM_SETTINGS.threshold} }`,
+      )
+    } catch { /* noop */ }
+    bloomLogRef.current = true
+  }, [bloom, bloomEligible, bloomGuardReady, noBloomOverride])
 
   React.useEffect(() => {
     uniforms.uBaseSize.value = pointSize * pointSizeScale
@@ -1452,6 +1548,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
         }}
         onCreated={({ gl }) => {
           const dprClamp = clampDPR(gl, 2)
+          const bloomAllowed = Number.isFinite(dprClamp) && dprClamp <= 1.8 && !isLowPowerDevice()
+          setBloomEligible(bloomAllowed)
+          setBloomGuardReady(true)
           const caps = getDreamdustCaps(gl.domElement)
           if (caps.aliasedPointSizeRange && !Object.isFrozen(caps.aliasedPointSizeRange)) {
             Object.freeze(caps.aliasedPointSizeRange)
@@ -1586,7 +1685,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             pointBudget={pointBudget}
             material={fallbackMaterial}
             uniforms={uniforms}
-            onMaterialValid={() => setBloomEnabled(true)}
+            onMaterialValid={() => setBloomEnabled(bloom && bloomEligible && !noBloomOverride)}
             onInstancesReady={logInstances}
           />
         ) : prebakedStatus === 'absent' && fallbackMaterial ? (
@@ -1598,7 +1697,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
               pointBudget={pointBudget}
               material={fallbackMaterial}
               uniforms={uniforms}
-              onMaterialValid={() => setBloomEnabled(true)}
+              onMaterialValid={() => setBloomEnabled(bloom && bloomEligible && !noBloomOverride)}
               onInstancesReady={logInstances}
             />
           )
@@ -1607,7 +1706,13 @@ export default function PointCloudStage(props: PointCloudStageProps) {
           radius={prebakedTransform ? prebakedTransform.radius : undefined}
           drawing={drawing}
         />
-        {bloomEnabled && <BloomPass strength={0.12} radius={0.1} threshold={0.7} />}
+        {bloomEnabled && (
+          <BloomPass
+            strength={BLOOM_SETTINGS.strength}
+            radius={BLOOM_SETTINGS.radius}
+            threshold={BLOOM_SETTINGS.threshold}
+          />
+        )}
       </Canvas>
       {debugVisible && (
         <div


### PR DESCRIPTION
## Inputs
- Applied bloom guardrails per `PointCloudStage.tsx` scope instructions.

## Outputs
- Updated `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`.

## Evidence
- Introduced bloom settings constant, low-power heuristics, and query override reader to support guard evaluation.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L70-L133】
- Gated bloom enablement via state, persisted overrides, and emitted the `[dreamdust] bloom` debug line on guard readiness.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L730-L733】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1242-L1313】
- Enforced guard in renderer creation and PointsMesh hooks while reusing shared bloom settings for rendering.【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1549-L1714】

## Baseline command outputs
```bash
$ corepack enable
root@357fe51e3422:/workspace/sdk# corepack enable
root@357fe51e3422:/workspace/sdk#

$ pnpm install --frozen-lockfile
root@357fe51e3422:/workspace/sdk# pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 167ms
Done in 2.3s
root@357fe51e3422:/workspace/sdk#

$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
root@357fe51e3422:/workspace/sdk# pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
root@357fe51e3422:/workspace/sdk#

$ pnpm --filter cryptiq-mindmap-demo run lint || true
root@357fe51e3422:/workspace/sdk# pnpm --filter cryptiq-mindmap-demo run lint || true

> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint


Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
683:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
684:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
685:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1284:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
root@357fe51e3422:/workspace/sdk#

$ CI=1 pnpm --filter cryptiq-mindmap-demo run build
root@357fe51e3422:/workspace/sdk# CI=1 pnpm --filter cryptiq-mindmap-demo run build

> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build


   ▲ Next.js 15.3.5

   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 3/3...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.]
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 3/3...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.]

Failed to compile.

app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.


> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1
root@357fe51e3422:/workspace/sdk#

$ pnpm run smoke
root@357fe51e3422:/workspace/sdk# pnpm run smoke

> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
root@357fe51e3422:/workspace/sdk#
```


------
https://chatgpt.com/codex/tasks/task_e_68d024c395148328af81bdda43ec3744