### PR TITLE
feat: add optional dreamdust ink probe

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -184,6 +184,15 @@ function readSearchParamSafe(name: string): string | null {
   }
 }
 
+function readDebugInkProbe(): boolean {
+  const value = readSearchParamSafe('inkProbe')
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized === '1' || normalized === 'true'
+  }
+  return false
+}
+
 function readNumberOverride(queryKey: string, envKey?: string): number | null {
   const queryValue = readSearchParamSafe(queryKey)
   if (queryValue !== null) {
@@ -1056,6 +1065,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const inkTex = dreamdustCtx?.inkTex ?? null
   const inkIntensity = dreamdustCtx?.inkIntensity ?? 1
   const vertexInkOk = dreamdustCtx?.vertexInkOk ?? runtimeCaps?.vertexInkOk ?? false
+  const debugInkProbe = React.useMemo(() => readDebugInkProbe(), [])
   const uniformsWithReveal = uniforms as DreamdustStageUniformsWithReveal
   const hasRevealUniform = !!uniformsWithReveal.uReveal
   const timelineSupported = hasRevealUniform && typeof startReveal === 'function'
@@ -1097,6 +1107,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     const material = createDreamdustMaterial(uniforms, {
       unproject: true,
       vertexInkOk: runtimeCaps.vertexInkOk ?? false,
+      debugInkProbe,
     })
     const defines = material.defines ?? {}
     const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
@@ -1109,12 +1120,13 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     material.defines = defines
     material.needsUpdate = true
     return material
-  }, [runtimeCaps, uniforms])
+  }, [debugInkProbe, runtimeCaps, uniforms])
   const prebakedMaterial = React.useMemo(() => {
     if (!runtimeCaps) return null
     const material = createDreamdustMaterial(uniforms, {
       unproject: false,
       vertexInkOk: runtimeCaps.vertexInkOk ?? false,
+      debugInkProbe,
     })
     const defines = material.defines ?? {}
     const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
@@ -1127,7 +1139,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     material.defines = defines
     material.needsUpdate = true
     return material
-  }, [runtimeCaps, uniforms])
+  }, [debugInkProbe, runtimeCaps, uniforms])
 
   React.useEffect(() => {
     return () => {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -17,13 +17,19 @@ type UniformRecord = Record<string, { value: unknown }>
 type DreamdustMaterialOptions = {
   unproject: boolean
   vertexInkOk: boolean
-  debugInkProbe: boolean
+  debugInkProbe?: boolean
 }
 
 type DreamdustMaterialOptionsInput = {
   unproject: boolean
   vertexInkOk?: boolean
   debugInkProbe?: boolean
+}
+
+type DreamdustMaterialResolvedOptions = {
+  unproject: boolean
+  vertexInkOk: boolean
+  debugInkProbe: boolean
 }
 
 const DEFAULT_UNIFORM_VALUES = {
@@ -498,7 +504,7 @@ export function makeDreamdustMaterial(
   aliasUniform(uniforms, 'uPointSize', 'uPointBaseSize')
   aliasUniform(uniforms, 'uThickness', 'uDepthBias')
 
-  const resolved: DreamdustMaterialOptions = {
+  const resolved: DreamdustMaterialResolvedOptions = {
     unproject: opts.unproject,
     vertexInkOk: opts.vertexInkOk ?? false,
     debugInkProbe: opts.debugInkProbe ?? false,

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -17,11 +17,13 @@ type UniformRecord = Record<string, { value: unknown }>
 type DreamdustMaterialOptions = {
   unproject: boolean
   vertexInkOk: boolean
+  debugInkProbe: boolean
 }
 
 type DreamdustMaterialOptionsInput = {
   unproject: boolean
   vertexInkOk?: boolean
+  debugInkProbe?: boolean
 }
 
 const DEFAULT_UNIFORM_VALUES = {
@@ -275,9 +277,16 @@ void main() {
   vec3 inkSampleTint = vec3(0.0);
   float inkSampleIntensity = 0.0;
 
+#ifdef DEBUG_INK_PROBE
+  float inkProbe = 0.0;
+#endif
+
 #ifdef USE_VERTEX_INK
   if (uInkIntensity > 1e-5 && uVertexInkOk > 0.5) {
     DreamdustInkSample inkSample = dreamdustSampleInk(uInkTex, aUv);
+#ifdef DEBUG_INK_PROBE
+    inkProbe = smoothstep(0.1, 1.0, inkSample.intensity);
+#endif
     float localIntensity = inkSample.intensity * uInkIntensity;
     if (localIntensity > 1e-5) {
       inkSampleOffset = inkSample.offset;
@@ -336,10 +345,17 @@ void main() {
     pointSize += inkSampleSwell * inkSampleIntensity * uSizeGain * uInkSizeBoost;
     inkTint = inkSampleTint;
     inkMix = inkSampleIntensity * uTintGain * uInkTintBoost;
+
   }
 #endif
 
-  gl_PointSize = max(0.0, pointSize);
+  float pointSizeClamped = max(0.0, pointSize);
+
+#ifdef DEBUG_INK_PROBE
+  pointSizeClamped *= mix(1.0, 4.0, inkProbe);
+#endif
+
+  gl_PointSize = pointSizeClamped;
 
   float mistLift = mix(0.35, 1.0, revealGate);
   mistLift = clamp(max(mistLift, revealProgress * 0.9), 0.0, 1.0);
@@ -454,6 +470,12 @@ void main() {
   color = dreamdustApplyRimLight(color, rim);
   alpha = dreamdustApplyRimAlpha(alpha, rim);
 
+#ifdef DEBUG_INK_PROBE
+  DreamdustInkSample debugInkSample = dreamdustSampleInk(uInkTex, vInkUv);
+  float inkProbe = smoothstep(0.1, 1.0, debugInkSample.intensity);
+  color = mix(color, vec3(0.1, 0.9, 0.8), inkProbe);
+#endif
+
   color = dreamdustApplyGamma(color, uGamma);
 
   // Premultiplied alpha output
@@ -479,6 +501,7 @@ export function makeDreamdustMaterial(
   const resolved: DreamdustMaterialOptions = {
     unproject: opts.unproject,
     vertexInkOk: opts.vertexInkOk ?? false,
+    debugInkProbe: opts.debugInkProbe ?? false,
   }
 
   const defines: Record<string, unknown> = {}
@@ -488,6 +511,9 @@ export function makeDreamdustMaterial(
   if (resolved.vertexInkOk) {
     defines.USE_VERTEX_INK = 1
     defines.VERTEX_INK_OK = 1
+  }
+  if (resolved.debugInkProbe) {
+    defines.DEBUG_INK_PROBE = 1
   }
   syncLegacyVertexInkDefine(defines)
 
@@ -519,6 +545,11 @@ export function makeDreamdustMaterial(
     delete (material as any).defines.USE_VERTEX_INK
     delete (material as any).defines.VERTEX_INK_OK
   }
+  if (resolved.debugInkProbe) {
+    ;(material as any).defines.DEBUG_INK_PROBE = 1
+  } else {
+    delete (material as any).defines.DEBUG_INK_PROBE
+  }
 
   if (uniforms.uVertexInkOk) {
     uniforms.uVertexInkOk.value = resolved.vertexInkOk ? 1 : 0
@@ -527,6 +558,12 @@ export function makeDreamdustMaterial(
   const originalOnBeforeCompile = (material as any).onBeforeCompile?.bind(material)
   ;(material as any).onBeforeCompile = function onBeforeCompile(shader: any, renderer: any) {
     syncLegacyVertexInkDefine((material as any).defines)
+    if (resolved.debugInkProbe) {
+      shader.defines = shader.defines ?? {}
+      shader.defines.DEBUG_INK_PROBE = 1
+    } else if (shader.defines) {
+      delete shader.defines.DEBUG_INK_PROBE
+    }
     if (originalOnBeforeCompile) {
       originalOnBeforeCompile(shader, renderer)
     }


### PR DESCRIPTION
## Summary
- introduce an optional `debugInkProbe` toggle when constructing the Dreamdust material so the shader receives a `DEBUG_INK_PROBE` define when requested
- gate new vertex and fragment shader helpers behind `#ifdef DEBUG_INK_PROBE` to scale point size and tint fragments based on sampled ink alpha

## Testing
- `corepack enable`
- `pnpm run smoke`

## Inputs
- PR-2 — GLSL Ink Probe (DEBUG_INK_PROBE)

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Evidence
- Optional probe define wiring and shader guard usage 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L280-L358】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L473-L566】

## Baseline command outputs
- `corepack enable`
- `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68d55867065c83289c5889bee79868ff