### PR TITLE
feat: surface sim/ink telemetry in hud

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -18,6 +18,8 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass'
 import { applyPerspectiveCover, applyPerspectiveFit, depthNormScaleFromRadius } from './anim/camera'
 import { createDreamdustMaterial } from './dreamdust/DreamdustMaterial'
+import { getDebugFlags } from './dreamdust/debug/getDebugFlags'
+import { useDebugControls } from './dreamdust/debug/useDebugControls'
 import { getDreamdustCaps, type DreamdustRuntimeCaps } from './dreamdust/capabilities'
 import { useDreamdustCtx } from './dreamdust/context'
 import {
@@ -38,6 +40,7 @@ import {
   pointCap,
 } from './pointcloud/budget'
 import { ParticleSim } from './dreamdust/sim/ParticleSim'
+import DebugHud from './dreamdust/ui/DebugHud'
 
 type PointCloudStageProps = {
   sceneId?: string
@@ -182,24 +185,6 @@ function readSearchParamSafe(name: string): string | null {
   } catch {
     return null
   }
-}
-
-function readDebugInkProbe(): boolean {
-  const value = readSearchParamSafe('inkProbe')
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    return normalized === '1' || normalized === 'true'
-  }
-  return false
-}
-
-function readDebugSimProbe(): boolean {
-  const value = readSearchParamSafe('simProbe')
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    return normalized === '1' || normalized === 'true'
-  }
-  return false
 }
 
 function readNumberOverride(queryKey: string, envKey?: string): number | null {
@@ -1074,8 +1059,10 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const inkTex = dreamdustCtx?.inkTex ?? null
   const inkIntensity = dreamdustCtx?.inkIntensity ?? 1
   const vertexInkOk = dreamdustCtx?.vertexInkOk ?? runtimeCaps?.vertexInkOk ?? false
-  const debugInkProbe = React.useMemo(() => readDebugInkProbe(), [])
-  const debugSimProbe = React.useMemo(() => readDebugSimProbe(), [])
+  const debugFlags = React.useMemo(() => getDebugFlags(), [])
+  const { simSnapshot, inkSnapshot } = useDebugControls(debugFlags)
+  const debugInkProbe = debugFlags.inkProbe
+  const debugSimProbe = debugFlags.simProbe
   const uniformsWithReveal = uniforms as DreamdustStageUniformsWithReveal
   const hasRevealUniform = !!uniformsWithReveal.uReveal
   const timelineSupported = hasRevealUniform && typeof startReveal === 'function'
@@ -2469,6 +2456,14 @@ export default function PointCloudStage(props: PointCloudStageProps) {
               />
               roll180 (rotate Z)
             </label>
+            {process.env.NODE_ENV !== 'production' && (debugFlags.simStats || debugFlags.inkStats) ? (
+              <DebugHud
+                simEnabled={debugFlags.simStats}
+                simSnapshot={simSnapshot}
+                inkEnabled={debugFlags.inkStats}
+                inkSnapshot={inkSnapshot}
+              />
+            ) : null}
           </div>
         </div>
       )}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/getDebugFlags.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/getDebugFlags.ts
