### PR TITLE
feat(dreamdust): Airy core — alpha-only reveal, soft sprites, slow drift

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -28,16 +28,16 @@ const DEFAULT_UNIFORM_VALUES = {
   uTime: 0,
   uReveal: 1,
   uBreath: 0.5,
-  uNoiseScale: 1,
-  uNoiseSpeed: 1,
+  uNoiseScale: 0.9,
+  uNoiseSpeed: 0.08,
   uNoiseThreshold: 1,
-  uDriftAmp: 0,
+  uDriftAmp: 0.6,
   uCurlFreq: 1,
-  uCurlAmp: 1,
+  uCurlAmp: 0.25,
   uDriftSpeed: 1,
   uTapGain: 0.5,
   uTapTau: 2,
-  uPointBaseSize: 1,
+  uPointBaseSize: 2.2,
   uFocal: 1,
   uMinSize: 1,
   uMaxSize: 1,
@@ -48,7 +48,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uDepthMin: 0,
   uDepthMax: 1,
   uGamma: 1,
-  uRimGamma: 2,
+  uRimGamma: 2.2,
   uDepthBias: 1.8,
   uDepthNormScale: 0.001,
   uHasCapture: 0,
@@ -61,7 +61,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uCascadeSizeBoost: 0,
   uVaporGain: 0,
   uBreathAmp: 0.08,
-  uEvolution: 1,
+  uEvolution: 0.4,
   uInkOffsetBoost: 1,
   uInkSizeBoost: 1,
   uInkTintBoost: 1,
@@ -200,6 +200,7 @@ varying float vRevealMix;
 varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 varying float vDepthView;
+varying float vViewBias;
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
@@ -294,10 +295,18 @@ void main() {
   vec4 viewPos4 = viewMatrix * vec4(revealPos, 1.0);
   vec3 viewPos = viewPos4.xyz;
   float viewDist = max(1e-3, -viewPos.z);
-  float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
+  float distanceScale = uFocal / viewDist;
+  float attenuation = clamp(distanceScale, uMinSize, uMaxSize);
   float breathScale = 1.0 + breathPhase * 0.12;
   float cascadeSize = mix(0.0, max(uCascadeSizeBoost, 0.0), cascadeMix);
+  float viewBias = clamp(distanceScale, 0.0, 1.0);
   float pointSize = uPointBaseSize * attenuation * breathScale * (1.0 + cascadeSize);
+  pointSize *= mix(1.0, 1.6, pow(viewBias, 0.9));
+
+  float instanceSeed = float(gl_InstanceID);
+  float jitterHash = dd_hash13(vec3(instanceSeed * 0.3183099, instanceSeed * 0.123, instanceSeed * 0.777));
+  float sizeJitter = mix(0.5, 0.8, jitterHash);
+  pointSize += sizeJitter;
 
   vec3 inkTint = vec3(0.0);
   float inkMix = 0.0;
@@ -330,6 +339,7 @@ void main() {
   vRevealCoord = aUv * (3.0 + uNoiseScale) + jitterSeed.xy;
   vPosMV = viewPos;
   vDepthView = viewDist;
+  vViewBias = viewBias;
 
   gl_Position = projectionMatrix * viewPos4;
 }
@@ -362,6 +372,7 @@ varying float vRevealMix;
 varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 varying float vDepthView;
+varying float vViewBias;
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_SOFT_SPRITE_CHUNK}
@@ -371,9 +382,9 @@ ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
   // Softer disc sprite for vapor look
-  vec2 pc = gl_PointCoord * 2.0 - 1.0;
-  float r = clamp(length(pc), 0.0, 1.0);
+  float r = length(gl_PointCoord * 2.0 - 1.0);
   float sprite = smoothstep(1.0, 0.0, r);
+  sprite *= sprite;
 
   float threshold = clamp(uNoiseThreshold, 0.0, 1.0);
   // Static reveal mask (no time animation) to avoid brightness pulsing
@@ -383,9 +394,11 @@ void main() {
   float baseReveal = smoothstep(threshold - 0.2, 1.0, flow);
   float revealAlpha = max(baseReveal, revealStrength * 0.35);
 
-  float alpha = sprite * revealAlpha * revealStrength;
+  float alpha = revealAlpha * revealStrength;
+  alpha *= pow(sprite, 1.35);
   float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);
   alpha *= dreamdustDepthAlpha(depthNorm, uDepthBias);
+  alpha *= mix(0.65, 1.0, clamp(vViewBias, 0.0, 1.0));
   if (alpha <= 0.001) {
     discard;
   }
@@ -419,7 +432,7 @@ void main() {
 
   float rim = dreamdustRimStrength(sprite);
   color = dreamdustApplyRimLight(color, rim);
-  alpha = dreamdustApplyRimAlpha(alpha, rim);
+  alpha = dreamdustApplyRimAlpha(alpha, rim * 0.7);
 
   color = dreamdustApplyGamma(color, uGamma);
 


### PR DESCRIPTION
## Inputs
- PR-1 — Airy core: alpha-only reveal + soft sprites + slow coherent drift (apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts)

## Outputs
- Updated `apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts` to retune Dreamdust defaults, add view-bias sizing, deterministic per-instance point jitter, and soften the fragment reveal mask so the alpha-only reveal stays time-independent with reduced rim weighting.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L27-L435】

## Evidence
- Lowered default flow speeds, enlarged base point size, and increased rim gamma to 2.2 for a softer reveal response.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L27-L66】
- Vertex shader now derives a clamped view bias, scales point size via `mix(1.0, 1.6, pow(bias, 0.9))`, applies deterministic 0.5–0.8px jitter from `gl_InstanceID`, and passes the bias to the fragment for alpha shaping.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L200-L343】
- Fragment shader computes the soft-disc sprite (`sprite *= sprite`), modulates alpha with `pow(sprite, 1.35)` and view bias, and reduces rim alpha weighting by ~30%.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L360-L435】
- Test Protocol (AK-DD-01..06) could not be executed in this headless environment; a browser session is required to generate the logs.

## Baseline
```text
$ corepack enable

$ pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 259ms
Done in 3.6s

$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit

$ pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
682:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
683:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
684:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1289:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
471:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
483:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
484:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
485:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
485:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
486:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
488:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
490:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
493:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
494:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
496:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
497:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
505:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
505:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
505:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
506:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

$ CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build
   ▲ Next.js 15.3.5
   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.
Retrying 2/3...
... (font fetch retries omitted for brevity)
Failed to compile.
app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.
app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1

$ pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"
smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68d058ab00d48328978a933ed6d5624c