### PR TITLE
feat(dreamdust): add sim VTF sanity probe

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -193,6 +193,15 @@ function readDebugInkProbe(): boolean {
   return false
 }
 
+function readDebugSimProbe(): boolean {
+  const value = readSearchParamSafe('simProbe')
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized === '1' || normalized === 'true'
+  }
+  return false
+}
+
 function readNumberOverride(queryKey: string, envKey?: string): number | null {
   const queryValue = readSearchParamSafe(queryKey)
   if (queryValue !== null) {
@@ -1066,6 +1075,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const inkIntensity = dreamdustCtx?.inkIntensity ?? 1
   const vertexInkOk = dreamdustCtx?.vertexInkOk ?? runtimeCaps?.vertexInkOk ?? false
   const debugInkProbe = React.useMemo(() => readDebugInkProbe(), [])
+  const debugSimProbe = React.useMemo(() => readDebugSimProbe(), [])
   const uniformsWithReveal = uniforms as DreamdustStageUniformsWithReveal
   const hasRevealUniform = !!uniformsWithReveal.uReveal
   const timelineSupported = hasRevealUniform && typeof startReveal === 'function'
@@ -1108,6 +1118,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
       unproject: true,
       vertexInkOk: runtimeCaps.vertexInkOk ?? false,
       debugInkProbe,
+      debugSimProbe,
     })
     const defines = material.defines ?? {}
     const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
@@ -1120,13 +1131,14 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     material.defines = defines
     material.needsUpdate = true
     return material
