### PR TITLE
Sim: seeded init, bounds fit, and renderer reset

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -72,13 +72,14 @@ type DreamdustStageUniformsWithReveal = DreamdustStageUniforms & {
 }
 
 type StageSimState = {
+  key: string
   count: number
   texSize: [number, number]
   simUvs: Float32Array
   stageUvs: Float32Array
   stageDepths: Float32Array
   positions: Float32Array
-  bounds: { center: [number, number, number]; radius: number }
+  bounds: { center: THREE.Vector3; radius: number }
 }
 
 const BLOOM_SETTINGS = {
@@ -875,16 +876,24 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const [rendererReadyTick, setRendererReadyTick] = React.useState(0)
   const simRef = React.useRef<ParticleSim | null>(null)
   const [simState, setSimState] = React.useState<StageSimState | null>(null)
-  const simFitRequestedRef = React.useRef(false)
-  const simFitLoggedRef = React.useRef(false)
+  const simFitRequestKeyRef = React.useRef<string | null>(null)
+  const simFitLoggedKeyRef = React.useRef<string | null>(null)
   const simInitKeyRef = React.useRef<string | null>(null)
   const debugDepth = React.useMemo(() => readSearchParamSafe('debugDepth') === '1', [])
   React.useEffect(() => {
+    const renderer = rendererRef.current
+    if (!renderer) {
+      return undefined
+    }
+    if (!simRef.current) {
+      simRef.current = new ParticleSim(renderer)
+    }
     return () => {
       simRef.current?.dispose()
       simRef.current = null
+      simInitKeyRef.current = null
     }
-  }, [])
+  }, [rendererReadyTick])
   const [bloomGuardReady, setBloomGuardReady] = React.useState(false)
   const [instanceCount, setInstanceCount] = React.useState<number | null>(null)
   const [dprClampValue, setDprClampValue] = React.useState<number | null>(null)
