### PR TITLE
feat(telemetry): add sim and ink probe readbacks

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -2,6 +2,8 @@
 // @ts-ignore three types are optional in this workspace
 import * as THREE from 'three'
 
+import { createInkTelemetryCollector } from './telemetry'
+
 import {
   DD_CURL3,
   DD_FBM3,
@@ -582,6 +584,21 @@ export function makeDreamdustMaterial(
   ;(material as any).uniforms = uniforms
   ;(material as any).defines = (material as any).defines ?? {}
   syncLegacyVertexInkDefine((material as any).defines)
+  const inkTelemetry = createInkTelemetryCollector()
+  const originalOnAfterRender = material.onAfterRender?.bind(material)
+  material.onAfterRender = function onAfterRenderHook(
+    renderer: THREE.WebGLRenderer,
+    scene: THREE.Scene,
+    camera: THREE.Camera,
+    geometry: THREE.BufferGeometry,
+    object: THREE.Object3D,
+    group?: THREE.Group,
+  ) {
+    inkTelemetry.capture(renderer, uniforms)
+    if (originalOnAfterRender) {
+      originalOnAfterRender(renderer, scene, camera, geometry, object, group)
+    }
+  }
   if (resolved.unproject) {
     ;(material as any).defines.USE_UNPROJECT = 1
   } else {
@@ -603,6 +620,12 @@ export function makeDreamdustMaterial(
     ;(material as any).defines.DEBUG_VTF_SANITY = 1
   } else {
     delete (material as any).defines.DEBUG_VTF_SANITY
+  }
+
+  const originalDispose = material.dispose.bind(material)
+  material.dispose = function disposeWithTelemetry() {
+    inkTelemetry.dispose()
+    originalDispose()
   }
 
   if (uniforms.uVertexInkOk) {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three'
 import type { WebGLRenderer } from 'three'
 
+import { createSimTelemetryCollector } from '../telemetry'
+
 const QUAD = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1])
 const VERT = `#version 300 es
 in vec2 position;
@@ -147,6 +149,7 @@ export class ParticleSim {
   private readonly initProgram: WebGLProgram
   private readonly updateProgram: WebGLProgram
   private readonly u: Record<string, WebGLUniformLocation | null>
+  private readonly simTelemetry: ReturnType<typeof createSimTelemetryCollector>
   private pos: TexturePackage[] = []
   private vel: TexturePackage[] = []
   private color: TexturePackage | null = null
@@ -202,6 +205,7 @@ export class ParticleSim {
     raw.bufferData(raw.ARRAY_BUFFER, QUAD, raw.STATIC_DRAW)
     raw.enableVertexAttribArray(0); raw.vertexAttribPointer(0, 2, raw.FLOAT, false, 0, 0)
     raw.bindVertexArray(null); raw.bindBuffer(raw.ARRAY_BUFFER, null)
+    this.simTelemetry = createSimTelemetryCollector(renderer)
   }
 
   private release() {
@@ -465,6 +469,12 @@ export class ParticleSim {
     gl.bindVertexArray(null)
     gl.useProgram(null)
     this.renderer.state.reset()
+    this.simTelemetry.sample(
+      this.fbos[dst] ?? null,
+      this.pos[dst] ?? null,
+      this.width,
+      this.height,
+    )
     this.current = dst
   }
 
@@ -496,5 +506,6 @@ export class ParticleSim {
 
   dispose() {
     this.release()
+    this.simTelemetry.dispose()
   }
 }

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/index.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/index.ts
@@ -1,0 +1,4 @@
+export { createSimTelemetryCollector } from './simTelemetry'
+export type { SimTelemetryCollector } from './simTelemetry'
+export { createInkTelemetryCollector } from './inkTelemetry'
+export type { InkTelemetryCollector } from './inkTelemetry'

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/inkTelemetry.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/inkTelemetry.ts
@@ -1,0 +1,225 @@
+import * as THREE from 'three'
+import type { WebGLRenderer } from 'three'
+
+type UniformRecord = Record<string, { value: unknown } | undefined>
+
+const SAMPLE_INTERVAL_MS = 1000
+const getNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+
+const detectInkTelemetryEnabled = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('engine') !== 'sim') {
+      return false
+    }
+    return params.get('inkStats') === '1'
+  } catch {
+    return false
+  }
+}
+
+const clamp01 = (value: number) => {
+  if (!Number.isFinite(value)) return 0
+  if (value <= 0) return 0
+  if (value >= 1) return 1
+  return value
+}
+
+const resolveNumber = (value: unknown, fallback: number) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'object' && value && 'value' in (value as Record<string, unknown>)) {
+    return resolveNumber((value as { value: unknown }).value, fallback)
+  }
+  return fallback
+}
+
+const makeVectorUniform = () => [new THREE.Vector4(), new THREE.Vector4(), new THREE.Vector4(), new THREE.Vector4()]
+
+export type InkTelemetryCollector = {
+  capture: (renderer: WebGLRenderer, uniforms: UniformRecord) => void
+  dispose: () => void
+  getTarget: () => THREE.WebGLRenderTarget | null
+}
+
+export const createInkTelemetryCollector = (): InkTelemetryCollector => {
+  const enabled = detectInkTelemetryEnabled()
+  if (!enabled) {
+    return {
+      capture: () => {},
+      dispose: () => {},
+      getTarget: () => null,
+    }
+  }
+
+  let renderTarget: THREE.WebGLRenderTarget | null = null
+  let scene: THREE.Scene | null = null
+  let camera: THREE.OrthographicCamera | null = null
+  let blitMaterial: THREE.ShaderMaterial | null = null
+  let quad: THREE.Mesh<THREE.BufferGeometry, THREE.ShaderMaterial> | null = null
+  let metricsUniform: { value: THREE.Vector4[] } | null = null
+  const readBuffer = new Float32Array(4 * 4)
+  let lastSampleMs = 0
+
+  const ensureResources = () => {
+    if (!renderTarget) {
+      renderTarget = new THREE.WebGLRenderTarget(4, 1, {
+        type: THREE.FloatType,
+        format: THREE.RGBAFormat,
+        depthBuffer: false,
+        stencilBuffer: false,
+      })
+    }
+    if (!scene) {
+      scene = new THREE.Scene()
+    }
+    if (!camera) {
+      camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    }
+    if (!metricsUniform) {
+      metricsUniform = { value: makeVectorUniform() }
+    }
+    if (!blitMaterial) {
+      blitMaterial = new THREE.ShaderMaterial({
+        uniforms: {
+          uMetrics: metricsUniform,
+        },
+        vertexShader: `
+          precision highp float;
+          attribute vec3 position;
+          void main() {
+            gl_Position = vec4(position, 1.0);
+          }
+        `,
+        fragmentShader: `
+          precision highp float;
+          uniform vec4 uMetrics[4];
+          void main() {
+            int idx = clamp(int(floor(gl_FragCoord.x)), 0, 3);
+            gl_FragColor = uMetrics[idx];
+          }
+        `,
+        depthTest: false,
+        depthWrite: false,
+        blending: THREE.NoBlending,
+      })
+      quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), blitMaterial)
+      scene!.add(quad)
+    }
+  }
+
+  const updateMetrics = (uniforms: UniformRecord) => {
+    if (!metricsUniform) {
+      return
+    }
+    const vecs = metricsUniform.value
+    const get = (key: string, fallback: number) => resolveNumber(uniforms[key]?.value ?? uniforms[key], fallback)
+
+    const reveal = clamp01(get('uReveal', 0))
+    const alphaFloor = clamp01(get('uAlphaFloor', 0.06))
+    const pointBaseSize = get('uPointBaseSize', 1)
+    const focal = Math.max(1e-3, get('uFocal', 1))
+    const minSize = get('uMinSize', 0)
+    const maxSize = get('uMaxSize', 4)
+    const breath = get('uBreath', 0.5)
+    const cascade = clamp01(get('uCascade', 0))
+    const cascadeBoost = Math.max(0, get('uCascadeSizeBoost', 0))
+
+    const viewDist = focal
+    let attenuation = focal / Math.max(1e-3, viewDist)
+    attenuation = Math.max(minSize, Math.min(maxSize, attenuation))
+    const breathPhase = (breath - 0.5) * 2
+    const breathScale = 1 + breathPhase * 0.06
+    const cascadeSize = cascade * cascadeBoost
+    const pointSize = pointBaseSize * attenuation * breathScale * (1 + cascadeSize)
+
+    const spriteAlpha = 0.85
+    const spriteMix = alphaFloor + (1 - alphaFloor) * spriteAlpha
+    const revealStrength = reveal
+    const alphaPre = spriteMix * revealStrength * Math.max(revealStrength, revealStrength * 0.4)
+
+    vecs[0].set(pointSize, alphaPre, revealStrength, 1)
+    vecs[1].set(0, 0, 0, 0)
+    vecs[2].set(0, 0, 0, 0)
+    vecs[3].set(0, 0, 0, 0)
+  }
+
+  const capture = (renderer: WebGLRenderer, uniforms: UniformRecord) => {
+    const now = getNow()
+    if (now - lastSampleMs < SAMPLE_INTERVAL_MS) {
+      return
+    }
+    lastSampleMs = now
+
+    ensureResources()
+    if (!renderTarget || !scene || !camera || !blitMaterial || !metricsUniform) {
+      return
+    }
+
+    updateMetrics(uniforms)
+
+    const prevTarget = renderer.getRenderTarget()
+    const prevViewport = new THREE.Vector4()
+    renderer.getViewport(prevViewport)
+    const prevScissor = new THREE.Vector4()
+    renderer.getScissor(prevScissor)
+    const prevScissorTest = renderer.getScissorTest()
+    const prevAutoClear = renderer.autoClear
+
+    renderer.setRenderTarget(renderTarget)
+    renderer.setViewport(0, 0, 4, 1)
+    renderer.setScissorTest(false)
+    renderer.autoClear = true
+    renderer.clear()
+    renderer.render(scene, camera)
+    renderer.setRenderTarget(prevTarget)
+    renderer.setViewport(prevViewport.x, prevViewport.y, prevViewport.z, prevViewport.w)
+    renderer.setScissor(prevScissor.x, prevScissor.y, prevScissor.z, prevScissor.w)
+    renderer.setScissorTest(prevScissorTest)
+    renderer.autoClear = prevAutoClear
+
+    try {
+      renderer.readRenderTargetPixels(renderTarget, 0, 0, 4, 1, readBuffer)
+    } catch {
+      return
+    }
+
+    const pointSize = readBuffer[0]
+    const alphaPre = readBuffer[1]
+    const revealStrength = readBuffer[2]
+    const format = (value: number) => (Number.isFinite(value) ? Number(value.toFixed(4)) : value)
+    console.info('[ink] point-stats', {
+      size: format(pointSize),
+      alpha: format(alphaPre),
+      reveal: format(revealStrength),
+    })
+  }
+
+  const dispose = () => {
+    if (renderTarget) {
+      renderTarget.dispose()
+      renderTarget = null
+    }
+    if (blitMaterial) {
+      blitMaterial.dispose()
+      blitMaterial = null
+    }
+    if (quad) {
+      quad.geometry.dispose()
+      quad = null
+    }
+    scene = null
+    camera = null
+    metricsUniform = null
+  }
+
+  return {
+    capture,
+    dispose,
+    getTarget: () => renderTarget,
+  }
+}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/simTelemetry.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/simTelemetry.ts
@@ -1,0 +1,157 @@
+import type { Texture, WebGLRenderer, WebGLRenderTarget } from 'three'
+
+type TextureHandle = {
+  texture: Texture | null
+  handle: WebGLTexture | null
+}
+
+type ReadTarget = {
+  isWebGLRenderTarget: true
+  width: number
+  height: number
+  texture: Texture | null
+}
+
+type RendererWithInternals = WebGLRenderer & {
+  properties?: { get: (target: unknown) => Record<string, unknown> }
+}
+
+const GRID_SIZE = 8
+const SAMPLE_INTERVAL_MS = 1000
+
+const getNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+
+const detectSimTelemetryEnabled = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('engine') !== 'sim') {
+      return false
+    }
+    return params.get('simStats') === '1'
+  } catch {
+    return false
+  }
+}
+
+const createReadTarget = (): ReadTarget => ({
+  isWebGLRenderTarget: true,
+  width: 0,
+  height: 0,
+  texture: null,
+})
+
+export type SimTelemetryCollector = {
+  sample: (
+    framebuffer: WebGLFramebuffer | null,
+    texture: TextureHandle | null,
+    width: number,
+    height: number,
+  ) => void
+  dispose: () => void
+}
+
+export const createSimTelemetryCollector = (renderer: WebGLRenderer): SimTelemetryCollector => {
+  const enabled = detectSimTelemetryEnabled()
+  if (!enabled) {
+    return {
+      sample: () => {},
+      dispose: () => {},
+    }
+  }
+
+  const internal = renderer as RendererWithInternals
+  const readTarget = createReadTarget()
+  const buffer = new Float32Array(4)
+  const scratchSamples = new Array<number>(GRID_SIZE * GRID_SIZE)
+  let lastSampleMs = 0
+
+  const sample = (
+    framebuffer: WebGLFramebuffer | null,
+    textureHandle: TextureHandle | null,
+    width: number,
+    height: number,
+  ) => {
+    if (!framebuffer || !textureHandle || width <= 0 || height <= 0) {
+      return
+    }
+    const now = getNow()
+    if (now - lastSampleMs < SAMPLE_INTERVAL_MS) {
+      return
+    }
+    lastSampleMs = now
+
+    readTarget.width = width
+    readTarget.height = height
+    readTarget.texture = textureHandle.texture
+
+    const props = internal.properties?.get(readTarget)
+    if (props) {
+      props.__webglFramebuffer = framebuffer
+      props.__webglTexture = textureHandle.handle
+    }
+
+    let min = Infinity
+    let max = -Infinity
+    let sum = 0
+    let finiteCount = 0
+    let nanCount = 0
+    let infCount = 0
+
+    for (let yIndex = 0; yIndex < GRID_SIZE; yIndex += 1) {
+      const v = GRID_SIZE === 1 ? 0.5 : yIndex / (GRID_SIZE - 1)
+      const texY = Math.min(height - 1, Math.max(0, Math.round(v * (height - 1))))
+      for (let xIndex = 0; xIndex < GRID_SIZE; xIndex += 1) {
+        const u = GRID_SIZE === 1 ? 0.5 : xIndex / (GRID_SIZE - 1)
+        const texX = Math.min(width - 1, Math.max(0, Math.round(u * (width - 1))))
+        buffer.fill(0)
+        try {
+          renderer.readRenderTargetPixels(readTarget as unknown as WebGLRenderTarget, texX, texY, 1, 1, buffer)
+        } catch {
+          return
+        }
+        const length = Math.hypot(buffer[0] ?? 0, buffer[1] ?? 0, buffer[2] ?? 0)
+        scratchSamples[yIndex * GRID_SIZE + xIndex] = length
+        if (Number.isNaN(length)) {
+          nanCount += 1
+          continue
+        }
+        if (!Number.isFinite(length)) {
+          infCount += 1
+          continue
+        }
+        if (length < min) min = length
+        if (length > max) max = length
+        sum += length
+        finiteCount += 1
+      }
+    }
+
+    const avg = finiteCount > 0 ? sum / finiteCount : 0
+    const payload = {
+      min: finiteCount > 0 ? Number(min.toFixed(4)) : 0,
+      max: finiteCount > 0 ? Number(max.toFixed(4)) : 0,
+      avg: finiteCount > 0 ? Number(avg.toFixed(4)) : 0,
+      nanCount,
+      infCount,
+      samples: scratchSamples.map((value) => {
+        if (!Number.isFinite(value)) {
+          return value
+        }
+        return Number(value.toFixed(4))
+      }),
+      texSize: [width, height] as [number, number],
+      grid: GRID_SIZE,
+    }
+    console.info('[sim] metrics', payload)
+  }
+
+  return {
+    sample,
+    dispose: () => {
+      readTarget.texture = null
+    },
+  }
+}


### PR DESCRIPTION
## Inputs
- 2025-09-25-dreamdust-ink-mask-brief.md
- 2025-09-25-test-protocol.md
- 2025-09-25-gpgpu-pipeline.md

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/index.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/inkTelemetry.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/simTelemetry.ts

## Evidence
- Sim telemetry wiring with throttled FBO sampling and cleanup hooks. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/sim/ParticleSim.ts†L1-L509】
- Ink telemetry capture tied into Dreamdust material lifecycle. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L583-L629】
- Shared telemetry helpers for query-flag gating, GPU readbacks, and metric logging. 【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/index.ts†L1-L4】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/inkTelemetry.ts†L1-L225】【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/telemetry/simTelemetry.ts†L1-L157】

## Baseline commands
- `corepack enable` 【f0b843†L1-L1】
- `pnpm install --frozen-lockfile` 【d7ba47†L1-L7】
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit` 【cd1c24†L1-L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true` 【8b2f32†L1-L74】
- `CI=1 pnpm --filter cryptiq-mindmap-demo run build` 【f30e9e†L1-L20】
- `pnpm run smoke` 【db57a6†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68d5ce4774c4832891baef7335eb403d