### PR TITLE
docs: sync dreamdust smoke briefs

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-24-dreamdust-ink-mask-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-24-dreamdust-ink-mask-brief.md
@@ -1,5 +1,23 @@
 # Dreamdust Ink — Mask Round Brief (v1)
 
+## Quick Index
+
+- [Metadata](#metadata)
+- [End Experience (aesthetic-only)](#end-experience-aesthetic-only)
+- [Test Route (canonical)](#test-route-canonical)
+- [Guardrails (baseline status)](#guardrails-baseline-status)
+- [Cross-Date Metrics](#cross-date-metrics)
+- [Current Evidence (2025-09-24 smoke)](#current-evidence-2025-09-24-smoke)
+- [2025-09-24 Post-Merge Smoke](#2025-09-24-post-merge-smoke)
+- [2025-09-25 Cover-Fit Dev Snapshot](#2025-09-25-cover-fit-dev-snapshot)
+- [2025-09-25 Sim Smoke](#2025-09-25-sim-smoke)
+- [2025-09-25 Probes Smoke (inkProbe=1, simProbe=1)](#2025-09-25-probes-smoke-inkprobe1-simprobe1)
+- [2025-09-26 Probes Smoke (post-probe fix)](#2025-09-26-probes-smoke-post-probe-fix)
+- [2025-09-27 Clamp + Preset Update](#2025-09-27-clamp--preset-update)
+- [Status Summary](#status-summary)
+
+Raw reference: [2025-09-28 smoke capture](2025-09-28-smoke-raw.md#4-console-objects-paste-the-expanded-payload-for-each).
+
 ## Metadata
 
 - Date: 2025-09-24
@@ -21,6 +39,17 @@
 - DPR clamp logged as 1.8 (desktop); point budget 89,441 instances.
 - Frame percentiles: single log `{ p50 ≈ 16.7 ms, p90 ≈ 58.4 ms }` with persistent rAF violations.
 - Ink worker disabled; fallback path active.
+
+## Cross-Date Metrics
+
+| Date / Run | Visual outcome snapshot | Sim avg / max | Frame p90 (ms) | Ink latency (ms) |
+| ---------- | ---------------------- | ------------- | -------------- | ---------------- |
+| 2025-09-24 baseline smoke | Bright white jittered swarm; silhouette lost. | — | 58.4 | — |
+| 2025-09-24 post-merge prod | Tighter cat silhouette with bloom, sits deep in frame. | — | 9.1 | 7.9 |
+| 2025-09-25 cover-fit dev | Cat fills viewport with crisp stipple, bloom on. | — | ≈9 | — |
+| 2025-09-25 sim smoke | Canvas nearly black; distant lone orb only. | — | 37.1 | — |
+| 2025-09-25 probes smoke | Probes linked but canvas blank with faint orb. | 1.02 / 1.55 | 41.8 | 40.1 |
+| 2025-09-28 probes smoke raw | HUD-only scene; faint orb, heavy rAF violations. | 1.02 / 1.55 | 60 | 2.3 |
 
 ## Current Evidence (2025-09-24 smoke)
 

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-25-dreamdust-ink-mask-brief.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-25-dreamdust-ink-mask-brief.md
@@ -1,5 +1,27 @@
 # Dreamdust Ink - Probes Smoke Brief (2025-09-25)
 
+## Quick Index
+
+- [Metadata](#metadata)
+- [Goal](#goal)
+- [Artifacts (evidence)](#artifacts-evidence)
+- [Telemetry Evidence (AK-DD)](#telemetry-evidence-ak-dd)
+- [Cross-reference vs expectations](#cross-reference-vs-expectations)
+- [Interaction probe results](#interaction-probe-results)
+- [Diagnosis (why the failure happens)](#diagnosis-why-the-failure-happens)
+- [Desired aesthetic/interaction impact](#desired-aestheticinteraction-impact)
+- [Next actions (code-level)](#next-actions-code-level)
+- [Appendix: Run configuration](#appendix-run-configuration)
+
+Cross-date metrics: see [2025-09-24 brief](2025-09-24-dreamdust-ink-mask-brief.md#cross-date-metrics) for p90/latency rollup.
+
+Raw console payloads are archived in [2025-09-28 smoke capture §4](2025-09-28-smoke-raw.md#4-console-objects-paste-the-expanded-payload-for-each) — especially:
+
+- [`[dreamdust] caps`](2025-09-28-smoke-raw.md#41-dreamdust-caps)
+- [`[dreamdust] frame-percentiles`](2025-09-28-smoke-raw.md#49-dreamdust-frame-percentiles)
+- [`[dreamdust] ink-latency`](2025-09-28-smoke-raw.md#411-dreamdust-ink-latency-short-tap)
+- [`[sim] metrics` snapshots](2025-09-28-smoke-raw.md#412-sim-metrics-tap-adjacent-immediately-after-short-tap)
+
 ## Metadata
 
 - Branch: `debug/batch0-baseline`

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-smoke-raw.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-smoke-raw.md
@@ -1,5 +1,30 @@
 # 10:15 AM ET, 2025-09-28 Smoke — Raw Capture
 
+## Index
+
+- [1. Metadata](#1-metadata)
+- [2. Process](#2-process)
+- [3. Terminal Session](#3-terminal-session)
+- [4. Console Objects](#4-console-objects-paste-the-expanded-payload-for-each)
+  - [[dreamdust] caps](#41-dreamdust-caps)
+  - [[dreamdust] caps-fanout](#42-dreamdust-caps-fanout)
+  - [[PC] instances](#43-pc-instances)
+  - [[Dreamdust] reveal start](#44-dreamdust-reveal-start)
+  - [[Dreamdust] reveal end](#45-dreamdust-reveal-end)
+  - [[dreamdust] cover-fit](#46-dreamdust-cover-fit-write-not-emitted-if-absent)
+  - [[engine] sim on](#47-engine-sim-on)
+  - [[engine] sim fit](#48-engine-sim-fit)
+  - [[dreamdust] frame-percentiles](#49-dreamdust-frame-percentiles)
+  - [[PC] ink debug](#410-pc-ink-debug-short-tap)
+  - [[dreamdust] ink-latency](#411-dreamdust-ink-latency-short-tap)
+  - [[sim] metrics (tap-adjacent)](#412-sim-metrics-tap-adjacent-immediately-after-short-tap)
+  - [[sim] metrics (late-run)](#413-sim-metrics-late-run-30s-after-long-stroke)
+  - [Shader / WebGL errors](#414-shader--webgl-errors-or-none)
+  - [Additional objects](#415-additional-objects-add-more-subsections-as-needed)
+- [5. Screenshot Notes](#5-screenshot-notes)
+- [6. Quick Gut Notes](#6-quick-gut-notes-one-liners-we-will-refine-later)
+- [8. Full Browser Console Logs](#8-full-browser-console-logs)
+
 ## 1. Metadata
 
 - Date / Time: 10:15 AM ET, 2025-09-28
@@ -281,8 +306,13 @@ Route (app)                                 Size  First Load JS
 
 ### 4.2 [dreamdust] caps-fanout
 
-```
-{ stage: true, context: true, host: true, metrics: true }
+```json
+{
+    "stage": true,
+    "context": true,
+    "host": true,
+    "metrics": true
+}
 ```
 
 ### 4.3 [PC] instances
@@ -309,25 +339,40 @@ Route (app)                                 Size  First Load JS
 
 ### 4.6 [dreamdust] cover-fit (write “not emitted” if absent)
 
-```
-Not Emitted
+```json
+{
+    "status": "not emitted"
+}
 ```
 
 ### 4.7 [engine] sim on
 
-```
-{ count:89441, texSize:[300,299] }
+```json
+{
+    "count": 89441,
+    "texSize": [
+        300,
+        299
+    ]
+}
 ```
 
 ### 4.8 [engine] sim fit
 
-```
-{ radius:0.382, center:[0.01,-0.03,1.13] }
+```json
+{
+    "radius": 0.382,
+    "center": [
+        0.01,
+        -0.03,
+        1.13
+    ]
+}
 ```
 
 ### 4.9 [dreamdust] frame-percentiles
 
-```
+```json
 {
     "sampleCount": 240,
     "p50Ms": 54.6,
@@ -350,7 +395,7 @@ Not Emitted
 
 ### 4.11 [dreamdust] ink-latency (short tap)
 
-```
+```json
 {
     "ms": 2.3,
     "frames": 0.14
@@ -359,7 +404,7 @@ Not Emitted
 
 ### 4.12 [sim] metrics (tap-adjacent, immediately after short tap)
 
-```
+```json
 {
     "min": 0,
     "max": 1.5524,
@@ -377,19 +422,23 @@ Not Emitted
         0.8235, 0.8235, 0.8235, 0.8235, 0.8177, 1.5493, 0.8235, 0.8177,
         0.8235, 0, 0, 0, 0, 0, 0, 0
     ],
-    "texSize": [300, 299]
+    "texSize": [
+        300,
+        299
+    ]
 }
 ```
 
 ### 4.13 [sim] metrics (late-run, ~30s after long stroke)
 
-```
+```json
 {
     "min": 0,
     "max": 1.5524,
     "avg": 1.0168,
     "nanCount": 0,
     "infCount": 0,
+    "grid": 8,
     "samples": [
         0.8177, 1.5493, 0.8235, 1.5524, 1.5524, 1.5524, 0.8235, 1.5524,
         0.8235, 0.8235, 1.5493, 1.5493, 0.8177, 0.8235, 0.8235, 1.5493,
@@ -400,8 +449,10 @@ Not Emitted
         0.8235, 0.8235, 0.8235, 0.8235, 0.8177, 1.5493, 0.8235, 0.8177,
         0.8235, 0, 0, 0, 0, 0, 0, 0
     ],
-    "texSize": [300, 299],
-    "grid": 8
+    "texSize": [
+        300,
+        299
+    ]
 }
 ```
 


### PR DESCRIPTION
## Inputs
- docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-24-dreamdust-ink-mask-brief.md
- docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-25-dreamdust-ink-mask-brief.md
- docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-smoke-raw.md

## Outputs
- Added navigation indices and cross-date metrics coverage across Dreamdust briefs and raw capture.

## Evidence
- Cross-date metrics table summarises visual outcomes, sim probes, frame p90, and ink latency across 2025-09-24 through 2025-09-28 runs.
- Raw capture index now links directly to each telemetry object, with every console payload recorded as expanded JSON blocks.

## Baseline
```bash
pnpm install --frozen-lockfile
```
```
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. prepare$
│
└─ Done in 285ms
Done in 3.5s
```

```bash
pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
```
```
```

```bash
pnpm --filter cryptiq-mindmap-demo run lint || true
```
```
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
836:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
837:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
838:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1448:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1880:198  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
70:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
574:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
586:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
587:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
588:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
588:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
589:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
606:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
608:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
611:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
612:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
614:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
615:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
618:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
620:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
623:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
625:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
638:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
640:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/sim/ParticleSim.ts
81:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
84:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
94:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
98:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
99:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
111:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
115:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
116:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
```

```bash
CI=1 pnpm --filter cryptiq-mindmap-demo run build
```
```
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build

   ▲ Next.js 15.3.5
   Creating an optimized production build ...
 ✓ Compiled successfully in 34.0s
   Skipping validation of types
   Skipping linting
 ⚠ Using edge runtime on a page currently disables static generation for that page
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                                 Size  First Load JS
┌ ○ /                                    3.71 kB         106 kB
├ ○ /_not-found                            143 B         102 kB
├ ƒ /api/brain-acceptance                  143 B         102 kB
├ ƒ /api/og                                143 B         102 kB
├ ○ /brain                                 27 kB         357 kB
├ ○ /debug/caps                          5.38 kB         107 kB
├ ○ /draw3d                              7.83 kB         335 kB
├ ƒ /quiz/[slug]                         31.9 kB         362 kB
└ ƒ /result/[id]                         2.04 kB         104 kB
+ First Load JS shared by all             102 kB
  ├ chunks/226-5dcf7e3380d711a9.js       46.6 kB
  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
  └ other shared chunks (total)          2.22 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```


------
https://chatgpt.com/codex/tasks/task_e_68d9599e3fc48328a4dd227f3249c5e1