### PR TITLE
fix: restore reveal clamp guard

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -376,7 +376,7 @@ void main() {
   }
 #endif
 
-  float pointSizeClamped = 8.0; // TEMP: force large points for diagnostics
+  float pointSizeClamped = max(0.0, pointSize);
 
 #ifdef DEBUG_INK_PROBE
   pointSizeClamped *= mix(1.0, 4.0, inkProbe);
@@ -422,6 +422,7 @@ uniform float uTime;
 uniform float uNoiseSpeed;
 uniform float uEvolution;
 uniform float uNoiseThreshold;
+uniform float uReveal;
 uniform float uInkIntensity;
 uniform float uTintGain;
 uniform float uInkTintBoost;
@@ -463,17 +464,17 @@ void main() {
   float threshold = clamp(uNoiseThreshold, 0.0, 1.0);
   float revealNoise = dd_noise2(vRevealCoord);
   float revealStrength = clamp(vRevealMix, 0.0, 1.0);
+  if (uReveal >= 0.999) {
+    revealStrength = 1.0;
+  }
   float w = 0.08;
   float baseReveal = smoothstep(threshold - w, threshold + w, revealNoise);
   float revealAlpha = max(baseReveal, revealStrength * 0.40);
 
   float alpha = spriteMix * revealAlpha * revealStrength;
   float depthNorm = dreamdustViewDepthNorm(vPosMV, uDepthNormScale);
-  float depthAlpha = dreamdustDepthAlpha(depthNorm, uDepthBias);
-
-  // TEMP diagnostics: output signer channels directly for visibility debugging.
-  gl_FragColor = vec4(depthAlpha, revealAlpha, spriteMix, 1.0);
-  return;
+  alpha *= dreamdustDepthAlpha(depthNorm, uDepthBias);
+  if (alpha <= 0.001) discard;
 
   vec3 color = vColor;
 


### PR DESCRIPTION
## Summary
- add the uReveal uniform to the fragment shader and restore the revealStrength clamp when the reveal is fully open so diagnostics are removed without breaking the guard【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L421-L477】

## Testing
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`【eca630†L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true` (fails with existing lint warnings)【4ab348†L1】【205905†L1-L52】
- `env TERM=dumb pnpm --filter cryptiq-mindmap-demo run build`【a88234†L1-L2】【19efe8†L1-L20】
- `pnpm run smoke`【740459†L1】【c222e2†L1-L6】

## Inputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Outputs
- apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts

## Evidence
- Dreamdust shader cleanup【F:apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts†L360-L477】

## Baseline command outputs
- `pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit`【eca630†L1】
- `pnpm --filter cryptiq-mindmap-demo run lint || true`【4ab348†L1】【205905†L1-L52】
- `env TERM=dumb pnpm --filter cryptiq-mindmap-demo run build`【a88234†L1-L2】【19efe8†L1-L20】
- `pnpm run smoke`【740459†L1】【c222e2†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68d71976d4e88328b7d0e40655cabf91