### PR TITLE
feat: align dreamdust uniforms and cascade timeline

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -92,24 +92,24 @@ const DEFAULT_UNIFORM_VALUES: DreamdustUniformValueMap = {
   uInkIntensity: 1,
   uReveal: 1,
   uBreath: 0.5,
-  uBreathAmp: 0.08,
+  uBreathAmp: 0.05,
   uCascade: 0,
   uCascadeColor: [1, 1, 1],
   uCascadeSizeBoost: 0,
   uVaporGain: 0,
   uNoiseScale: 1,
   uNoiseSpeed: 1,
-  uEvolution: 1,
-  uNoiseThreshold: 1,
-  uDriftAmp: 0,
-  uCurlAmp: 1,
+  uEvolution: 0.85,
+  uNoiseThreshold: 0.92,
+  uDriftAmp: 0.55,
+  uCurlAmp: 0.55,
   uPointBaseSize: 1,
   uDepthMin: 0,
   uDepthMax: 1,
   uDepthBias: 1.8,
   uDepthNormScale: 0.001,
-  uGamma: 1,
-  uRimGamma: 2,
+  uGamma: 1.15,
+  uRimGamma: 2.4,
   uFocal: 1,
   uMinSize: 1,
   uMaxSize: 1,
@@ -190,13 +190,16 @@ function useOptionalThree<T>(selector: (state: RootState) => T): T | null {
   }
 }
 
-const DEFAULT_REVEAL_MS = 2000
+const DEFAULT_REVEAL_MS = 900
 const MIN_REVEAL_SECONDS = 0.2
 const BREATH_PERIOD_SECONDS = 7.5
 const BREATH_SPEED = (Math.PI * 2) / BREATH_PERIOD_SECONDS
