### PR TITLE
chore(dreamdust): blue-noise density + tiny Bloom guards

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -71,9 +71,9 @@ type DreamdustStageUniformsWithReveal = DreamdustStageUniforms & {
 }
 
 const BLOOM_SETTINGS = {
-  strength: 0.12,
-  radius: 0.1,
-  threshold: 0.7,
+  strength: 0.2,
+  radius: 0.4,
+  threshold: 0.8,
 } as const
 
 type NavigatorWithPowerHints = Navigator & {
@@ -135,6 +135,18 @@ function readNoBloomOverride(): boolean {
   try {
     const params = new URLSearchParams(window.location.search)
     return params.get('noBloom') === '1'
+  } catch {
+    return false
+  }
+}
+
+function readForceBloomOverride(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const params = new URLSearchParams(window.location.search)
+    return params.get('forceBloom') === '1'
   } catch {
     return false
   }
@@ -418,65 +430,70 @@ function buildAttributes(
     return s - Math.floor(s)
   }
 
-  const totalCandidates = Math.ceil((w / stride) * (h / stride))
-  const maxPoints = cap
+  const safeStride = Math.max(1, Math.floor(stride))
+  const cellsX = Math.max(1, Math.ceil(w / safeStride))
+  const cellsY = Math.max(1, Math.ceil(h / safeStride))
+  const totalCandidates = cellsX * cellsY
+  const maxPoints = Math.max(0, Math.floor(cap))
   const keepRatio = Math.min(1, maxPoints / Math.max(1, totalCandidates))
+  const [denomX, denomY] = [Math.max(1, w - 1), Math.max(1, h - 1)]
+  const [maxColorX, maxColorY] = [Math.max(0, cw - 1), Math.max(0, ch - 1)]
+  const [maxDepthX, maxDepthY] = [Math.max(0, dw - 1), Math.max(0, dh - 1)]
 
   let kept = 0
-  for (let y = 0; y < h; y += stride) {
-    for (let x = 0; x < w; x += stride) {
-      // map sample to each source's native grid to avoid misindexing
-      const xC = Math.round((x / Math.max(1, w - 1)) * Math.max(0, cw - 1))
-      const yC = Math.round((y / Math.max(1, h - 1)) * Math.max(0, ch - 1))
-      const pColor = yC * cw + xC
 
-      const xD = Math.round((x / Math.max(1, w - 1)) * Math.max(0, dw - 1))
-      const yD = Math.round((y / Math.max(1, h - 1)) * Math.max(0, dh - 1))
-      const pDepth = yD * dw + xD
+  const rowPhase =
+    cellsY > 0 ? Math.floor(hash(cellsX + 0.5, cellsY + 0.25) * cellsY) % cellsY : 0
 
-      const d01 = dep16[pDepth] / 65535.0
-      if (d01 < minDepth01) minDepth01 = d01
-      if (d01 > maxDepth01) maxDepth01 = d01
+  const sampleCells = (forceKeep: boolean) => {
+    for (let rowIter = 0; rowIter < cellsY; rowIter++) {
+      const cellY = (rowIter + rowPhase) % cellsY
+      const baseY = cellY * safeStride
+      const cellHeight = Math.min(safeStride, h - baseY)
+      if (cellHeight <= 0) continue
 
-      const r = col[pColor * 4] / 255.0
-      const g = col[pColor * 4 + 1] / 255.0
-      const b = col[pColor * 4 + 2] / 255.0
-      const luma = 0.299 * r + 0.587 * g + 0.114 * b
+      const rowSeed = hash(cellY + 0.5, (cellY + 1) * 1.41421356237)
+      const yOffset = Math.min(cellHeight - 1, Math.floor(rowSeed * cellHeight))
+      const sampleY = baseY + yOffset
+      const yNorm = sampleY / denomY
+      const colorY = Math.round(yNorm * maxColorY)
+      const depthY = Math.round(yNorm * maxDepthY)
+      const phaseX = cellsX > 0 ? Math.floor(rowSeed * cellsX) % cellsX : 0
 
-      const near = 1.0 - d01
-      const keep = (0.45 + 0.35 * near + 0.2 * (1.0 - luma)) * keepRatio
-      if (hash(x, y) > keep) continue
+      for (let colIter = 0; colIter < cellsX; colIter++) {
+        const cellX = (colIter + phaseX) % cellsX
+        const baseX = cellX * safeStride
+        const cellWidth = Math.min(safeStride, w - baseX)
+        if (cellWidth <= 0) continue
 
-      us.push(x / Math.max(1, w - 1), y / Math.max(1, h - 1))
-      ds.push(d01)
-      xs.push(0, 0, 0)
-      cs.push(r, g, b)
-      kept++
-    }
-  }
+        const jitterSeed = hash(cellX + 0.5 + rowSeed * 3.1, cellY + 0.5 + rowSeed * 1.7)
+        const xOffset = Math.min(cellWidth - 1, Math.floor(jitterSeed * cellWidth))
+        const sampleX = baseX + xOffset
+        const xNorm = sampleX / denomX
+        const colorX = Math.round(xNorm * maxColorX)
+        const depthX = Math.round(xNorm * maxDepthX)
 
-  if (kept < 100 && keepRatio < 1) {
-    // rerun with keep forced to 1 (no stochastic drop) to avoid "dot" during bring-up
-    xs.length = 0
-    us.length = 0
-    ds.length = 0
-    cs.length = 0
-    kept = 0
-    for (let y = 0; y < h; y += stride) {
-      for (let x = 0; x < w; x += stride) {
-        const xC = Math.round((x / Math.max(1, w - 1)) * Math.max(0, cw - 1))
-        const yC = Math.round((y / Math.max(1, h - 1)) * Math.max(0, ch - 1))
-        const pColor = yC * cw + xC
-        const xD = Math.round((x / Math.max(1, w - 1)) * Math.max(0, dw - 1))
-        const yD = Math.round((y / Math.max(1, h - 1)) * Math.max(0, dh - 1))
-        const pDepth = yD * dw + xD
+        const pColor = colorY * cw + colorX
+        const pDepth = depthY * dw + depthX
         const d01 = dep16[pDepth] / 65535.0
         if (d01 < minDepth01) minDepth01 = d01
         if (d01 > maxDepth01) maxDepth01 = d01
+
         const r = col[pColor * 4] / 255.0
         const g = col[pColor * 4 + 1] / 255.0
         const b = col[pColor * 4 + 2] / 255.0
-        us.push(x / Math.max(1, w - 1), y / Math.max(1, h - 1))
+        const luma = 0.299 * r + 0.587 * g + 0.114 * b
+
+        if (!forceKeep) {
+          const near = 1.0 - d01
+          const keep = (0.45 + 0.35 * near + 0.2 * (1.0 - luma)) * keepRatio
+          const dropSeed = hash(
+            sampleX + rowSeed * 17.0 + cellX * 0.13,
+            sampleY + rowSeed * 13.0 + cellY * 0.17,
+          )
+          if (dropSeed > keep) continue
+        }
+        us.push(xNorm, yNorm)
         ds.push(d01)
         xs.push(0, 0, 0)
         cs.push(r, g, b)
@@ -485,8 +502,23 @@ function buildAttributes(
     }
   }
 
+  if (maxPoints > 0) {
+    sampleCells(false)
+
+    if (kept < 100 && keepRatio < 1) {
+      xs.length = 0
+      us.length = 0
+      ds.length = 0
+      cs.length = 0
+      kept = 0
+      minDepth01 = 1.0
+      maxDepth01 = 0.0
+      sampleCells(true)
+    }
+  }
+
   console.log(
-    `[PC] build: color ${cw}x${ch} depth ${dw}x${dh} → grid ${w}x${h} stride=${stride} candidates=${totalCandidates} kept=${kept} | uvs=${us.length / 2} depths=${ds.length} colors=${cs.length / 3} | depth01[min,max]=[${minDepth01.toFixed(4)},${maxDepth01.toFixed(4)}]`
+    `[PC] build: color ${cw}x${ch} depth ${dw}x${dh} → grid ${w}x${h} stride=${safeStride} cap=${maxPoints} cells=${cellsX}x${cellsY} candidates=${totalCandidates} kept=${kept} | uvs=${us.length / 2} depths=${ds.length} colors=${cs.length / 3} | depth01[min,max]=[${minDepth01.toFixed(4)},${maxDepth01.toFixed(4)}]`
   )
 
   return {
@@ -864,8 +896,12 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   } = props
   const [bloomEnabled, setBloomEnabled] = React.useState(false)
   const [noBloomOverride] = React.useState(readNoBloomOverride)
+  const [forceBloomOverride] = React.useState(readForceBloomOverride)
   const [bloomEligible, setBloomEligible] = React.useState(false)
   const [bloomGuardReady, setBloomGuardReady] = React.useState(false)
+  const [instanceCount, setInstanceCount] = React.useState<number | null>(null)
+  const [dprClampValue, setDprClampValue] = React.useState<number | null>(null)
+  const [lowPowerGuard, setLowPowerGuard] = React.useState(false)
   const [drawing, setDrawing] = React.useState(false)
   const inkUpdateLoggedRef = React.useRef(false)
   const base = sceneId ? `/assets/pointclouds/${sceneId}` : null
@@ -936,7 +972,10 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     packed.width > 0 &&
     packed.height > 0
   const readyFallback = fallbackGate && colorReady && !!depth16From8
-  const pointBudget = React.useMemo(() => pointCap(), [])
+  const pointBudget = React.useMemo(
+    () => pointCap({ mobile: 100_000, desktop: 110_000 }),
+    [],
+  )
   const [runtimeCaps, setRuntimeCaps] = React.useState<Readonly<DreamdustRuntimeCaps> | null>(null)
 
   const dreamdustUniformApi = useDreamdustUniforms()
@@ -1407,7 +1446,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   }))
   const [fitRequest, setFitRequest] = React.useState(0)
   const { bloom, pointSizeScale, reveal, thickness } = ui
-  const bloomActive = !simEnabled && bloom && bloomEligible && !noBloomOverride
+  const bloomActive =
+    !simEnabled && bloom && !noBloomOverride && (forceBloomOverride || bloomEligible)
   const thicknessScale = React.useMemo(() => Math.max(0.05, Math.min(1.0, thickness)), [thickness])
   React.useEffect(() => {
     try {
@@ -1458,6 +1498,27 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   React.useEffect(() => {
     setBloomEnabled(bloomActive)
   }, [bloomActive])
+
+  React.useEffect(() => {
+    const guardOk =
+      !simEnabled &&
+      !lowPowerGuard &&
+      typeof dprClampValue === 'number' &&
+      dprClampValue <= 1.8 &&
+      typeof instanceCount === 'number' &&
+      instanceCount > 0 &&
+      instanceCount <= Math.min(pointBudget, 110_000)
+    setBloomEligible(guardOk)
+  }, [simEnabled, lowPowerGuard, dprClampValue, instanceCount, pointBudget])
+
+  React.useEffect(() => {
+    const ready =
+      typeof dprClampValue === 'number' &&
+      (typeof instanceCount === 'number' || forceBloomOverride)
+    if (ready !== bloomGuardReady) {
+      setBloomGuardReady(ready)
+    }
+  }, [bloomGuardReady, dprClampValue, forceBloomOverride, instanceCount])
 
   const bloomLogRef = React.useRef(false)
   React.useEffect(() => {
@@ -1523,10 +1584,15 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const loggedInstancesRef = React.useRef(false)
   const revealStartedRef = React.useRef(false)
   const logInstances = React.useCallback((count: number) => {
-    if (!Number.isFinite(count) || count <= 0) return
+    if (!Number.isFinite(count) || count <= 0) {
+      setInstanceCount(null)
+      return
+    }
+    const floored = Math.floor(count)
+    setInstanceCount(floored)
     if (loggedInstancesRef.current) return
     try {
-      console.log('[PC] instances:', Math.floor(count))
+      console.log('[PC] instances:', floored)
     } catch {
       /* noop */
     }
@@ -1536,12 +1602,14 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   React.useEffect(() => {
     loggedInstancesRef.current = false
     revealStartedRef.current = false
+    setInstanceCount(null)
   }, [sceneId])
 
   React.useEffect(() => {
     if (prebakedStatus === 'loading' || prebakedStatus === 'idle') {
       loggedInstancesRef.current = false
       revealStartedRef.current = false
+      setInstanceCount(null)
     }
   }, [prebakedStatus])
 
@@ -1549,6 +1617,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     if (!sceneId) {
       loggedInstancesRef.current = false
       revealStartedRef.current = false
+      setInstanceCount(null)
     }
   }, [sceneId, colorUrl, depthUrl, depthRg])
 
@@ -1836,10 +1905,12 @@ export default function PointCloudStage(props: PointCloudStageProps) {
           console.log('[PC] pointer down', e.clientX, e.clientY)
         }}
         onCreated={({ gl }) => {
-          const dprClamp = clampDPR(gl, 2)
-          const bloomAllowed = !simEnabled && Number.isFinite(dprClamp) && dprClamp <= 1.8 && !isLowPowerDevice()
-          setBloomEligible(bloomAllowed)
-          setBloomGuardReady(true)
+          const mobile = detectMobile()
+          const dprLimit = mobile ? 1.6 : 1.8
+          const dprClamp = clampDPR(gl, dprLimit)
+          setDprClampValue(Number.isFinite(dprClamp) ? dprClamp : null)
+          const lowPower = isLowPowerDevice()
+          setLowPowerGuard(lowPower)
           const caps = getDreamdustCaps(gl.domElement)
           // Do not freeze typed arrays directly (V8 throws on freezing array buffer views with elements).
           // Instead, clone the range and freeze the container object to maintain immutability semantics.
@@ -1863,6 +1934,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             aliasedPointSizeRange: Array.from(frozenCaps.aliasedPointSizeRange),
             dpr: frozenCaps.dpr,
             dprClamp,
+            dprLimit,
           })
           // ACES tone mapping for nicer highlights
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
## Inputs
- Updated `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx` per task requirements.

## Outputs
- Modified `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`.

## Evidence
- Added blue-noise sampling with per-row jitter and cap-aware logging in the fallback attribute builder. 【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L405-L532】
- Introduced bloom overrides, guard state tracking, and mobile-friendly point budgets with explicit query toggles. 【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L143-L151】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L897-L1512】
- Synced instance-count resets and renderer DPR clamping with guarded bloom enablement. 【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1586-L1622】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1907-L1938】

## Baseline
```bash
corepack enable
# (no output)

pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 257ms
Done in 3.7s

pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit
# (no output)

pnpm --filter cryptiq-mindmap-demo run lint
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
309:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
309:87  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
309:114  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
310:80  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
327:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
327:87  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
327:114  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
328:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
850:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
851:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
852:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1483:6  Warning: React Hook React.useEffect has a missing dependency: 'ui'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
1836:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
485:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
497:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
498:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
499:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
499:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
500:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
502:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
507:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
508:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
510:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
511:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
518:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
520:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.

Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.

Retrying 2/3...
... (retries repeated) ...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.]

Failed to compile.

app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1

pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68d16ad9317c832884231c795b73cd78