### PR TITLE
fix: clamp dreamdust point sizing defaults

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -30,7 +30,7 @@ import {
   type DreamdustTunables,
 } from './dreamdust/metrics'
 import InkSurface from './dreamdust/InkSurface'
-import { useDreamdustUniforms } from './dreamdust/useDreamdustUniforms'
+import { DEFAULT_POINT_SIZING, useDreamdustUniforms } from './dreamdust/useDreamdustUniforms'
 import { PresetAiry } from './dreamdust/presets'
 import {
   capInstances,
@@ -876,7 +876,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     colorUrl: colorUrlProp,
     depthUrl: depthUrlProp,
     depthRgUrl,
-    pointSize = 2.2,
+    pointSize = DEFAULT_POINT_SIZING.baseSize,
     stride = 1,
     // omit perspective in baseline
   } = props
@@ -1026,15 +1026,16 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     const { curlFreq, curlAmp } = tunablesRef.current
     setUniform('uGamma', 0.82)
     setUniform('uFocal', 1600)
-    setUniform('uMinSize', 0.75)
-    setUniform('uMaxSize', 9.5)
+    setUniform('uPointBaseSize', DEFAULT_POINT_SIZING.baseSize)
+    setUniform('uMinSize', DEFAULT_POINT_SIZING.minSize)
+    setUniform('uMaxSize', DEFAULT_POINT_SIZING.maxSize)
     setUniform('uDepthBias', 0.14)
     setUniform('uNoiseScale', curlFreq)
     setUniform('uNoiseSpeed', 0.24)
     // Stronger contrast on first draw: halve base drift, boost ink gains
     setUniform('uDriftAmp', curlAmp)
-    setUniform('uSizeGain', 1.0)
-    setUniform('uOffsetGain', 5.0)
+    setUniform('uSizeGain', DEFAULT_POINT_SIZING.sizeGain)
+    setUniform('uOffsetGain', Math.max(DEFAULT_POINT_SIZING.offsetGain, 5.0))
     setUniform('uTintGain', 0.2)
   }, [setUniform])
 
@@ -1465,7 +1466,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     roll180?: boolean
   }>(() => ({
     thickness: 0.38,
-    pointSizeScale: 2.2,
+    pointSizeScale: 1,
     keepRatio: 1,
     bloom: true,
     fovDeg: defaultFovDeg,

--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -1452,6 +1452,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     }
     return `h:${h.toString(16)}`
   }, [])