-  }, [debugInkProbe, runtimeCaps, uniforms])
+  }, [debugInkProbe, debugSimProbe, runtimeCaps, uniforms])
   const prebakedMaterial = React.useMemo(() => {
     if (!runtimeCaps) return null
     const material = createDreamdustMaterial(uniforms, {
       unproject: false,
       vertexInkOk: runtimeCaps.vertexInkOk ?? false,
       debugInkProbe,
+      debugSimProbe,
     })
     const defines = material.defines ?? {}
     const vertexInkDefine = runtimeCaps.vertexInkOk ? 1 : 0
@@ -1139,7 +1151,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     material.defines = defines
     material.needsUpdate = true
     return material
-  }, [debugInkProbe, runtimeCaps, uniforms])
+  }, [debugInkProbe, debugSimProbe, runtimeCaps, uniforms])
 
   React.useEffect(() => {
     return () => {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -18,18 +18,21 @@ type DreamdustMaterialOptions = {
   unproject: boolean
   vertexInkOk: boolean
   debugInkProbe?: boolean
+  debugSimProbe?: boolean
 }
 
 type DreamdustMaterialOptionsInput = {
   unproject: boolean
   vertexInkOk?: boolean
   debugInkProbe?: boolean
+  debugSimProbe?: boolean
 }
 
 type DreamdustMaterialResolvedOptions = {
   unproject: boolean
   vertexInkOk: boolean
   debugInkProbe: boolean
+  debugSimProbe: boolean
 }
 
 const DEFAULT_UNIFORM_VALUES = {
@@ -220,11 +223,24 @@ varying float vRevealMix;
 varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 varying float vDepthView;
+#ifdef DEBUG_VTF_SANITY
+varying float vSimProbe;
+#endif
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
 ${DD_FBM3}
 ${DD_CURL3}
+
+#ifdef DEBUG_VTF_SANITY
+vec3 dreamdustSampleSimPosition(vec2 uv) {
+#ifdef USE_SIM_POS
+  return texture2D(uSimPositionTex, uv).xyz;
+#else
+  return vec3(0.0);
+#endif
+}
+#endif
 
 vec4 dreamdustUnproject(vec3 localPos, vec2 captureUv, float depth01) {
 #ifdef USE_UNPROJECT
@@ -384,6 +400,10 @@ void main() {
   vRevealCoord = ss * (2.6 + uNoiseScale * 0.8) + jitterSeed.xy * 0.07;
   vPosMV = viewPos;
   vDepthView = viewDist;
+#ifdef DEBUG_VTF_SANITY
+  vec3 simProbePos = dreamdustSampleSimPosition(aSimUv);
+  vSimProbe = length(simProbePos);
+#endif
 
   gl_Position = projectionMatrix * viewPos4;
 }
@@ -482,6 +502,19 @@ void main() {
   color = mix(color, vec3(0.1, 0.9, 0.8), inkProbe);
 #endif
 
+#ifdef DEBUG_VTF_SANITY
+  float simProbe = vSimProbe;
+  bool probeNaN = isnan(simProbe);
+  bool probeInf = isinf(simProbe);
+  bool probeBad = probeNaN || probeInf || simProbe < 0.01;
+  if (probeBad) {
+    color = mix(color, vec3(1.0, 0.15, 0.15), 0.7);
+  }
+  if (probeNaN || probeInf) {
+    alpha = -abs(alpha);
+  }
+#endif
+
   color = dreamdustApplyGamma(color, uGamma);
 
   // Premultiplied alpha output
@@ -508,6 +541,7 @@ export function makeDreamdustMaterial(
     unproject: opts.unproject,
     vertexInkOk: opts.vertexInkOk ?? false,
     debugInkProbe: opts.debugInkProbe ?? false,
+    debugSimProbe: opts.debugSimProbe ?? false,
   }
 
   const defines: Record<string, unknown> = {}
@@ -520,6 +554,9 @@ export function makeDreamdustMaterial(
   }
   if (resolved.debugInkProbe) {
     defines.DEBUG_INK_PROBE = 1
+  }
+  if (resolved.debugSimProbe) {
+    defines.DEBUG_VTF_SANITY = 1
   }
   syncLegacyVertexInkDefine(defines)
 
@@ -556,6 +593,11 @@ export function makeDreamdustMaterial(
   } else {
     delete (material as any).defines.DEBUG_INK_PROBE
   }
+  if (resolved.debugSimProbe) {
+    ;(material as any).defines.DEBUG_VTF_SANITY = 1
+  } else {
+    delete (material as any).defines.DEBUG_VTF_SANITY
+  }
 
   if (uniforms.uVertexInkOk) {
     uniforms.uVertexInkOk.value = resolved.vertexInkOk ? 1 : 0
@@ -569,6 +611,12 @@ export function makeDreamdustMaterial(
       shader.defines.DEBUG_INK_PROBE = 1
     } else if (shader.defines) {
       delete shader.defines.DEBUG_INK_PROBE
+    }
+    if (resolved.debugSimProbe) {
+      shader.defines = shader.defines ?? {}
+      shader.defines.DEBUG_VTF_SANITY = 1
+    } else if (shader.defines) {
+      delete shader.defines.DEBUG_VTF_SANITY
     }
     if (originalOnBeforeCompile) {
       originalOnBeforeCompile(shader, renderer)

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -226,6 +226,9 @@ varying float vDepthView;
 #ifdef DEBUG_VTF_SANITY
 varying float vSimProbe;
 #endif
+#ifdef DEBUG_VTF_SANITY
+varying float vSimProbe;
+#endif
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_INK_SAMPLE_CHUNK}
@@ -437,6 +440,9 @@ varying float vRevealMix;
 varying vec2 vRevealCoord;
 varying vec3 vPosMV;
 varying float vDepthView;
+#ifdef DEBUG_VTF_SANITY
+varying float vSimProbe;
+#endif
 
 ${DREAMDUST_NOISE_CHUNK}
 ${DREAMDUST_SOFT_SPRITE_CHUNK}


### PR DESCRIPTION
## Inputs
- `apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts`
- `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`

## Outputs
- Updated Dreamdust material to expose a VTF sanity probe guarded by `DEBUG_VTF_SANITY`.
- Added query parameter plumbing to toggle the probe from PointCloudStage.

## Evidence
- Added `debugSimProbe` option to the Dreamdust material API and wired it through material defines and `onBeforeCompile` to emit `DEBUG_VTF_SANITY`. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L18-L35】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L525-L624】
- Sampled the simulation texture when the guard is enabled and tinted fragments red or encoded invalid data by flipping alpha. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L226-L405】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L499-L521】
- Surfaced the new debug probe toggle via the `simProbe` query parameter so it can be enabled at runtime. 【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L187-L204】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1072-L1154】

## Baseline
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit` 【4399f8†L1-L1】
- `pnpm --filter cryptiq-mindmap-demo exec tsc -p tsconfig.typecheck.json --noEmit` *(fails: existing workspace type errors)* 【ba5534†L1-L1】【b8ee00†L1-L66】
- `pnpm --filter cryptiq-mindmap-demo run lint || true` *(fails: existing lint errors)* 【a2c488†L1-L4】【439e08†L1-L60】
- `CI=1 pnpm --filter cryptiq-mindmap-demo run build` 【055ba6†L1-L4】【dd3255†L1-L18】
- `pnpm run smoke` 【be1237†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68d579e2ed3c832896f26e059623c089