@@ -1,0 +1,45 @@
+'use client'
+
+export type DebugFlags = {
+  debug: boolean
+  engineSim: boolean
+  inkProbe: boolean
+  simProbe: boolean
+  simStats: boolean
+  inkStats: boolean
+}
+
+const DEFAULT_FLAGS: DebugFlags = {
+  debug: false,
+  engineSim: false,
+  inkProbe: false,
+  simProbe: false,
+  simStats: false,
+  inkStats: false,
+}
+let cachedSearch: string | null = null
+let cachedFlags: DebugFlags = DEFAULT_FLAGS
+const toFlag = (value: string | null) =>
+  typeof value === 'string' && ['1', 'true'].includes(value.trim().toLowerCase())
+
+export function getDebugFlags(): DebugFlags {
+  if (typeof window === 'undefined') return DEFAULT_FLAGS
+  const { search } = window.location
+  if (cachedSearch === search) return cachedFlags
+  cachedSearch = search
+  try {
+    const params = new URLSearchParams(search)
+    const engineSim = (params.get('engine') ?? '').trim().toLowerCase() === 'sim'
+    cachedFlags = {
+      debug: params.get('debug') === '1',
+      engineSim,
+      inkProbe: toFlag(params.get('inkProbe')),
+      simProbe: toFlag(params.get('simProbe')),
+      simStats: engineSim && toFlag(params.get('simStats')),
+      inkStats: engineSim && toFlag(params.get('inkStats')),
+    }
+  } catch {
+    cachedFlags = DEFAULT_FLAGS
+  }
+  return cachedFlags
+}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/useDebugControls.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/useDebugControls.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import * as React from 'react'
+
+import { getDebugFlags, type DebugFlags } from './getDebugFlags'
+
+export type SimTelemetrySnapshot = {
+  min: number; max: number; avg: number; nanCount: number; infCount: number; texSize: [number, number]; grid: number
+}
+export type InkTelemetrySnapshot = { size: number; alpha: number; reveal: number }
+
+const num = (value: unknown, fallback = 0) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback
+const count = (value: unknown) => Math.max(0, Math.floor(num(value)))
+const parseSim = (payload: unknown): SimTelemetrySnapshot | null => {
+  if (typeof payload !== 'object' || !payload) return null
+  const r = payload as Record<string, unknown>
+  const tex = Array.isArray(r.texSize) ? r.texSize : []
+  return { min: num(r.min), max: num(r.max), avg: num(r.avg), nanCount: count(r.nanCount), infCount: count(r.infCount), texSize: [num(tex[0]), num(tex[1])], grid: count(r.grid) }
+}
+const parseInk = (payload: unknown): InkTelemetrySnapshot | null => {
+  if (typeof payload !== 'object' || !payload) return null
+  const r = payload as Record<string, unknown>
+  return { size: num(r.size), alpha: num(r.alpha), reveal: num(r.reveal) }
+}
+
+export function useDebugControls(initialFlags?: DebugFlags) {
+  const flags = React.useMemo(() => initialFlags ?? getDebugFlags(), [initialFlags])
+  const [simSnapshot, setSimSnapshot] = React.useState<SimTelemetrySnapshot | null>(null)
+  const [inkSnapshot, setInkSnapshot] = React.useState<InkTelemetrySnapshot | null>(null)
+
+  React.useEffect(() => {
+    if (!flags.simStats) setSimSnapshot(null)
+    if (!flags.inkStats) setInkSnapshot(null)
+  }, [flags.simStats, flags.inkStats])
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return
+    if (!flags.simStats && !flags.inkStats) return
+    if (typeof window === 'undefined') return
+    const original = console.info
+    if (typeof original !== 'function') return
+    const patched: typeof console.info = (...args) => {
+      if (flags.simStats && args[0] === '[sim] metrics') {
+        const next = parseSim(args[1])
+        if (next) setSimSnapshot(next)
+      } else if (flags.inkStats && args[0] === '[ink] point-stats') {
+        const next = parseInk(args[1])
+        if (next) setInkSnapshot(next)
+      }
+      return original.apply(console, args as Parameters<typeof console.info>)
+    }
+    console.info = patched
+    return () => {
+      console.info = original
+    }
+  }, [flags.inkStats, flags.simStats])
+
+  if (process.env.NODE_ENV === 'production' || (!flags.simStats && !flags.inkStats)) {
+    return { flags, simSnapshot: null, inkSnapshot: null }
+  }
+  return { flags, simSnapshot, inkSnapshot }
+}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/ui/DebugHud.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/ui/DebugHud.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import type { InkTelemetrySnapshot, SimTelemetrySnapshot } from '../debug/useDebugControls'
+
+type Severity = 'ok' | 'warn' | 'error'
+
+type Props = {
+  simEnabled: boolean
+  simSnapshot: SimTelemetrySnapshot | null
+  inkEnabled: boolean
+  inkSnapshot: InkTelemetrySnapshot | null
+}
+
+const COLORS: Record<Severity, string> = { ok: '#2fdf84', warn: '#fbbf24', error: '#ff6b6b' }
+const format = (value: number) => (Number.isFinite(value) ? value.toFixed(4) : '—')
+const simSeverity = (snapshot: SimTelemetrySnapshot | null): Severity =>
+  !snapshot ? 'warn' : snapshot.nanCount > 0 || snapshot.infCount > 0 ? 'error' : snapshot.avg <= 0 ? 'warn' : 'ok'
+const inkSeverity = (snapshot: InkTelemetrySnapshot | null): Severity =>
+  !snapshot ? 'warn' : snapshot.reveal <= 0.05 ? 'error' : snapshot.alpha <= 0.1 ? 'warn' : 'ok'
+
+export default function DebugHud({ simEnabled, simSnapshot, inkEnabled, inkSnapshot }: Props) {
+  if (process.env.NODE_ENV === 'production' || (!simEnabled && !inkEnabled)) return null
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        paddingTop: 12,
+        borderTop: '1px solid rgba(255,255,255,0.15)',
+        display: 'grid',
+        rowGap: 10,
+      }}
+    >
+      {simEnabled && (
+        <section>
+          <header style={{ fontWeight: 600, marginBottom: 4, color: COLORS[simSeverity(simSnapshot)] }}>
+            Sim telemetry
+          </header>
+          <div style={{ fontSize: 11, lineHeight: 1.4 }}>
+            {simSnapshot ? (
+              <>
+                <div>avg: {format(simSnapshot.avg)}</div>
+                <div>min/max: {format(simSnapshot.min)} / {format(simSnapshot.max)}</div>
+                <div>nan/inf: {simSnapshot.nanCount} / {simSnapshot.infCount}</div>
+                <div>
+                  tex: {simSnapshot.texSize[0]} × {simSnapshot.texSize[1]} · grid {simSnapshot.grid}
+                </div>
+              </>
+            ) : (
+              <div style={{ opacity: 0.7 }}>Waiting for samples…</div>
+            )}
+          </div>
+        </section>
+      )}
+      {inkEnabled && (
+        <section>
+          <header style={{ fontWeight: 600, marginBottom: 4, color: COLORS[inkSeverity(inkSnapshot)] }}>
+            Ink telemetry
+          </header>
+          <div style={{ fontSize: 11, lineHeight: 1.4 }}>
+            {inkSnapshot ? (
+              <>
+                <div>size: {format(inkSnapshot.size)}</div>
+                <div>alpha: {format(inkSnapshot.alpha)}</div>
+                <div>reveal: {format(inkSnapshot.reveal)}</div>
+              </>
+            ) : (
+              <div style={{ opacity: 0.7 }}>Waiting for samples…</div>
+            )}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Inputs
- Task brief "PR-2 — Debug Flag Wiring & HUD Exposure".

## Outputs
- apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
- apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/getDebugFlags.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/useDebugControls.ts
- apps/cryptiq-mindmap-demo/app/components/dreamdust/ui/DebugHud.tsx

## Evidence
- Centralized debug flag parsing now exposes telemetry gates and is consumed by PointCloudStage to drive probes and HUD visibility.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/getDebugFlags.ts†L1-L44】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L21-L43】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L1062-L1068】
- useDebugControls taps telemetry console output when flags are active, caching snapshots for the HUD.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/debug/useDebugControls.ts†L3-L63】
- DebugHud renders sim/ink snapshots with severity coloring and is only injected into the dev-only debug panel when telemetry flags are present.【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/ui/DebugHud.tsx†L1-L74】【F:apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx†L2459-L2466】

## Baseline command outputs
- `corepack enable`【4b3b81†L1-L2】
- `pnpm install --frozen-lockfile`【d628c6†L1-L4】【cf2375†L1-L5】
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`【012f57†L1-L2】
- `pnpm --filter cryptiq-mindmap-demo run lint || true`【6fc99e†L1-L5】【3506eb†L1-L66】
- `CI=1 pnpm --filter cryptiq-mindmap-demo run build`【746611†L1-L3】【514956†L1-L5】【c4be79†L1-L26】
- `pnpm run smoke`【84afc5†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_68d5d6ac8110832894cad1e53569456a