### PR TITLE
Dreamdust: implement pre-smoke instrumentation & debug velocity override; dev verification (20251024-220825)

### DIFF
--- a/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
+++ b/apps/cryptiq-mindmap-demo/app/components/PointCloudStage.tsx
@@ -1520,29 +1520,61 @@ export default function PointCloudStage(props: PointCloudStageProps) {
   const [fluidBoost, setFluidBoost] = React.useState(process.env.NEXT_PUBLIC_FLUID_DEBUG === '1')
   const [dreamdustDebug, setDreamdustDebug] = React.useState(DREAMDUST_DEBUG_ENV)
   const dreamdustDebugRef = React.useRef(DREAMDUST_DEBUG_ENV)
+  const dreamdustDebugLogRef = React.useRef(false)
+  const sentinelPoints = React.useMemo(() => {
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array([0, 0, 0]), 3))
+    const material = new THREE.PointsMaterial({ size: 0.05, color: 0xffffff })
+    return new THREE.Points(geometry, material)
+  }, [])
+  const sentinelLoggedRef = React.useRef(false)
   const [forceVisible, setForceVisible] = React.useState(false)
   const forceVisibleRef = React.useRef(false)
   React.useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
+    let queryEnabled = false
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search)
+      if (params.get('fluidBoost') === '1') {
+        setFluidBoost(true)
+      } else if (params.get('fluidBoost') === '0') {
+        setFluidBoost(false)
+      }
+      setForceVisible(params.get('forceVisible') === '1')
+      queryEnabled = params.get(DD_DEBUG_QUERY_KEY) === '1'
     }
-    const params = new URLSearchParams(window.location.search)
-    if (params.get('fluidBoost') === '1') {
-      setFluidBoost(true)
-    } else if (params.get('fluidBoost') === '0') {
-      setFluidBoost(false)
+    const effectiveDebug = DREAMDUST_DEBUG_ENV || queryEnabled
+    if (dreamdustDebug !== effectiveDebug) {
+      setDreamdustDebug(effectiveDebug)
     }
-    setForceVisible(params.get('forceVisible') === '1')
-    const debugParam = params.get(DD_DEBUG_QUERY_KEY)
-    if (debugParam === '1') {
-      setDreamdustDebug(true)
-    } else if (debugParam === '0') {
-      setDreamdustDebug(false)
+    dreamdustDebugRef.current = effectiveDebug
+    if (!dreamdustDebugLogRef.current) {
+      try {
+        console.info('[PC] ddDebug', {
+          env: DREAMDUST_DEBUG_ENV,
+          query: queryEnabled,
+          effective: effectiveDebug,
+          resolvedVertexInkOk: null,
+        })
+      } catch {
+        /* noop */
+      }
+      dreamdustDebugLogRef.current = true
     }
-  }, [])
+  }, [dreamdustDebug])
   React.useEffect(() => {
     dreamdustDebugRef.current = dreamdustDebug
   }, [dreamdustDebug])
+  React.useEffect(() => {
+    if (!dreamdustDebugRef.current || sentinelLoggedRef.current) {
+      return
+    }
+    try {
+      console.info('[PC] sentinel-points', { uuid: sentinelPoints.uuid })
+    } catch {
+      /* noop */
+    }
+    sentinelLoggedRef.current = true
+  }, [dreamdustDebug, sentinelPoints])
   const resolvedVelToNdc = fluidBoost ? FLUID_DEBUG_VEL_TO_NDC : FLUID_BASE_VEL_TO_NDC
   const resolvedInkBlend = fluidBoost ? FLUID_DEBUG_INK_BLEND : FLUID_BASE_INK_BLEND
   const [drawing, setDrawing] = React.useState(false)
