### PR TITLE
feat(dreamdust): Preset “AirySmoke” (gated)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/presets.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/presets.ts
@@ -1,6 +1,7 @@
 import { getDreamdustTunables, updateDreamdustTunables, type DreamdustTunables } from './metrics'
 
 export type DreamdustMaterialPreset = {
+  fov?: number
   revealDuration: number
   breathAmp: number
   curlFactor: number
@@ -18,6 +19,17 @@ export const PresetC: DreamdustMaterialPreset = {
   inkGain: 1.4,
   rimGamma: 1.6,
   cascadeRate: 0.85,
+} as const
+
+export const PresetAiry: DreamdustMaterialPreset = {
+  fov: 27,
+  revealDuration: 1.1,
+  breathAmp: 0.03,
+  curlFactor: 0.25,
+  evolution: 0.4,
+  inkGain: 1.2,
+  rimGamma: 2.2,
+  cascadeRate: 0.6,
 } as const
 
 export type DreamdustPresetId = 'calm' | 'breathy' | 'vaporizeFast'

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -9,7 +9,7 @@ import {
   logOnce,
   subscribeDreamdustTunables,
 } from './metrics'
-import { PresetC } from './presets'
+import { PresetAiry, PresetC } from './presets'
 
 type TextureLike = unknown
 type Vec3 = [number, number, number]
@@ -236,7 +236,8 @@ function extractInkTextureMetrics(texture: TextureLike): TextureMetrics | null {
 }
 
 const PRESET_QUERY_KEY = 'preset'
-const PRESET_QUERY_VALUE = 'vapor'
+const PRESET_VAPOR_VALUE = 'vapor'
+const PRESET_AIRY_VALUE = 'airy'
 const PRESET_ENV_KEY = 'DD_PRESET'
 const INK_BUMP_QUERY_KEY = 'inkBump'
 const INK_BUMP_ENV_KEY = 'DD_INK_BUMP'
@@ -269,13 +270,24 @@ function readSearchParam(name: string): string | null {
   }
 }
 