-const CASCADE_DURATION_SECONDS = 1.6
-const CASCADE_SIZE_BOOST = 2.4
-const CASCADE_VAPOR_GAIN = 1.35
+const CASCADE_RAMP_S = 0.7
+const CASCADE_HOLD_S = 0.2
+const CASCADE_DECAY_S = 0.8
+const CASCADE_DURATION_SECONDS = CASCADE_RAMP_S + CASCADE_HOLD_S + CASCADE_DECAY_S
+const CASCADE_SIZE_PEAK = 0.25
+const CASCADE_VAPOR_PEAK = 0.9
 
 function clamp01(value: number): number {
   if (value < 0) return 0
@@ -682,7 +685,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     ? PresetAiry.cascadeRate
     : presetVaporEnabled
       ? PresetC.cascadeRate
-      : CASCADE_VAPOR_GAIN
+      : CASCADE_VAPOR_PEAK
 
   const revealTimelineRef = React.useRef<RevealTimelineState>({
     active: false,
@@ -694,7 +697,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     active: false,
     elapsed: 0,
     duration: CASCADE_DURATION_SECONDS,
-    sizeBoost: CASCADE_SIZE_BOOST,
+    sizeBoost: CASCADE_SIZE_PEAK,
     vaporGain: cascadeVaporGain,
     didLogStart: false,
     didLogEnd: false,
@@ -771,6 +774,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
       }
 
       const cascade = cascadeTimelineRef.current
+      let cascadeEnded = false
       if (cascade.active) {
         if (!cascade.didLogStart) {
           cascade.didLogStart = true
@@ -778,23 +782,32 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
             duration: Number(cascade.duration.toFixed(3)),
           })
         }
-        cascade.elapsed = Math.min(cascade.elapsed + safeDelta, cascade.duration)
-        const progress = cascade.duration > 0 ? cascade.elapsed / cascade.duration : 1
-        const eased = cubicEaseInOut(progress)
-        const mix = clamp01(eased)
-        uniforms.uCascade.value = mix
-        uniforms.uCascadeSizeBoost.value = cascade.sizeBoost
-        uniforms.uVaporGain.value = cascade.vaporGain * mix
-        if (cascade.elapsed >= cascade.duration) {
+        const cascadeDuration = CASCADE_DURATION_SECONDS
+        cascade.elapsed = Math.min(cascade.elapsed + safeDelta, cascadeDuration)
+        const t = cascade.elapsed
+        let mix = 0
+        if (t < CASCADE_RAMP_S) {
+          const s = t / CASCADE_RAMP_S
+          mix = cubicEaseInOut(s)
+        } else if (t < CASCADE_RAMP_S + CASCADE_HOLD_S) {
+          mix = 1
+        } else if (t < cascadeDuration) {
+          const s = (t - CASCADE_RAMP_S - CASCADE_HOLD_S) / CASCADE_DECAY_S
+          mix = 1 - cubicEaseInOut(s)
+        } else {
           cascade.active = false
-          uniforms.uCascade.value = 1
-          uniforms.uVaporGain.value = 0
-          if (!cascade.didLogEnd) {
-            cascade.didLogEnd = true
-            safeLog('[Dreamdust] cascade end', {
-              duration: Number(cascade.duration.toFixed(3)),
-            })
-          }
+          cascade.elapsed = 0
+          mix = 0
+          cascadeEnded = true
+        }
+        uniforms.uCascade.value = mix
+        uniforms.uVaporGain.value = CASCADE_VAPOR_PEAK * mix
+        uniforms.uCascadeSizeBoost.value = CASCADE_SIZE_PEAK * mix
+        if (cascadeEnded && !cascade.didLogEnd) {
+          cascade.didLogEnd = true
+          safeLog('[Dreamdust] cascade end', {
+            duration: Number(cascade.duration.toFixed(3)),
+          })
         }
       } else if (uniforms.uVaporGain.value > 1e-4) {
         uniforms.uVaporGain.value = Math.max(
@@ -903,13 +916,13 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     cascade.active = true
     cascade.elapsed = 0
     cascade.duration = CASCADE_DURATION_SECONDS
-    cascade.sizeBoost = CASCADE_SIZE_BOOST
+    cascade.sizeBoost = CASCADE_SIZE_PEAK
     cascade.vaporGain = cascadeVaporGain
     cascade.didLogStart = false
     cascade.didLogEnd = false
     if (!uniforms) return
     uniforms.uCascade.value = 0
-    uniforms.uCascadeSizeBoost.value = cascade.sizeBoost
+    uniforms.uCascadeSizeBoost.value = 0
     uniforms.uVaporGain.value = 0
     const target = uniforms.uCascadeColor.value
     for (let i = 0; i < target.length && i < color.length; i += 1) {


### PR DESCRIPTION
## Inputs
- Task brief for `apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts`

## Outputs
- Updated `apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts`

## Evidence
- `apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts`: Aligns default uniform magnitudes with shader expectations, introduces ramp/hold/decay cascade constants, and drives `uCascade`, `uVaporGain`, and `uCascadeSizeBoost` via the new state machine while keeping logging semantics intact.

## Baseline
```bash
corepack enable
pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 197ms
Done in 3.4s

pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit \
  || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit

pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint
...
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1

CI=1 pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build
   ▲ Next.js 15.3.5
   Creating an optimized production build ...
 ✓ Compiled successfully in 22.0s
   Skipping validation of types
   Skipping linting
 ⚠ Using edge runtime on a page currently disables static generation for that page
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization
Route (app)                                 Size  First Load JS
┌ ○ /                                    3.71 kB         106 kB
├ ○ /_not-found                            143 B         102 kB
├ ƒ /api/brain-acceptance                  143 B         102 kB
├ ƒ /api/og                                143 B         102 kB
├ ○ /brain                                 27 kB         357 kB
├ ○ /debug/caps                          5.38 kB         107 kB
├ ○ /draw3d                              7.83 kB         335 kB
├ ƒ /quiz/[slug]                         31.9 kB         362 kB
└ ƒ /result/[id]                         2.04 kB         104 kB
+ First Load JS shared by all             102 kB
  ├ chunks/226-5dcf7e3380d711a9.js       46.6 kB
  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
  └ other shared chunks (total)          2.22 kB

pnpm run smoke
> @refinery/monorepo@0.0.0 smoke /workspace/sdk
> node -e "console.log('smoke ok')"
smoke ok
```


------
https://chatgpt.com/codex/tasks/task_e_68d456f61a10832898ebc62eaa33ea78