### PR TITLE
feat: condense dreamdust shader reveal band

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -30,11 +30,11 @@ const DEFAULT_UNIFORM_VALUES = {
   uBreath: 0.5,
   uNoiseScale: 1,
   uNoiseSpeed: 1,
-  uNoiseThreshold: 1,
-  uDriftAmp: 0,
+  uNoiseThreshold: 0.92,
+  uDriftAmp: 0.55,
   uCurlFreq: 1,
-  uCurlAmp: 1,
-  uDriftSpeed: 1,
+  uCurlAmp: 0.55,
+  uDriftSpeed: 0.28,
   uTapGain: 0.5,
   uTapTau: 2,
   uPointBaseSize: 2.2,
@@ -47,8 +47,8 @@ const DEFAULT_UNIFORM_VALUES = {
   uTintGain: 1,
   uDepthMin: 0,
   uDepthMax: 1,
-  uGamma: 1,
-  uRimGamma: 2,
+  uGamma: 1.15,
+  uRimGamma: 2.4,
   uDepthBias: 0.7,
   uDepthNormScale: 0.001,
   uHasCapture: 0,
@@ -60,8 +60,8 @@ const DEFAULT_UNIFORM_VALUES = {
   uCascadeColor: [1, 1, 1] as [number, number, number],
   uCascadeSizeBoost: 0,
   uVaporGain: 0,
-  uBreathAmp: 0.08,
-  uEvolution: 1,
+  uBreathAmp: 0.05,
+  uEvolution: 0.85,
   uInkOffsetBoost: 1,
   uInkSizeBoost: 1,
   uInkTintBoost: 1,
@@ -69,7 +69,7 @@ const DEFAULT_UNIFORM_VALUES = {
   uViewport: [1, 1] as [number, number],
   uSimPositionTex: null,
   uSimColorTex: null,
-  uAlphaFloor: 0.08,
+  uAlphaFloor: 0.06,
 } as const
 
 type DefaultUniformKey = keyof typeof DEFAULT_UNIFORM_VALUES
@@ -259,14 +259,15 @@ void main() {
   vec3 jitterSeed = dd_hash33(vec3(aUv * 173.0, aDepth * 59.0));
   vec3 mistDir = jitterSeed * 2.0 - 1.0;
   mistDir = normalize(mistDir + vec3(1e-4));
-  float mistAmount = (1.0 - revealGate) * 1.8 + 0.35;
+  float settle = smoothstep(0.55, 1.0, revealProgress);
+  float mistAmount = (1.0 - revealProgress) * 1.8;
   vec3 mistPos = basePos + mistDir * mistAmount;
 
   float breathPhase = (uBreath - 0.5) * 2.0;
   float breathAmp = max(uBreathAmp, 0.0);
-  mistPos += mistDir * (breathPhase * breathAmp);
+  mistPos += mistDir * (breathPhase * breathAmp * (1.0 - 0.7 * settle));
 
-  vec3 revealPos = mix(mistPos, basePos, revealGate);
+  vec3 revealPos = mix(mistPos, basePos, settle);
 
   float tapImpulse = 0.0;
   vec2 inkSampleOffset = vec2(0.0);
@@ -300,7 +301,8 @@ void main() {
   vec3 curlSample = revealPos * uCurlFreq + vec3(uTime * uDriftSpeed);
   float cascadeMix = clamp(uCascade, 0.0, 1.0);
   float vaporGain = max(uVaporGain, 0.0);
-  float curlMix = (uDriftAmp + tapImpulse) * uCurlAmp;
+  float curlFade = 1.0 - 0.7 * settle;
+  float curlMix = (uDriftAmp + tapImpulse) * uCurlAmp * curlFade;
   float curlBoost = mix(1.0, 4.0, cascadeMix);
   float vaporBoost = 1.0 + vaporGain * cascadeMix;
   curlMix *= curlBoost * vaporBoost;
@@ -319,7 +321,7 @@ void main() {
   vec3 viewPos = viewPos4.xyz;
   float viewDist = max(1e-3, -viewPos.z);
   float attenuation = clamp(uFocal / viewDist, uMinSize, uMaxSize);
-  float breathScale = 1.0 + breathPhase * 0.12;
+  float breathScale = 1.0 + breathPhase * 0.06;
   float cascadeSize = mix(0.0, max(uCascadeSizeBoost, 0.0), cascadeMix);
   float pointSize = uPointBaseSize * attenuation * breathScale * (1.0 + cascadeSize);
 
@@ -354,9 +356,10 @@ void main() {
   vec4 clipPos = projectionMatrix * viewPos4;
   float invW = 1.0 / max(1e-6, clipPos.w);
   vec2 ndc = clipPos.xy * invW; // [-1,1]
-  vInkUv = ndc * 0.5 + 0.5;     // [0,1]
+  vec2 ss = ndc * 0.5 + 0.5;
+  vInkUv = ss;                   // [0,1]
   vRevealMix = mistLift;
-  vRevealCoord = aUv * (3.0 + uNoiseScale) + jitterSeed.xy;
+  vRevealCoord = ss * (2.6 + uNoiseScale * 0.8) + jitterSeed.xy * 0.07;
   vPosMV = viewPos;
   vDepthView = viewDist;
 
@@ -407,12 +410,11 @@ void main() {
   float spriteMix = mix(alphaFloor, 1.0, spriteAlpha);
 
   float threshold = clamp(uNoiseThreshold, 0.0, 1.0);
-  // Static reveal mask (no time animation) to avoid brightness pulsing
   float revealNoise = dd_noise2(vRevealCoord);
   float revealStrength = clamp(vRevealMix, 0.0, 1.0);
-  float flow = revealNoise + revealStrength * (1.0 - threshold * 0.5);
-  float baseReveal = smoothstep(threshold - 0.2, 1.0, flow);
-  float revealAlpha = max(baseReveal, revealStrength * 0.35);
+  float w = 0.08;
+  float baseReveal = smoothstep(threshold - w, threshold + w, revealNoise);
+  float revealAlpha = max(baseReveal, revealStrength * 0.40);
 
   float alpha = spriteMix * revealAlpha * revealStrength;
   float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);


### PR DESCRIPTION
## Inputs
- PR-1 — Shader Condensation & Reveal Band
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Evidence
- Adjusted Dreamdust default uniforms for condensation tuning and rim shaping. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L27-L73】
- Reworked vertex settle, breath, curl fade, and screen-space reveal coordinates. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L255-L366】
- Narrowed fragment reveal band with reveal strength floor to preserve PMA blend. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L412-L419】

## Baseline Command Outputs
```bash
$ corepack enable
```

```bash
$ pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 254ms
Done in 3.8s
```

```bash
$ pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
```

```bash
$ pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
824:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
825:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
826:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1424:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1853:198  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
57:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
494:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
506:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
507:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
508:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
508:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
509:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
511:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
513:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
516:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
517:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
519:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
520:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
527:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
528:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
528:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
528:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
529:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/sim/ParticleSim.ts
79:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
80:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
81:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
92:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
96:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
97:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
109:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
113:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
114:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
```

```bash
$ CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

   ▲ Next.js 15.3.5

   Creating an optimized production build ...
 ✓ Compiled successfully in 31.0s
   Skipping validation of types
   Skipping linting
 ⚠ Using edge runtime on a page currently disables static generation for that page
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                                 Size  First Load JS
┌ ○ /                                    3.71 kB         106 kB
├ ○ /_not-found                            143 B         102 kB
├ ƒ /api/brain-acceptance                  143 B         102 kB
├ ƒ /api/og                                143 B         102 kB
├ ○ /brain                                 27 kB         357 kB
├ ○ /debug/caps                          5.38 kB         107 kB
├ ○ /draw3d                              7.83 kB         335 kB
├ ƒ /quiz/[slug]                         31.9 kB         362 kB
└ ƒ /result/[id]                         2.04 kB         104 kB
+ First Load JS shared by all             102 kB
  ├ chunks/226-5dcf7e3380d711a9.js       46.6 kB
  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
  └ other shared chunks (total)          2.22 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```

```bash
$ pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"

smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68d44e28afac83289f673da457e62522