@@ -1819,21 +1828,22 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   }, [prebakedUvDepth, simActive, simState])
 
   React.useEffect(() => {
-    if (!simEnabled || !simSource || !rendererRef.current) {
-      setSimState(null)
-      if (simRef.current) {
-        simRef.current.dispose()
-        simRef.current = null
-      }
-      simInitKeyRef.current = null
+    const instance = simRef.current
+    if (!instance || !rendererRef.current) {
       return
     }
-    const renderer = rendererRef.current
-    let instance = simRef.current
-    if (!instance) {
-      instance = new ParticleSim(renderer)
-      simRef.current = instance
+    if (!simEnabled) {
+      return
+    }
+    if (!simSource || simSource.count <= 0) {
+      if (simState) {
+        setSimState(null)
+      }
+      instance.dispose()
       simInitKeyRef.current = null
+      simFitRequestKeyRef.current = null
+      simFitLoggedKeyRef.current = null
+      return
     }
     const gravityY = typeof simUniforms?.gravityY === 'number' ? simUniforms.gravityY : -0.05
     const damping =
@@ -1841,7 +1851,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     const gravityVec: [number, number, number] = [0, gravityY, 0]
     instance.setDynamics({ gravity: gravityVec, damping })
     const simKey = `${sceneId ?? 'none'}:${simSource.count}:${debugDepth ? 1 : 0}:${hashArraySample(simSource.positions)}:${hashArraySample(simSource.depths)}:${hashArraySample(simSource.colors as any)}`
-    const needsInit = simInitKeyRef.current !== simKey || !simState
+    const needsInit = simInitKeyRef.current !== simKey
     if (needsInit) {
       instance.createSim(
         {
@@ -1857,21 +1867,24 @@ export default function PointCloudStage(props: PointCloudStageProps) {
         }
       )
       simInitKeyRef.current = simKey
+      simFitRequestKeyRef.current = null
+      simFitLoggedKeyRef.current = null
+    }
+    if (needsInit || !simState || simState.key !== simKey) {
       const bounds = instance.getBounds()
       const texSize = instance.getTexSize()
       const simUvs = instance.getSimUvs()
       setSimState({
+        key: simKey,
         count: simSource.count,
         texSize,
         simUvs,
         stageUvs: simSource.stageUvs,
         stageDepths: simSource.depths as Float32Array,
-        positions: new Float32Array(simSource.count > 0 ? simSource.count * 3 : 0),
-        bounds: { center: bounds.center, radius: bounds.radius },
+        positions: simSource.positions as Float32Array,
+        bounds: { center: bounds.center.clone(), radius: bounds.radius },
       })
     }
-    simFitRequestedRef.current = false
-    simFitLoggedRef.current = false
   }, [
     rendererReadyTick,
     simEnabled,
@@ -1880,10 +1893,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     simUniforms?.velocityDamping,
     sceneId,
     debugDepth,
-    renderBuffers,
-    recolored,
-    prebaked,
-    prebakedUvDepth,
+    hashArraySample,
     simState,
   ])
 
@@ -1935,11 +1945,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
 
   const cameraFitTarget = React.useMemo<[number, number, number]>(() => {
     if (simActive && simBounds) {
-      const center = new THREE.Vector3(
-        simBounds.center[0],
-        simBounds.center[1],
-        simBounds.center[2]
-      )
+      const center = simBounds.center.clone()
       center.multiply(new THREE.Vector3(1, 1, thicknessScale))
       center.multiply(new THREE.Vector3(mirrorScale[0], mirrorScale[1], mirrorScale[2]))
       const scale = prebakedTransform?.scale ?? 1
@@ -2012,21 +2018,22 @@ export default function PointCloudStage(props: PointCloudStageProps) {
 
   React.useEffect(() => {
     if (!simActive || !simState || !simBounds) {
-      simFitRequestedRef.current = false
-      simFitLoggedRef.current = false
       return
     }
-    if (!simFitRequestedRef.current) {
+    if (simFitRequestKeyRef.current !== simState.key) {
       setFitRequest((v) => v + 1)
-      simFitRequestedRef.current = true
+      simFitRequestKeyRef.current = simState.key
     }
-    if (!simFitLoggedRef.current) {
-      const centerLog = cameraFitTarget.map((v) => Number(v).toFixed(2)).join(',')
-      const radiusLog = Number(cameraFitRadius).toFixed(3)
+    if (simFitLoggedKeyRef.current !== simState.key) {
+      const centerVec = simBounds.center
+      const centerLog = [centerVec.x, centerVec.y, centerVec.z]
+        .map((v) => Number(v).toFixed(2))
+        .join(',')
+      const radiusLog = Number(simBounds.radius).toFixed(3)
       console.log(`[engine] sim fit { radius:${radiusLog}, center:[${centerLog}] }`)
-      simFitLoggedRef.current = true
+      simFitLoggedKeyRef.current = simState.key
     }
-  }, [cameraFitRadius, cameraFitTarget, simActive, simBounds, simState, setFitRequest])
+  }, [simActive, simBounds, simState, setFitRequest])
 
   React.useEffect(() => {
     if (!uniforms.uDepthNormScale) return

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts
@@ -164,6 +164,9 @@ export class ParticleSim {
   private time = 0
   private ready = false
   private uvs: Float32Array = new Float32Array(0)
+  private boundsCenter = new THREE.Vector3(0, 0, 0)
+  private boundsRadius = 1
+  private simOnLogged = false
 
   constructor(renderer: WebGLRenderer) {
     this.renderer = renderer
@@ -215,6 +218,8 @@ export class ParticleSim {
     this.initFbo = null
     this.ready = false
     this.uvs = new Float32Array(0)
+    this.boundsCenter.set(0, 0, 0)
+    this.boundsRadius = 1
   }
 
   createSim(opts: SimOptions, spawn?: SpawnPayload) {
@@ -331,6 +336,15 @@ export class ParticleSim {
       this.boundsMax = [maxXp, maxYp, maxZp]
     }
 
+    const min = this.boundsMin
+    const max = this.boundsMax
+    this.boundsCenter.set((min[0] + max[0]) * 0.5, (min[1] + max[1]) * 0.5, (min[2] + max[2]) * 0.5)
+    const extentX = max[0] - min[0]
+    const extentY = max[1] - min[1]
+    const extentZ = max[2] - min[2]
+    const maxExtent = Math.max(extentX, extentY, extentZ)
+    this.boundsRadius = maxExtent > 0 ? maxExtent * 0.5 : 1
+
     this.width = w
     this.height = h
     this.count = spawnCount
@@ -360,7 +374,10 @@ export class ParticleSim {
     spawnPosTex.texture.dispose()
     spawnColorTex?.texture.dispose()
     this.ready = true
-    console.log(`[engine] sim on { count:${spawnCount}, texSize:[${w},${h}] }`)
+    if (!this.simOnLogged) {
+      console.log(`[engine] sim on { count:${spawnCount}, texSize:[${w},${h}] }`)
+      this.simOnLogged = true
+    }
   }
 
   private runInit(
@@ -405,6 +422,8 @@ export class ParticleSim {
     gl.activeTexture(gl.TEXTURE0)
     gl.bindTexture(gl.TEXTURE_2D, null)
     gl.bindVertexArray(null)
+    gl.useProgram(null)
+    this.renderer.state.reset()
   }
 
   update(dt: number) {
@@ -444,6 +463,8 @@ export class ParticleSim {
     gl.activeTexture(gl.TEXTURE0)
     gl.bindTexture(gl.TEXTURE_2D, null)
     gl.bindVertexArray(null)
+    gl.useProgram(null)
+    this.renderer.state.reset()
     this.current = dst
   }
 
@@ -463,20 +484,8 @@ export class ParticleSim {
     return [this.width, this.height]
   }
 
-  getBounds(): { center: Vec3; radius: number } {
-    const min = this.boundsMin
-    const max = this.boundsMax
-    const center: Vec3 = [
-      (min[0] + max[0]) * 0.5,
-      (min[1] + max[1]) * 0.5,
-      (min[2] + max[2]) * 0.5,
-    ]
-    const extentX = max[0] - min[0]
-    const extentY = max[1] - min[1]
-    const extentZ = max[2] - min[2]
-    const maxExtent = Math.max(extentX, extentY, extentZ)
-    const radius = maxExtent > 0 ? maxExtent * 0.5 : 1
-    return { center, radius }
+  getBounds(): { center: THREE.Vector3; radius: number } {
+    return { center: this.boundsCenter.clone(), radius: this.boundsRadius }
   }
 
   setDynamics(opts: { gravity: Vec3; damping: number; floorY?: number }) {


### PR DESCRIPTION
## Inputs
- Current Architecture
- Target Architecture
- Test Protocol
- Canonical Brief

## Outputs
- Modified `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`
- Modified `apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts`

## Evidence
- ParticleSim now caches spawn bounds as a center/radius vector, seeds from prebaked payloads once, and resets WebGL state after init/update.
- PointCloudStage reuses a single ParticleSim instance, reuses sim hashes to avoid duplicate logs, and fits the camera using the cached bounds.

## Baseline
```bash
corepack enable
# (no output)

pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 197ms
Done in 2.7s

pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
# (no output)

pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
824:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
825:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
826:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1424:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1853:198  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
485:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
497:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
498:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
499:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
499:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
500:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
502:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
504:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
507:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
508:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
510:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
511:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
518:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
520:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/sim/ParticleSim.ts
79:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
80:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
81:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
92:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
96:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
97:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
109:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
113:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
114:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build
   ▲ Next.js 15.3.5
   Creating an optimized production build ...
Failed to fetch font file from `https://fonts.gstatic.com/s/anton/v27/1Ptgg87LROyAm3K9-C8CSKlvPfE.woff2`.
Retrying 1/3...
...
[Error: Failed to fetch font file from `https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwl5FgsAXHNlYzg.woff2`.]
Failed to compile.
app/layout.tsx
`next/font` error:
Failed to fetch `Anton` from Google Fonts.

app/layout.tsx
`next/font` error:
Failed to fetch `IBM Plex Mono` from Google Fonts.

> Build failed because of webpack errors
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 build: `next build`
Exit status 1

pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"
smoke ok
```

------
https://chatgpt.com/codex/tasks/task_e_68d19dc6d5cc83289535a2009defa36c