@@ -3687,6 +3719,8 @@ export default function PointCloudStage(props: PointCloudStageProps) {
       group?: THREE.Group,
     ) {
       if (!pointsBeforeRenderLoggedRef.current) {
+        const rendererProps = (rendererArg as any)?.properties?.get?.(material) ?? null
+        const defines = (material as any)?.defines ?? null
         const layersMask = (this as any)?.layers?.mask ?? null
         try {
           console.info('[PC] points-visibility-state', {
@@ -3702,6 +3736,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
         try {
           console.info('[PC] points-before-render', {
             timestamp: Date.now(),
+            useVelocityDisp: !!(defines?.USE_VELOCITY_DISP ?? false),
+            vertexInkOkDefine: !!(defines?.VERTEX_INK_OK ?? false),
+            programCompiled: !!(rendererProps?.program ?? null),
             renderOrder: this.renderOrder ?? null,
           })
         } catch {
@@ -4158,7 +4195,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
               ;(renderLists as any).__originalGet = originalGet
               renderLists.get = function patchedRenderListsGet(scene: THREE.Scene, camera: THREE.Camera) {
                 const shouldLogFirst = !firstRenderListLogRef.current
-                const shouldLogFrame = !renderListLoggedRef.current && forceVisibleRef.current
+                const shouldLogFrame =
+                  !renderListLoggedRef.current &&
+                  (forceVisibleRef.current || dreamdustDebugRef.current)
                 if (dreamdustDebugRef.current && !renderListGuardLoggedRef.current) {
                   try {
                     console.info('[PC] render-list guard-state', {
@@ -4224,7 +4263,9 @@ export default function PointCloudStage(props: PointCloudStageProps) {
                 }
               }
               const renderPassIndex = renderPassLogRef.current
-              const shouldLogRenderPass = renderPassIndex < RENDER_CALL_LOG_LIMIT
+              const shouldLogRenderPass =
+                renderPassIndex < RENDER_CALL_LOG_LIMIT ||
+                (dreamdustDebugRef.current && renderPassIndex < 2)
               if (shouldLogRenderPass) {
                 try {
                   console.info('[PC] render-pass begin', {
@@ -4404,6 +4445,7 @@ export default function PointCloudStage(props: PointCloudStageProps) {
             }}
           />
         )}
+        {dreamdustDebugRef.current && <primitive object={sentinelPoints} />}
         <TempForceDriver
           tempForceRef={tempForceRef}
           tempIntensityRef={tempIntensityRef}

--- a/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
+++ b/apps/cryptiq-mindmap-demo/app/components/dreamdust/DreamdustMaterial.ts
@@ -758,7 +758,8 @@ export function makeDreamdustMaterial(
     defines.DIAG_SOLID_COLOR = 1
   }
   syncLegacyVertexInkDefine(defines)
-  if (!resolved.vertexInkOk && DREAMDUST_DEBUG_FORCE_VELOCITY) {
+  const velocityOverrideActive = !resolved.vertexInkOk && DREAMDUST_DEBUG_FORCE_VELOCITY
+  if (velocityOverrideActive) {
     defines.USE_VELOCITY_DISP = 1
     defines.VERTEX_INK_OK = 0
   }
@@ -779,9 +780,11 @@ export function makeDreamdustMaterial(
   ;(material as any).uniforms = uniforms
   ;(material as any).defines = (material as any).defines ?? {}
   syncLegacyVertexInkDefine((material as any).defines)
-  if (!resolved.vertexInkOk && DREAMDUST_DEBUG_FORCE_VELOCITY) {
-    (material as any).defines.USE_VELOCITY_DISP = 1
-    (material as any).defines.VERTEX_INK_OK = 0
+  if (velocityOverrideActive) {
+    ;(material as any).defines.USE_VELOCITY_DISP = 1
+    ;(material as any).defines.VERTEX_INK_OK = 0
+    material.needsUpdate = true
+    material.version = (material.version ?? 0) + 1
   }
   if (useGaussian) {
     ;(material as any).defines.USE_GAUSSIAN = 1
@@ -815,9 +818,6 @@ export function makeDreamdustMaterial(
     /* noop */
   }
   material.needsUpdate = true
-  if (DREAMDUST_DEBUG_FORCE_VELOCITY) {
-    material.version = (material.version ?? 0) + 1
-  }
 
   // CRITICAL FIX: Force shader recompile when USE_GAUSSIAN define changes
   // THREE.js program cache doesn't key by defines alone, so we add explicit cache key

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/console/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825/console-manual.txt
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/console/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825/console-manual.txt
@@ -1,0 +1,184 @@
+
+> cryptiq-mindmap-demo@0.1.0 dev /workspace/sdk/apps/cryptiq-mindmap-demo
+> next dev --turbopack
+
+   ▲ Next.js 15.3.5 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://172.30.1.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 1451ms
+ ○ Compiling /quiz/[slug] ...
+Failed to download `IBM Plex Mono` from Google Fonts. Using fallback font instead.
+Failed to download `Anton` from Google Fonts. Using fallback font instead.
+ ✓ Compiled /quiz/[slug] in 8.2s
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /quiz/archetype-v1?pc=scene-03&forceVisible=1&ddDebug=1 200 in 9607ms
+ ⚠ Cross origin request detected from 127.0.0.1 to /_next/* resource. In a future major version of Next.js, you will need to explicitly configure "allowedDevOrigins" in next.config to allow this.
+Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ ○ Compiling /_not-found/page ...
+ ✓ Compiled /_not-found/page in 3.4s
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/positions.f32 404 in 3615ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/positions.f32 404 in 101ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/depth_rg.png 404 in 143ms
+ GET /assets/pointclouds/scene-03/color.png 404 in 144ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/depth16.png 404 in 72ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /quiz/archetype-v1?pc=scene-03&forceVisible=1&ddDebug=1 200 in 180ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/positions.f32 404 in 202ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/positions.f32 404 in 68ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/depth_rg.png 404 in 128ms
+ GET /assets/pointclouds/scene-03/color.png 404 in 131ms
+ ⚠ [next]/internal/font/google/anton_d0dedbcc.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Anton:wght@400&display=swap.
+
+
+ ⚠ [next]/internal/font/google/ibm_plex_mono_c728b84.module.css
+Error while requesting resource
+There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&display=swap.
+
+
+ GET /assets/pointclouds/scene-03/depth16.png 404 in 73ms
+/workspace/sdk/apps/cryptiq-mindmap-demo:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  cryptiq-mindmap-demo@0.1.0 dev: `next dev --turbopack`
+Command failed with signal "SIGTERM"
+[?25h

--- a/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/console/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825/console-playwright.json
+++ b/docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/console/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825/console-playwright.json
@@ -1,0 +1,436 @@
+{
+  "ok": false,
+  "summary": {
+    "[PC] ddDebug": 1,
+    "[PC] sentinel-points": 1,
+    "[PC] render-list guard-state": 0,
+    "[PC] render-list snapshot|empty": 0,
+    "[PC] points-before-render": 0,
+    "[PC] points-after-render": 0,
+    "[PC] render-pass begin": 0,
+    "[PC] render-pass end": 0,
+    "[PC] renderer-render-pass": 0,
+    "[PC] render-info": 0
+  },
+  "renderInfo": [],
+  "errorMessage": null,
+  "url": "http://127.0.0.1:3000/quiz/archetype-v1?pc=scene-03&forceVisible=1&ddDebug=1",
+  "logs": [
+    {
+      "type": "info",
+      "text": "%cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold"
+    },
+    {
+      "type": "info",
+      "text": "[PC] ddDebug {env: true, query: true, effective: true, resolvedVertexInkOk: null}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] sentinel-points {uuid: 8c06f7d4-b673-40a0-873c-8317ec1acac1}"
+    },
+    {
+      "type": "log",
+      "text": "[PC] ink debug {vertexInkOk: false, uViewport: Array(2), inkIntensity: 1}"
+    },
+    {
+      "type": "info",
+      "text": "[vertex] stage data snapshot {simActive: false, stageUvDepthCount: 0, stageUvCount: 0, simStageUvCount: 0, simKey: null}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] forceVisible uniforms {uReveal: 1, uAlphaFloor: 1, uPointBaseSize: 8, uMinSize: 4, uMaxSize: 14}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] forceVisible applied {depthTest: TBD, depthWrite: TBD, blending: TBD, applied: false}"
+    },
+    {
+      "type": "warning",
+      "text": "[GroupMarkerNotSet(crbug.com/242999)!:A07020002C230000]Automatic fallback to software WebGL has been deprecated. Please use the --enable-unsafe-swiftshader (about:flags#enable-unsafe-swiftshader) flag to opt in to lower security guarantees for trusted content."
+    },
+    {
+      "type": "log",
+      "text": "[dreamdust] vertex-ink-ok {value: 1}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] renderer-capabilities {isWebGL2: true, maxVertexTextures: 32, maxTextures: 32, precision: highp, logarithmicDepthBuffer: false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] instrumentation render-list override active {timestamp: 1761344394708, hasRenderLists: true}"
+    },
+    {
+      "type": "info",
+      "text": "[dreamdust] caps-fanout { stage: true, context: true, host: true, metrics: true }"
+    },
+    {
+      "type": "info",
+      "text": "[PC] material-defines {\"vertexInkOk\":false,\"useVertexInk\":false,\"useVelocityDisp\":true,\"blending\":1,\"depthTest\":true,\"depthWrite\":false,\"toneMapped\":false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] diag solid color {enabled: true}"
+    },
+    {
+      "type": "info",
+      "text": "[preset] {preset: current, blending: 1, blendingName: NormalBlending, depthTest: true, hasGaussian: false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] material-defines {\"vertexInkOk\":false,\"useVertexInk\":false,\"useVelocityDisp\":true,\"blending\":1,\"depthTest\":true,\"depthWrite\":false,\"toneMapped\":false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] diag solid color {enabled: true}"
+    },
+    {
+      "type": "info",
+      "text": "[preset] {preset: current, blending: 1, blendingName: NormalBlending, depthTest: true, hasGaussian: false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] material-defines {\"vertexInkOk\":false,\"useVertexInk\":false,\"useVelocityDisp\":true,\"blending\":1,\"depthTest\":true,\"depthWrite\":false,\"toneMapped\":false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] diag solid color {enabled: true}"
+    },
+    {
+      "type": "info",
+      "text": "[preset] {preset: current, blending: 1, blendingName: NormalBlending, depthTest: true, hasGaussian: false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] material-defines {\"vertexInkOk\":false,\"useVertexInk\":false,\"useVelocityDisp\":true,\"blending\":1,\"depthTest\":true,\"depthWrite\":false,\"toneMapped\":false}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] diag solid color {enabled: true}"
+    },
+    {
+      "type": "info",
+      "text": "[preset] {preset: current, blending: 1, blendingName: NormalBlending, depthTest: true, hasGaussian: false}"
+    },
+    {
+      "type": "warning",
+      "text": "[.WebGL-0x349c000ee900]GL Driver Message (OpenGL, Performance, GL_CLOSE_PATH_NV, High): GPU stall due to ReadPixels"
+    },
+    {
+      "type": "error",
+      "text": "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    },
+    {
+      "type": "error",
+      "text": "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    },
+    {
+      "type": "info",
+      "text": "[PC] camera-diag {enabled: true, cameraPosition: Array(3), target: Array(3), radius: 600, near: 0.1}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 1: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "log",
+      "text": "[Dreamdust] ink-tex bind {width: 256, height: 256, needsUpdate: false}"
+    },
+    {
+      "type": "log",
+      "text": "[dreamdust] ink-telemetry {intensity: 0.75, offsetBoost: 1, sizeBoost: 1, vertexInkOk: 0}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] scene-candidates {candidates: Object, renderCallCount: 0}"
+    },
+    {
+      "type": "log",
+      "text": "[PC] attach controls to JSHandle@node"
+    },
+    {
+      "type": "log",
+      "text": "[DEBUG] Camera position check:"
+    },
+    {
+      "type": "log",
+      "text": "  Expected: [-65.737, 103.054, -681.379]"
+    },
+    {
+      "type": "log",
+      "text": "  Actual: [-65.737, 103.054, -681.379]"
+    },
+    {
+      "type": "log",
+      "text": "  Match: true"
+    },
+    {
+      "type": "log",
+      "text": "[PC] Preset applied (initial): {position: Array(3), target: Array(3), actualPosition: Array(3), actualTarget: null}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] fluid uniforms prime {invSize: Array(2), velToNdc: 0.028, inkBlend: 0.78}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] forceVisible applied {depthTest: false, depthWrite: false, blending: 2, applied: true}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 2: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "info",
+      "text": "[PC] fluid-step skipped {reason: diagnostic-disable}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] stage-points-missing {framesElapsed: 3, forceVisible: true}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 3: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "error",
+      "text": "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 4: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 5: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "error",
+      "text": "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 6: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 7: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 8: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 9: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 10: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 11: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "error",
+      "text": "Failed to load resource: the server responded with a status of 404 (Not Found)"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 12: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 13: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 14: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 15: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 16: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 17: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 18: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 19: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 20: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 21: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 22: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 23: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 24: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 25: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 26: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 27: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 28: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 29: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 30: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 31: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 32: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 33: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 34: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 35: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 36: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 37: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 38: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 39: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 40: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 41: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 42: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 43: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 44: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 45: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 46: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 47: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 48: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 49: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 50: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 51: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 52: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 53: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 54: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 55: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 56: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 57: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 58: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 59: {expected: Object, actual: Object}"
+    },
+    {
+      "type": "warning",
+      "text": "[PC] Preset drifted at frame 60: {expected: Object, actual: Object}"
+    }
+  ]
+}


### PR DESCRIPTION
Base: docs/ink-falloff-flag-latch-2025-10-12
Head: feat/dreamdust-pre-smoke-20251024-220825
Plan: PLANS.md (Context Pack 2025-10-15)

## Summary
- Tighten Dreamdust debug gating with env/query effective flag, once-per-run ddDebug logging, sentinel instrumentation, and expanded render probes for velocity state and render list/pass logging.
- Dev verification executed under Node v20.19.4.

## Evidence
- Console: docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/console/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825
- Assets:  docs/initiatives/cryptiq-mindmap-mvp/dreamdust-ink-mask-docs/context-pack-2025-10-10/cursor-ooda-ink-prototype/assets/72ebe3a2/docs/ink-falloff-flag-latch-2025-10-12/20251024-220825
- Grep/JQ summary:

```
{
  "ok": false,
  "summary": {
    "[PC] ddDebug": 1,
    "[PC] sentinel-points": 1,
    "[PC] render-list guard-state": 0,
    "[PC] render-list snapshot|empty": 0,
    "[PC] points-before-render": 0,
    "[PC] points-after-render": 0,
    "[PC] render-pass begin": 0,
    "[PC] render-pass end": 0,
    "[PC] renderer-render-pass": 0,
    "[PC] render-info": 0
  },
  "errorMessage": null,
  "renderInfoCount": 0
}
```

------
https://chatgpt.com/codex/tasks/task_e_68fbf2dcaf648328b3ae3ddcff1d1e7f