### PR TITLE
feat: dreamdust alpha floor visibility guard

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -37,7 +37,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uDriftSpeed: 1,
   uTapGain: 0.5,
   uTapTau: 2,
-  uPointBaseSize: 1,
+  uPointBaseSize: 2.2,
   uFocal: 1,
   uMinSize: 1,
   uMaxSize: 1,
@@ -49,7 +49,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uDepthMax: 1,
   uGamma: 1,
   uRimGamma: 2,
-  uDepthBias: 1.8,
+  uDepthBias: 0.7,
   uDepthNormScale: 0.001,
   uHasCapture: 0,
   uZNearNdc: -0.85,
@@ -69,6 +69,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uViewport: [1, 1] as [number, number],
   uSimPositionTex: null,
   uSimColorTex: null,
+  uAlphaFloor: 0.08,
 } as const
 
 type DefaultUniformKey = keyof typeof DEFAULT_UNIFORM_VALUES
@@ -377,6 +378,7 @@ uniform float uDepthBias;
 uniform float uDepthNormScale;
 uniform float uGamma;
 uniform float uRimGamma;
+uniform float uAlphaFloor;
 uniform float uCascade;
 uniform vec3 uCascadeColor;
 
@@ -399,9 +401,10 @@ ${DREAMDUST_DEPTH_FADE_CHUNK}
 
 void main() {
   // Softer disc sprite for vapor look
-  vec2 pc = gl_PointCoord * 2.0 - 1.0;
-  float r = clamp(length(pc), 0.0, 1.0);
-  float sprite = smoothstep(1.0, 0.0, r);
+  float sprite = dreamdustSoftSprite(gl_PointCoord);
+  float spriteAlpha = pow(max(sprite, 0.0), 0.85);
+  float alphaFloor = clamp(uAlphaFloor, 0.0, 1.0);
+  float spriteMix = mix(alphaFloor, 1.0, spriteAlpha);
 
   float threshold = clamp(uNoiseThreshold, 0.0, 1.0);
   // Static reveal mask (no time animation) to avoid brightness pulsing
@@ -411,7 +414,7 @@ void main() {
   float baseReveal = smoothstep(threshold - 0.2, 1.0, flow);
   float revealAlpha = max(baseReveal, revealStrength * 0.35);
 
-  float alpha = sprite * revealAlpha * revealStrength;
+  float alpha = spriteMix * revealAlpha * revealStrength;
   float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);
   alpha *= dreamdustDepthAlpha(depthNorm, uDepthBias);
   if (alpha <= 0.001) {
@@ -461,11 +464,15 @@ export function makeDreamdustMaterial(
   opts: DreamdustMaterialOptions | DreamdustMaterialOptionsInput
 ) {
   aliasUniform(uniforms, 'uBaseSize', 'uPointBaseSize')
+  aliasUniform(uniforms, 'uPointSize', 'uPointBaseSize')
+  aliasUniform(uniforms, 'uThickness', 'uDepthBias')
   const uniformNames = Object.keys(DEFAULT_UNIFORM_VALUES) as DefaultUniformKey[]
   for (const name of uniformNames) {
     ensureUniform(uniforms, name)
   }
   aliasUniform(uniforms, 'uBaseSize', 'uPointBaseSize')
+  aliasUniform(uniforms, 'uPointSize', 'uPointBaseSize')
+  aliasUniform(uniforms, 'uThickness', 'uDepthBias')
 
   const resolved: DreamdustMaterialOptions = {
     unproject: opts.unproject,


### PR DESCRIPTION
## Inputs
- PR-2 brief for Dreamdust material visibility guard.

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Evidence
- Increased default point size and tuned depth bias while adding an alpha floor uniform to hold vapor visibility.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L27-L75】
- Applied soft sprite gamma with clamped alpha blending in the fragment shader to prevent vanishing particles.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L367-L459】
- Mirrored Stage uniform aliases for `uPointSize` and `uThickness` so both names map to the updated defaults.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L462-L520】

## Baseline
```
$ corepack enable

$ pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 158ms
Done in 2.4s

$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit \
  || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit

$ pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
823:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
824:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
825:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1415:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1843:198  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1875:6  Warning: React Hook React.useEffect has a missing dependency: 'hashArraySample'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
492:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
505:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
506:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
506:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
507:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
509:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
511:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
514:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
515:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
517:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
518:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
525:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
526:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
526:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
526:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
527:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/sim/ParticleSim.ts
79:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
80:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
81:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
92:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
96:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
97:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
109:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
113:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
114:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

$ pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build
   ▲ Next.js 15.3.5
   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.
Retrying 1/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.
Retrying 2/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.
Retrying 3/3...
Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.
Retrying 3/3...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K8-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3Kz-C8CSKlv.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iAq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iIq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1isq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1iEq131nj-otFQ.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlRFgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgsAXHNk.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl1FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl9FgsAXHNlYzg.woff2`.]

Failed to compile.
app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1

$ pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"
smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68d19ddde2808328ba04694957cf22d9