+  const initialPointScale =
+    Number.isFinite(pointSize) && pointSize > 0 ? pointSize / DEFAULT_POINT_SIZING.baseSize : 1
+
   const [ui, setUi] = React.useState<{
     thickness: number
     pointSizeScale: number
@@ -1466,7 +1469,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
     roll180?: boolean
   }>(() => ({
     thickness: 0.38,
-    pointSizeScale: 1,
+    pointSizeScale: initialPointScale,
     keepRatio: 1,
     bloom: true,
     fovDeg: defaultFovDeg,
@@ -1555,8 +1558,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   }, [bloomActive, bloomGuardReady])
 
   React.useEffect(() => {
-    uniforms.uBaseSize.value = pointSize * pointSizeScale
-  }, [pointSize, pointSizeScale, uniforms, ui])
+    setUniform('uPointBaseSize', DEFAULT_POINT_SIZING.baseSize * pointSizeScale)
+  }, [pointSizeScale, setUniform])
 
   React.useEffect(() => {
     if (timelineSupported) return

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -697,7 +697,13 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     const inkOffsetBoostValue = inkOffsetBase * (inkBumpEnabled ? INK_BUMP_OFFSET_MULTIPLIER : 1)
     const inkSizeBoostValue = inkSizeBase * (inkBumpEnabled ? INK_BUMP_SIZE_MULTIPLIER : 1)
     const inkTintBoostValue = inkTintBase * (inkBumpEnabled ? INK_BUMP_TINT_MULTIPLIER : 1)
-    const pointSizingDefaults = resolvePointSizing(defaults)
+    const pointSizingDefaults = resolvePointSizing({
+      uPointBaseSize: defaults.uPointBaseSize,
+      uMinSize: defaults.uMinSize,
+      uMaxSize: defaults.uMaxSize,
+      uSizeGain: defaults.uSizeGain,
+      uOffsetGain: defaults.uOffsetGain,
+    })
 
     uniformsRef.current = {
       uTime: { value: defaults.uTime },
@@ -738,6 +744,20 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
   }
 
   const tunablesRef = React.useRef(getDreamdustTunables())
+
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      return
+    }
+    const uniforms = uniformsRef.current
+    if (!uniforms) {
+      return
+    }
+    const base = uniforms.uPointBaseSize?.value ?? DEFAULT_POINT_SIZING.baseSize
+    const min = uniforms.uMinSize?.value ?? DEFAULT_POINT_SIZING.minSize
+    const max = uniforms.uMaxSize?.value ?? DEFAULT_POINT_SIZING.maxSize
+    safeLog('[dreamdust] point-size-debug', { base, min, max })
+  }, [])
 
   const resolveRevealDurationSeconds = React.useCallback(() => {
     if (presetAiryEnabled) {
@@ -791,7 +811,13 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     const inkOffsetValue = inkOffsetBase * (inkBumpEnabled ? INK_BUMP_OFFSET_MULTIPLIER : 1)
     const inkSizeValue = inkSizeBase * (inkBumpEnabled ? INK_BUMP_SIZE_MULTIPLIER : 1)
     const inkTintValue = inkTintBase * (inkBumpEnabled ? INK_BUMP_TINT_MULTIPLIER : 1)
-    const resolvedPointSizing = resolvePointSizing(defaults)
+    const resolvedPointSizing = resolvePointSizing({
+      uPointBaseSize: defaults.uPointBaseSize,
+      uMinSize: defaults.uMinSize,
+      uMaxSize: defaults.uMaxSize,
+      uSizeGain: defaults.uSizeGain,
+      uOffsetGain: defaults.uOffsetGain,
+    })
 
     for (const key of Object.keys(defaults) as (keyof DreamdustUniformValueMap)[]) {
       if (!(key in uniforms)) {

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts
@@ -99,6 +99,105 @@ const DEFAULT_SIM_CURVE: DreamdustSimCurveUniforms = Object.freeze({
   solidAlpha: 0.6,
 })
 
+export const DEFAULT_POINT_SIZING = Object.freeze({
+  baseSize: 3,
+  minSize: 2,
+  maxSize: 10,
+  sizeGain: 1,
+  offsetGain: 1,
+}) as const
+
+type PointSizingUniformName =
+  | 'uPointBaseSize'
+  | 'uMinSize'
+  | 'uMaxSize'
+  | 'uSizeGain'
+  | 'uOffsetGain'
+
+type PointSizingValues = Pick<DreamdustUniformValueMap, PointSizingUniformName>
+
+function isPointSizingUniformName(name: keyof DreamdustUniformValueMap): name is PointSizingUniformName {
+  return (
+    name === 'uPointBaseSize' ||
+    name === 'uMinSize' ||
+    name === 'uMaxSize' ||
+    name === 'uSizeGain' ||
+    name === 'uOffsetGain'
+  )
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min
+  }
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+function resolvePointSizing(source: PointSizingValues): PointSizingValues {
+  const floor = DEFAULT_POINT_SIZING.minSize
+  const ceiling = DEFAULT_POINT_SIZING.maxSize
+  const safeMin = clampNumber(source.uMinSize ?? floor, floor, ceiling)
+  const safeMaxCandidate = clampNumber(source.uMaxSize ?? ceiling, floor, ceiling)
+  const minBound = Math.min(safeMin, safeMaxCandidate)
+  const maxBound = Math.max(minBound, safeMaxCandidate)
+  const base = clampNumber(source.uPointBaseSize ?? DEFAULT_POINT_SIZING.baseSize, minBound, maxBound)
+  const sizeGain = Math.max(
+    DEFAULT_POINT_SIZING.sizeGain,
+    Number.isFinite(source.uSizeGain) ? (source.uSizeGain as number) : DEFAULT_POINT_SIZING.sizeGain
+  )
+  const offsetGain = Math.max(
+    DEFAULT_POINT_SIZING.offsetGain,
+    Number.isFinite(source.uOffsetGain)
+      ? (source.uOffsetGain as number)
+      : DEFAULT_POINT_SIZING.offsetGain
+  )
+  return {
+    uPointBaseSize: base,
+    uMinSize: minBound,
+    uMaxSize: maxBound,
+    uSizeGain: sizeGain,
+    uOffsetGain: offsetGain,
+  }
+}
+
+function applyPointSizingUniformValue(
+  uniforms: DreamdustUniforms,
+  name: PointSizingUniformName,
+  rawValue: number
+): number {
+  const fallback: PointSizingValues = {
+    uPointBaseSize: DEFAULT_POINT_SIZING.baseSize,
+    uMinSize: DEFAULT_POINT_SIZING.minSize,
+    uMaxSize: DEFAULT_POINT_SIZING.maxSize,
+    uSizeGain: DEFAULT_POINT_SIZING.sizeGain,
+    uOffsetGain: DEFAULT_POINT_SIZING.offsetGain,
+  }
+
+  const current: PointSizingValues = { ...fallback }
+
+  for (const key of Object.keys(current) as PointSizingUniformName[]) {
+    const uniform = uniforms[key]
+    if (uniform && typeof uniform.value === 'number' && Number.isFinite(uniform.value)) {
+      current[key] = uniform.value as PointSizingValues[typeof key]
+    }
+  }
+
+  current[name] = Number.isFinite(rawValue) ? rawValue : current[name]
+
+  const resolved = resolvePointSizing(current)
+
+  for (const key of Object.keys(resolved) as PointSizingUniformName[]) {
+    const uniform = uniforms[key]
+    if (uniform) {
+      ;(uniform as typeof uniform).value = resolved[key] as typeof uniform.value
+    }
+  }
+
+  return resolved[name]
+}
+
 function cloneSimCurve(curve: DreamdustSimCurveUniforms): DreamdustSimCurveUniforms {
   return {
     fadeIn: curve.fadeIn,
@@ -598,6 +697,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     const inkOffsetBoostValue = inkOffsetBase * (inkBumpEnabled ? INK_BUMP_OFFSET_MULTIPLIER : 1)
     const inkSizeBoostValue = inkSizeBase * (inkBumpEnabled ? INK_BUMP_SIZE_MULTIPLIER : 1)
     const inkTintBoostValue = inkTintBase * (inkBumpEnabled ? INK_BUMP_TINT_MULTIPLIER : 1)
+    const pointSizingDefaults = resolvePointSizing(defaults)
 
     uniformsRef.current = {
       uTime: { value: defaults.uTime },
@@ -617,7 +717,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
       uNoiseThreshold: { value: defaults.uNoiseThreshold },
       uDriftAmp: { value: defaults.uDriftAmp },
       uCurlAmp: { value: defaults.uCurlAmp },
-      uPointBaseSize: { value: defaults.uPointBaseSize },
+      uPointBaseSize: { value: pointSizingDefaults.uPointBaseSize },
       uDepthMin: { value: defaults.uDepthMin },
       uDepthMax: { value: defaults.uDepthMax },
       uDepthBias: { value: defaults.uDepthBias },
@@ -625,10 +725,10 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
       uGamma: { value: defaults.uGamma },
       uRimGamma: { value: defaults.uRimGamma },
       uFocal: { value: defaults.uFocal },
-      uMinSize: { value: defaults.uMinSize },
-      uMaxSize: { value: defaults.uMaxSize },
-      uSizeGain: { value: defaults.uSizeGain },
-      uOffsetGain: { value: defaults.uOffsetGain },
+      uMinSize: { value: pointSizingDefaults.uMinSize },
+      uMaxSize: { value: pointSizingDefaults.uMaxSize },
+      uSizeGain: { value: pointSizingDefaults.uSizeGain },
+      uOffsetGain: { value: pointSizingDefaults.uOffsetGain },
       uInkOffsetBoost: { value: inkOffsetBoostValue },
       uInkSizeBoost: { value: inkSizeBoostValue },
       uTintGain: { value: defaults.uTintGain },
@@ -691,6 +791,7 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     const inkOffsetValue = inkOffsetBase * (inkBumpEnabled ? INK_BUMP_OFFSET_MULTIPLIER : 1)
     const inkSizeValue = inkSizeBase * (inkBumpEnabled ? INK_BUMP_SIZE_MULTIPLIER : 1)
     const inkTintValue = inkTintBase * (inkBumpEnabled ? INK_BUMP_TINT_MULTIPLIER : 1)
+    const resolvedPointSizing = resolvePointSizing(defaults)
 
     for (const key of Object.keys(defaults) as (keyof DreamdustUniformValueMap)[]) {
       if (!(key in uniforms)) {
@@ -708,6 +809,8 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
         nextValue = inkSizeValue as DreamdustUniformValueMap[typeof key]
       } else if (key === 'uInkTintBoost') {
         nextValue = inkTintValue as DreamdustUniformValueMap[typeof key]
+      } else if (isPointSizingUniformName(key)) {
+        nextValue = resolvedPointSizing[key] as DreamdustUniformValueMap[typeof key]
       }
 
       const uniform = uniforms[key]
@@ -915,6 +1018,13 @@ export function useDreamdustUniforms(): UseDreamdustUniformsResult {
     <Name extends DreamdustUniformName>(name: Name, value: DreamdustUniformValue<Name>) => {
       const uniforms = uniformsRef.current
       if (!uniforms) return
+      if (isPointSizingUniformName(name) && typeof value === 'number') {
+        const uniform = uniforms[name]
+        if (!uniform) return
+        applyPointSizingUniformValue(uniforms, name, value)
+        return
+      }
+
       const uniform = uniforms[name]
       if (!uniform) return
       const current = uniform.value


### PR DESCRIPTION
## Inputs
- Updated Dreamdust uniform initialization and clamping in `apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts`.
- Synced stage defaults and UI baseline in `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`.

## Outputs
- `apps/cryptiq-mindmap-demo/app/components/dreamdust/useDreamdustUniforms.ts`
- `apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx`

## Evidence
- Introduced `DEFAULT_POINT_SIZING` and clamp helpers so Dreamdust uniforms respect sane floors/ceilings on init, preset swap, and manual updates.
- PointCloudStage now seeds `uPointBaseSize`, `uMinSize`, `uMaxSize`, and related UI defaults from the shared sizing constant so runtime and controls match on first render.

## Baseline command outputs
- ✅ `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`
- ⚠️ `pnpm --filter cryptiq-mindmap-demo run lint || true` (fails on existing Next.js lint warnings and unused exports)
- ✅ `CI=1 pnpm --filter cryptiq-mindmap-demo run build`
- ✅ `pnpm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68d7197fbcf48328aa5cb5670db574a6