### PR TITLE
docs: outline dreamdust experiment 01

### DIFF
--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-experiments.md
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-experiments.md
@@ -1,0 +1,16 @@
+# 2025-09-28 Dreamdust Experiments
+
+## Experiment 01 — Alpha vs Vertex Choke
+- **Goal:** Determine whether alpha blending values or vertex position updates are the main bottleneck causing the Dreamdust render to stall during ink-mask playback.
+- **Proposed tweak:** Hardcode the Dreamdust particle alpha to `1.0` for a single render pass while bypassing the particle simulation step that warps vertex positions, so the stage renders with static geometry but full opacity.
+- **Success evidence:**
+  - Render loop holds stable frame pacing (no AK watchdog warnings) while alpha is fixed and simulation bypassed.
+  - GPU frame timings drop measurably in AK-DD logs compared to the baseline stall captures, with no spike when particle counts peak.
+  - Visual output shows static particle positions but remains fully visible (no unexpected transparency artifacts).
+- **Failure evidence:**
+  - Frame pacing still degrades or watchdog trips even with alpha forced and simulation skipped, indicating another choke point.
+  - GPU timings or AK-DD logs continue to show the same latency spikes seen in baseline runs.
+  - Visuals exhibit clipping or blank frames despite alpha hardcoding, implying the tweak is ineffective or introduces new regressions.
+- **Next actions:**
+  - **If successful:** Proceed to isolate alpha-handling paths (e.g., PMA blend config, framebuffer clears) in subsequent experiments, then gradually reintroduce simulation to pinpoint the minimum change that preserves stability.
+  - **If failure:** Pivot to inspecting downstream consumers (post-processing passes, framebuffer swaps) and design Experiment 02 around instrumenting those stages, restoring original alpha/sim settings before testing.


### PR DESCRIPTION
## Inputs
- Drafted a new experiment plan aligned with the Dreamdust ink-mask documentation structure.

## Outputs
- Added `docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-experiments.md`.

## Evidence
- Dreamdust Experiment 01 plan covering goal, tweak, success/failure signals, and next steps.【F:docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/2025-09-28-experiments.md†L1-L16】

## Baseline command outputs
```
root@7dafc7fbe532:/workspace/sdk# pnpm install --frozen-lockfile
Scope: all 19 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

. prepare$
│
└─ Done in 243ms
Done in 3.4s
root@7dafc7fbe532:/workspace/sdk#
```
```
root@7dafc7fbe532:/workspace/sdk# pnpm --filter @refinery/schema exec tsc -p tsconfig.json --noEmit || pnpm --filter cryptiq-mindmap-demo exec tsc -p apps/cryptiq-mindmap-demo/tsconfig.typecheck.json --noEmit
root@7dafc7fbe532:/workspace/sdk#
```
```
root@7dafc7fbe532:/workspace/sdk# pnpm --filter cryptiq-mindmap-demo run lint || true
> cryptiq-mindmap-demo@0.1.0 lint /workspace/sdk/apps/cryptiq-mindmap-demo
> next lint

Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry


./app/components/BackgroundBrain.tsx
112:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
121:6  Warning: React Hook useEffect has a missing dependency: 'pixelSize'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
412:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
467:8  Warning: React Hook useEffect has an unnecessary dependency: 'vertices'. Either exclude it or remove the dependency array. Outer scope values like 'vertices' aren't valid dependencies because mutating them doesn't re-render the component.  react-hooks/exhaustive-deps

./app/components/PointCloudStage.tsx
836:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
837:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
838:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1448:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
1880:198  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/brainAnchors.worker.ts
68:78  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
149:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
150:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
152:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/DreamdustMaterial.ts
70:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
574:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
586:34  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
587:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
588:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
588:45  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
589:42  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
606:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
608:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
611:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
612:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
614:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
615:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
618:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
620:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
623:19  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
625:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
638:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:73  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
639:88  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
640:44  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/components/dreamdust/sim/ParticleSim.ts
81:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:33  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
84:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
94:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
98:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
99:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
111:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
115:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
116:15  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/AppHost.tsx
24:53  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
135:27  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
157:9  Warning: The 'classifyNow' function makes the dependencies of useEffect Hook (at line 358) change on every render. To fix this, wrap the definition of 'classifyNow' in its own useCallback() Hook.  react-hooks/exhaustive-deps
287:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:55  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
287:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
288:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
354:17  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
356:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/canvas/preprocess.ts
4:81  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
21:85  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/geometry/__tests__/strokeToCloud.test.ts
5:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
18:21  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ml/doodlenet.ts
11:25  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
19:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
20:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:46  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:29  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
37:43  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/FormationView.tsx
14:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/MorphFormationView.tsx
25:23  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
26:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
78:32  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
79:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
82:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
83:30  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
86:40  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
91:41  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
169:64  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/renderer/transitions.ts
9:26  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
13:24  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
38:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
55:36  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/draw3d/modules/ui/HUD.tsx
37:31  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
44:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
45:20  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any

./app/page.tsx
7:10  Error: 'tweenCamera' is defined but never used.  @typescript-eslint/no-unused-vars
8:10  Error: 'getR3FStateOrNull' is defined but never used.  @typescript-eslint/no-unused-vars
18:11  Error: 'hyperdriveDone' is assigned a value but never used.  @typescript-eslint/no-unused-vars
18:27  Error: 'startCountdown' is assigned a value but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
/workspace/sdk/apps/cryptiq-mindmap-demo:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 lint: `next lint`
Exit status 1
root@7dafc7fbe532:/workspace/sdk#
```
```
root@7dafc7fbe532:/workspace/sdk# TERM=dumb pnpm --filter cryptiq-mindmap-demo run build
> cryptiq-mindmap-demo@0.1.0 build /workspace/sdk/apps/cryptiq-mindmap-demo
> next build
   ▲ Next.js 15.3.5
   Creating an optimized production build ...
 ✓ Compiled successfully in 32.0s
   Skipping validation of types
   Skipping linting
 ⚠ Using edge runtime on a page currently disables static generation for that page
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                                 Size  First Load JS
┌ ○ /                                    3.71 kB         106 kB
├ ○ /_not-found                            143 B         102 kB
├ ƒ /api/brain-acceptance                  143 B         102 kB
├ ƒ /api/og                                143 B         102 kB
├ ○ /brain                                 27 kB         357 kB
├ ○ /debug/caps                          5.38 kB         107 kB
├ ○ /draw3d                              7.83 kB         335 kB
├ ƒ /quiz/[slug]                         31.9 kB         362 kB
└ ƒ /result/[id]                         2.04 kB         104 kB
+ First Load JS shared by all             102 kB
  ├ chunks/226-5dcf7e3380d711a9.js       46.6 kB
  ├ chunks/8d5daf79-879d5759a0deefd7.js  53.2 kB
  └ other shared chunks (total)          2.22 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

root@7dafc7fbe532:/workspace/sdk#
```


------
https://chatgpt.com/codex/tasks/task_e_68d959a983648328ad90011cea1866e8