-function detectVaporPreset(): boolean {
+function detectPresetGate(target: string): boolean {
+  if (!target) {
+    return false
+  }
   const envValue = normalizeGateValue(readEnvValue(PRESET_ENV_KEY))
-  if (envValue === PRESET_QUERY_VALUE) {
+  if (envValue === target) {
     return true
   }
   const queryValue = normalizeGateValue(readSearchParam(PRESET_QUERY_KEY))
-  return queryValue === PRESET_QUERY_VALUE
+  return queryValue === target
+}
+
+function detectVaporPreset(): boolean {
+  return detectPresetGate(PRESET_VAPOR_VALUE)
+}
+
+function detectAiryPreset(): boolean {
+  return detectPresetGate(PRESET_AIRY_VALUE)
 }
 
 function detectInkBump(): boolean {
@@ -323,24 +335,40 @@ type CascadeTimelineState = {
 }
 
 export function useDreamdustUniforms(): UseDreamdustUniformsResult {
+  const presetAiryEnabled = React.useMemo(detectAiryPreset, [])
   const presetVaporEnabled = React.useMemo(detectVaporPreset, [])
-  const inkBumpEnabled = React.useMemo(detectInkBump, [])
+  const inkBumpEnabled = React.useMemo(
+    () => (presetAiryEnabled ? false : detectInkBump()),
+    [presetAiryEnabled],
+  )
   const uniformsRef = React.useRef<DreamdustUniforms | null>(null)
 
   if (!uniformsRef.current) {
-    const breathAmpValue = presetVaporEnabled
-      ? PresetC.breathAmp
-      : DEFAULT_UNIFORM_VALUES.uBreathAmp
-    const evolutionValue = presetVaporEnabled
-      ? PresetC.evolution
-      : DEFAULT_UNIFORM_VALUES.uEvolution
-    const curlAmpValue = presetVaporEnabled
-      ? PresetC.curlFactor
-      : DEFAULT_UNIFORM_VALUES.uCurlAmp
-    const rimGammaValue = presetVaporEnabled
-      ? PresetC.rimGamma
-      : DEFAULT_UNIFORM_VALUES.uRimGamma
-    const baseInkGain = presetVaporEnabled ? PresetC.inkGain : 1
+    const breathAmpValue = presetAiryEnabled
+      ? PresetAiry.breathAmp
+      : presetVaporEnabled
+        ? PresetC.breathAmp
+        : DEFAULT_UNIFORM_VALUES.uBreathAmp
+    const evolutionValue = presetAiryEnabled
+      ? PresetAiry.evolution
+      : presetVaporEnabled
+        ? PresetC.evolution
+        : DEFAULT_UNIFORM_VALUES.uEvolution
+    const curlAmpValue = presetAiryEnabled
+      ? PresetAiry.curlFactor
+      : presetVaporEnabled
+        ? PresetC.curlFactor
+        : DEFAULT_UNIFORM_VALUES.uCurlAmp
+    const rimGammaValue = presetAiryEnabled
+      ? PresetAiry.rimGamma
+      : presetVaporEnabled
+        ? PresetC.rimGamma
+        : DEFAULT_UNIFORM_VALUES.uRimGamma
+    const baseInkGain = presetAiryEnabled
+      ? PresetAiry.inkGain
+      : presetVaporEnabled
+        ? PresetC.inkGain
+        : 1
     const inkOffsetBoostValue =
       baseInkGain * (inkBumpEnabled ? INK_BUMP_OFFSET_MULTIPLIER : 1)
     const inkSizeBoostValue =
@@ -389,17 +417,22 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
   const tunablesRef = React.useRef(getDreamdustTunables())
 
   const resolveRevealDurationSeconds = React.useCallback(() => {
+    if (presetAiryEnabled) {
+      return Math.max(MIN_REVEAL_SECONDS, PresetAiry.revealDuration)
+    }
     if (presetVaporEnabled) {
       return Math.max(MIN_REVEAL_SECONDS, PresetC.revealDuration)
     }
     const { revealMs } = tunablesRef.current
     const ms = Number.isFinite(revealMs) ? Math.max(100, revealMs) : DEFAULT_REVEAL_MS
     return Math.max(MIN_REVEAL_SECONDS, ms / 1000)
-  }, [presetVaporEnabled])
+  }, [presetAiryEnabled, presetVaporEnabled])
 
-  const cascadeVaporGain = presetVaporEnabled
-    ? PresetC.cascadeRate
-    : CASCADE_VAPOR_GAIN
+  const cascadeVaporGain = presetAiryEnabled
+    ? PresetAiry.cascadeRate
+    : presetVaporEnabled
+      ? PresetC.cascadeRate
+      : CASCADE_VAPOR_GAIN
 
   const revealTimelineRef = React.useRef<RevealTimelineState>({
     active: false,


### PR DESCRIPTION
## Inputs
- Task brief for Dreamdust AirySmoke preset (PR-3).

## Outputs
- Modified: apps/cryptiq-mindmap-demo/app/components/dreamdust/presets.ts
- Modified: apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts

## Evidence
- Added `PresetAiry` constant with the gated tuning targets, including optional FOV metadata. (apps/cryptiq-mindmap-demo/app/components/dreamdust/presets.ts)
- Gated the airy preset via DD_PRESET/query, disabled ink bump boosts during tuning, and applied the new values to uniform init/reveal/cascade flow. (apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts)

## Baseline
```sh
$ corepack enable
(no stdout)
```

```sh
$ pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

. prepare$ husky install
. prepare: husky - install command is DEPRECATED
. prepare: Done
Done in 3.8s
root@41f2b39ef83b:/workspace/sdk#
```

```sh
$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
(no stdout)
```

```sh
$ pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
692:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
693:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
694:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
470:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
482:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
483:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
484:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
484:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
485:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
487:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
489:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
492:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
493:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
495:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
496:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
503:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
505:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
root@41f2b39ef83b:/workspace/sdk#
```

```sh
$ CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

   ▲ Next.js 15.3.5

   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 3/3...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.]
Failed to compile.

app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.


> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1
root@41f2b39ef83b:/workspace/sdk#
```

```sh
$ pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
root@41f2b39ef83b:/workspace/sdk#
```

## Test Protocol
- Not run (AK protocol tooling not available in repo; no automated preset AK logs produced).


------
https://chatgpt.com/codex/tasks/task_e_68d05e45ef24832893e0e19e9ff78973